### PR TITLE
fix: iOS focus

### DIFF
--- a/ios/CameraView+Focus.swift
+++ b/ios/CameraView+Focus.swift
@@ -74,7 +74,11 @@ extension CameraView {
       }
 
       // in {0..1} system
-      let normalizedPoint = captureDevicePointConverted(fromLayerPoint: point)
+      var normalizedPoint = captureDevicePointConverted(fromLayerPoint: point)
+      if let previewView = previewView as? PreviewView {
+        // previewView is of type PreviewView can use the built in captureDevicePointConverted
+        normalizedPoint = previewView.videoPreviewLayer.captureDevicePointConverted(fromLayerPoint: point)
+      }
 
       do {
         try device.lockForConfiguration()

--- a/ios/CameraView+Focus.swift
+++ b/ios/CameraView+Focus.swift
@@ -74,10 +74,12 @@ extension CameraView {
       }
 
       // in {0..1} system
-      var normalizedPoint = captureDevicePointConverted(fromLayerPoint: point)
+      var normalizedPoint: CGPoint
       if let previewView = previewView as? PreviewView {
         // previewView is of type PreviewView can use the built in captureDevicePointConverted
         normalizedPoint = previewView.videoPreviewLayer.captureDevicePointConverted(fromLayerPoint: point)
+      } else {
+        normalizedPoint = captureDevicePointConverted(fromLayerPoint: point)
       }
 
       do {

--- a/ios/CameraView+Focus.swift
+++ b/ios/CameraView+Focus.swift
@@ -80,18 +80,52 @@ extension CameraView {
         try device.lockForConfiguration()
 
         device.focusPointOfInterest = normalizedPoint
-        device.focusMode = .continuousAutoFocus
+        device.focusMode = .autoFocus
 
         if device.isExposurePointOfInterestSupported {
           device.exposurePointOfInterest = normalizedPoint
-          device.exposureMode = .continuousAutoExposure
+          device.exposureMode = .autoExpose
         }
+
+        // Enable subject area change monitoring
+        device.isSubjectAreaChangeMonitoringEnabled = true
+
+        // Remove any existing observer for subject area change notifications
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange, object: nil)
+
+        // Register observer for subject area change notifications
+        NotificationCenter.default.addObserver(self, selector: #selector(subjectAreaDidChange), name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange, object: nil)
 
         device.unlockForConfiguration()
         return nil
       } catch {
         throw CameraError.device(DeviceError.configureError)
       }
+    }
+  }
+
+  @objc func subjectAreaDidChange(notification: NSNotification) {
+    guard let device = self.videoDeviceInput?.device else {
+      invokeOnError(.session(.cameraNotReady))
+      return
+    }
+    do {
+      try device.lockForConfiguration()
+
+      // Reset focus and exposure settings to continuous mode
+      if device.isFocusPointOfInterestSupported {
+        device.focusMode = .continuousAutoFocus
+      }
+
+      if device.isExposurePointOfInterestSupported {
+        device.exposureMode = .continuousAutoExposure
+      }
+      
+      device.isSubjectAreaChangeMonitoringEnabled = false
+
+      device.unlockForConfiguration()
+    } catch {
+      invokeOnError(.device(.configureError))
     }
   }
 }


### PR DESCRIPTION
## What

iOS focus method did not do anything because the device stayed in `continuousAutoFocus` mode

## Changes

- use `autoFocus` and `autoExpose` instead when focus is called
- enable `isSubjectAreaChangeMonitoringEnabled`
- when subject area is changed then switch back to `continuousAutoFocus` and `continuousAutoExposure`

## Tested on

* iPhone 13 Pro iOS 16.3
* iPhone 6s Plus iOS 13.1.2

## Related issues

https://github.com/mrousavy/react-native-vision-camera/issues/1376#issuecomment-1483633319
