### PR TITLE
feat: Access active format in frame processor plugin

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
@@ -14,7 +14,6 @@ In this guide we will create a custom QR Code Scanner Plugin which can be used f
 
 iOS Frame Processor Plugins can be written in either **Objective-C** or **Swift**.
 
-
 <Tabs
   defaultValue="objc"
   values={[
@@ -39,6 +38,7 @@ iOS Frame Processor Plugins can be written in either **Objective-C** or **Swift*
 static inline id scanQRCodes(Frame* frame, NSArray* args) {
   CMSampleBufferRef buffer = frame.buffer;
   UIImageOrientation orientation = frame.orientation;
+  AVCaptureDeviceFormat cameraFormat = frame.cameraFormat;
   // code goes here
   return @[];
 }
@@ -92,6 +92,7 @@ public class QRCodeFrameProcessorPlugin: NSObject, FrameProcessorPluginBase {
   public static func callback(_ frame: Frame!, withArgs _: [Any]!) -> Any! {
     let buffer = frame.buffer
     let orientation = frame.orientation
+    let cameraFormat = frame.cameraFormat
     // code goes here
     return []
   }
@@ -99,7 +100,6 @@ public class QRCodeFrameProcessorPlugin: NSObject, FrameProcessorPluginBase {
 ```
 
 6. **Implement your frame processing.** See [Example Plugin (Swift)](https://github.com/mrousavy/react-native-vision-camera/blob/main/example/ios/Frame%20Processor%20Plugins/Example%20Plugin%20%28Swift%29) for reference.
-
 
 </TabItem>
 </Tabs>

--- a/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
+++ b/example/ios/VisionCameraExample.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		B8DB3BD5263DE8B7004C18D7 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		B8DB3BD5263DE8B7004C18D7 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		B8DB3BDC263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BD8263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m */; };
 		B8DB3BDD263DEA31004C18D7 /* ExamplePluginSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BDA263DEA31004C18D7 /* ExamplePluginSwift.swift */; };
 		B8DB3BDE263DEA31004C18D7 /* ExamplePluginSwift.m in Sources */ = {isa = PBXBuildFile; fileRef = B8DB3BDB263DEA31004C18D7 /* ExamplePluginSwift.m */; };
@@ -178,7 +178,7 @@
 				LastUpgradeCheck = 1250;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = CJW62Q77E7;
+						DevelopmentTeam = TFP6882UUN;
 						LastSwiftMigration = 1240;
 					};
 				};
@@ -364,7 +364,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				B8DB3BDC263DEA31004C18D7 /* ExampleFrameProcessorPlugin.m in Sources */,
-				B8DB3BD5263DE8B7004C18D7 /* BuildFile in Sources */,
+				B8DB3BD5263DE8B7004C18D7 /* (null) in Sources */,
 				B8DB3BDD263DEA31004C18D7 /* ExamplePluginSwift.swift in Sources */,
 				B8F0E10825E0199F00586F16 /* File.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
@@ -382,7 +382,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CJW62Q77E7;
+				DEVELOPMENT_TEAM = TFP6882UUN;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = VisionCameraExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ios/CameraView+RecordVideo.swift
+++ b/ios/CameraView+RecordVideo.swift
@@ -223,7 +223,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
             self.isRunningFrameProcessor = true
 
             let perfSample = self.frameProcessorPerformanceDataCollector.beginPerformanceSampleCollection()
-            let frame = Frame(buffer: sampleBuffer, orientation: self.bufferOrientation)
+            let frame = Frame(buffer: sampleBuffer, orientation: self.bufferOrientation, cameraFormat: self.videoDeviceInput?.device.activeFormat)
             frameProcessor(frame)
             perfSample.endPerformanceSampleCollection()
 

--- a/ios/Frame Processor/Frame.h
+++ b/ios/Frame Processor/Frame.h
@@ -11,12 +11,14 @@
 #import <Foundation/Foundation.h>
 #import <CoreMedia/CMSampleBuffer.h>
 #import <UIKit/UIImage.h>
+#import <AVFoundation/AVCaptureDevice.h>
 
 @interface Frame : NSObject
 
-- (instancetype) initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation;
+- (instancetype) initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation cameraFormat:(AVCaptureDeviceFormat*)cameraFormat;
 
 @property (nonatomic, readonly) CMSampleBufferRef buffer;
 @property (nonatomic, readonly) UIImageOrientation orientation;
+@property (nonatomic, readonly) AVCaptureDeviceFormat* cameraFormat;
 
 @end

--- a/ios/Frame Processor/Frame.m
+++ b/ios/Frame Processor/Frame.m
@@ -13,18 +13,21 @@
 @implementation Frame {
   CMSampleBufferRef buffer;
   UIImageOrientation orientation;
+  AVCaptureDeviceFormat *cameraFormat;
 }
 
-- (instancetype) initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation {
+- (instancetype) initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation cameraFormat:(AVCaptureDeviceFormat *)cameraFormat {
   self = [super init];
   if (self) {
     _buffer = buffer;
     _orientation = orientation;
+    _cameraFormat = cameraFormat;
   }
   return self;
 }
 
 @synthesize buffer = _buffer;
 @synthesize orientation = _orientation;
+@synthesize cameraFormat = _cameraFormat;
 
 @end


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR adds the active camera format (`AVCaptureDevice.Format`) to the `Frame` class so that properties such as camera FOV can be accessed in the frame processor plugin callback. This is especially useful for advanced image processing tasks such as integration with ARCore https://developers.google.com/ar/develop/ios/augmented-faces/developer-guide#initialize_an_augmented_faces_session 👀

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

- Adds `cameraFormat` property to `Frame` class
- Passes the active format into the frame processor plugin during `captureOutput`

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

- iPhone 13 Pro

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

## Todo

- [x] iOS Implementation
- [ ] Android Implementation
