### PR TITLE
Add exposure (Android) and ISO+shootingTime (Ios)

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -86,7 +86,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   var photo: Boolean? = null
   var video: Boolean? = null
   var audio: Boolean? = null
-  var exposure: Int? = 0
+  var exposure: Int? = null
 
   var enableFrameProcessor = false
   // props that require format reconfiguring
@@ -485,7 +485,7 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
       val range = exposureState?.exposureCompensationRange;
       Log.d("got exposure ", exposure.toString());
       val MAX_PROP_RANGE = 100;
-      if (range != null) {
+      if (range != null && exposure != null) {
         val LOW_RANGE = Math.min(Math.abs(range!!.lower), Math.abs(range!!.upper));
         val EXPOSURE_VALUE_RATIO = LOW_RANGE.toDouble() / MAX_PROP_RANGE
         Log.i("finish exposure ", (exposure!! * EXPOSURE_VALUE_RATIO).toInt().toString());

--- a/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -86,10 +86,13 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
   var photo: Boolean? = null
   var video: Boolean? = null
   var audio: Boolean? = null
+  var exposure: Int? = 0
+
   var enableFrameProcessor = false
   // props that require format reconfiguring
   var format: ReadableMap? = null
   var fps: Int? = null
+
   var hdr: Boolean? = null // nullable bool
   var colorSpace: String? = null
   var lowLightBoost: Boolean? = null // nullable bool
@@ -471,13 +474,24 @@ class CameraView(context: Context, private val frameProcessorThread: ExecutorSer
       if (photo == true) {
         if (fallbackToSnapshot) {
           Log.i(TAG, "Tried to add photo use-case (`photo={true}`) but the Camera device only supports " +
-            "a single use-case at a time. Falling back to Snapshot capture.")
+                  "a single use-case at a time. Falling back to Snapshot capture.")
         } else {
           Log.i(TAG, "Adding ImageCapture use-case...")
           imageCapture = imageCaptureBuilder.build()
           useCases.add(imageCapture!!)
         }
       }
+      val exposureState: ExposureState? = camera?.cameraInfo?.exposureState;
+      val range = exposureState?.exposureCompensationRange;
+      Log.d("got exposure ", exposure.toString());
+      val MAX_PROP_RANGE = 100;
+      if (range != null) {
+        val LOW_RANGE = Math.min(Math.abs(range!!.lower), Math.abs(range!!.upper));
+        val EXPOSURE_VALUE_RATIO = LOW_RANGE.toDouble() / MAX_PROP_RANGE
+        Log.i("finish exposure ", (exposure!! * EXPOSURE_VALUE_RATIO).toInt().toString());
+        camera?.cameraControl?.setExposureCompensationIndex((exposure!! * EXPOSURE_VALUE_RATIO).toInt())
+      };
+
       if (enableFrameProcessor) {
         Log.i(TAG, "Adding ImageAnalysis use-case...")
         imageAnalysis = imageAnalysisBuilder.build().apply {

--- a/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraViewManager.kt
@@ -62,6 +62,13 @@ class CameraViewManager(reactContext: ReactApplicationContext) : ViewGroupManage
       addChangedPropToTransaction(view, "audio")
     view.audio = audio
   }
+  
+  @ReactProp(name = "exposure")
+  fun setLowLightBoost(view: CameraView, exposure: Int) {
+    if (view.exposure != exposure)
+      addChangedPropToTransaction(view, "exposure")
+    view.exposure = exposure
+  }
 
   @ReactProp(name = "enableFrameProcessor")
   fun setEnableFrameProcessor(view: CameraView, enableFrameProcessor: Boolean) {

--- a/ios/CameraView+AVCaptureSession.swift
+++ b/ios/CameraView+AVCaptureSession.swift
@@ -137,36 +137,35 @@ extension CameraView {
       captureSession.addOutput(videoOutput!)
     }
 
-    ReactLogger.log(level: .info, message: "Start adding exposure...")
-
-    guard let device = videoDeviceInput?.device else {
-      invokeOnError(.session(.cameraNotReady))
-      return
-    }
-    do {
-      try device.lockForConfiguration()
+    if shootingTime != nil && iso != nil {
+      ReactLogger.log(level: .info, message: "Start adding exposure...")
+      guard let device = videoDeviceInput?.device else {
+        invokeOnError(.session(.cameraNotReady))
+        return
+      }
+      do {
+        try device.lockForConfiguration()
         ReactLogger.log(level: .info, message: "Exposure mode supporting is: \"\(device.isExposureModeSupported(AVCaptureDevice.ExposureMode.custom))\"...")
-        if(device.isExposureModeSupported(AVCaptureDevice.ExposureMode.custom)){
-          let shootingTimeSafe = (shootingTime != nil) ? shootingTime : 400
-          if((iso != nil) && iso!.floatValue > device.activeFormat.minISO && iso!.floatValue < device.activeFormat.maxISO){
-              ReactLogger.log(level: .info, message: "Bad prop ISO: \"\(String(describing: iso))\"... Will be use ISO = 400.")
+        if device.isExposureModeSupported(AVCaptureDevice.ExposureMode.custom) {
+          let shootingTimeSafe = shootingTime
+          if iso!.floatValue > device.activeFormat.minISO && iso!.floatValue < device.activeFormat.maxISO {
+            ReactLogger.log(level: .info, message: "Out of range ISO: \"\(String(describing: iso))\"... Will be use ISO = 400.")
           }
-          let isoSafe = (iso != nil) && iso!.floatValue > device.activeFormat.minISO && iso!.floatValue < device.activeFormat.maxISO ? iso : 400
+          let isoSafe = iso!.floatValue > device.activeFormat.minISO && iso!.floatValue < device.activeFormat.maxISO ? iso : 400
           ReactLogger.log(level: .info, message: "ISO: \"\(String(describing: isoSafe))\"...")
-          ReactLogger.log(level: .info, message: "ShootingTime: \"\(String(describing: shootingTimeSafe))\"...")
-          device.setExposureModeCustom(duration: CMTimeMake(value: 1, timescale: shootingTimeSafe as! Int32), iso: isoSafe as! Float, completionHandler: nil)
+          ReactLogger.log(level: .info, message: "ShootingTime: \"\(String(describing: shootingTime))\"...")
+            device.setExposureModeCustom(duration: CMTimeMake(value: 1, timescale: shootingTime as! Int32), iso: isoSafe as! Float, completionHandler: nil)
           ReactLogger.log(level: .info, message: "Exposure successfully configured!")
-          } else {
-              ReactLogger.log(level: .info, message: "Exposure dont support!")
-          }
-          device.unlockForConfiguration()
-          
+        } else {
+          ReactLogger.log(level: .info, message: "Exposure dont support!")
+        }
+        device.unlockForConfiguration()
       } catch let error as NSError {
         invokeOnError(.device(.configureError), cause: error)
         return
       }
-      
-    ReactLogger.log(level: .info, message: "Finish adding exposure...")
+      ReactLogger.log(level: .info, message: "Finish adding exposure...")
+    }
 
     onOrientationChanged()
 

--- a/ios/CameraView.swift
+++ b/ios/CameraView.swift
@@ -25,6 +25,8 @@ private let propsThatRequireReconfiguration = ["cameraId",
                                                "enablePortraitEffectsMatteDelivery",
                                                "preset",
                                                "photo",
+                                               "iso",
+                                               "shootingTime",
                                                "video",
                                                "enableFrameProcessor"]
 private let propsThatRequireDeviceReconfiguration = ["fps",
@@ -51,6 +53,8 @@ public final class CameraView: UIView {
   @objc var enableFrameProcessor = false
   // props that require format reconfiguring
   @objc var format: NSDictionary?
+  @objc var iso: NSNumber?
+  @objc var shootingTime: NSNumber?
   @objc var fps: NSNumber?
   @objc var frameProcessorFps: NSNumber = -1.0 // "auto"
   @objc var hdr: NSNumber? // nullable bool

--- a/ios/CameraViewManager.m
+++ b/ios/CameraViewManager.m
@@ -35,6 +35,8 @@ RCT_EXPORT_VIEW_PROPERTY(enableFrameProcessor, BOOL);
 // device format
 RCT_EXPORT_VIEW_PROPERTY(format, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(fps, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(iso, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(shootingTime, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(frameProcessorFps, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(hdr, NSNumber); // nullable bool
 RCT_EXPORT_VIEW_PROPERTY(lowLightBoost, NSNumber); // nullable bool

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -115,6 +115,30 @@ export interface CameraProps extends ViewProps {
    */
   lowLightBoost?: boolean;
   /**
+   * Add exposure -100 .. 100 range (It will be cast to posible range)
+   *
+   * https://developer.android.com/reference/kotlin/androidx/camera/core/CameraControl#setexposurecompensationindex
+   */
+  exposure?: number;
+
+  /**
+   * Only IOS
+   *
+   * Release param ISO. Out of range casting IOS to value = 400
+   * https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustom
+   */
+  iso?: number;
+
+
+  /**
+   * Only IOS
+   *
+   * Release param shooting time.
+   * https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustom
+   */
+  shootingTime?: number;
+
+  /**
    * Specifies the color space to use for this camera device. Make sure the given `format` contains the given `colorSpace`.
    *
    * Requires `format` to be set.

--- a/src/CameraProps.ts
+++ b/src/CameraProps.ts
@@ -115,12 +115,12 @@ export interface CameraProps extends ViewProps {
    */
   lowLightBoost?: boolean;
   /**
+   * Only Android
    * Add exposure -100 .. 100 range (It will be cast to posible range)
    *
    * https://developer.android.com/reference/kotlin/androidx/camera/core/CameraControl#setexposurecompensationindex
    */
   exposure?: number;
-
   /**
    * Only IOS
    *
@@ -128,8 +128,6 @@ export interface CameraProps extends ViewProps {
    * https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustom
    */
   iso?: number;
-
-
   /**
    * Only IOS
    *
@@ -137,7 +135,6 @@ export interface CameraProps extends ViewProps {
    * https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustom
    */
   shootingTime?: number;
-
   /**
    * Specifies the color space to use for this camera device. Make sure the given `format` contains the given `colorSpace`.
    *


### PR DESCRIPTION
## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for setup exposure.
    Android: https://developer.android.com/reference/kotlin/androidx/camera/core/CameraControl#setexposurecompensationindex
    Ios: https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustom
-->

## Changes

/**
   * Add exposure -100 .. 100 range (It will be cast to posible range)
   *
   * https://developer.android.com/reference/kotlin/androidx/camera/core/CameraControl#setexposurecompensationindex
   */
  exposure?: number;

  /**
   * Only IOS
   *
   * Release param ISO. Out of range casting IOS to value = 400
   * https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustom
   */
  iso?: number;

  /**
   * Only IOS
   *
   * Release param shooting time.
   * https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624646-setexposuremodecustom
   */
  shootingTime?: number;

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 13 Pro, iOS 15.2.1
    * Redmi Note 9 Pro, Android 10
-->

## Related issues

<!--
https://github.com/mrousavy/react-native-vision-camera/discussions/643
-->
