### PR TITLE
fix: fix ios reload by observing RCT module invalidate

### DIFF
--- a/ios/Frame Processor/FrameProcessorRuntimeManager.h
+++ b/ios/Frame Processor/FrameProcessorRuntimeManager.h
@@ -12,6 +12,7 @@
 #import <React/RCTBridge.h>
 
 @interface FrameProcessorRuntimeManager : NSObject
+@property (nonatomic) int viewTag;
 
 - (instancetype)init NS_UNAVAILABLE;
 


### PR DESCRIPTION
## What

Resolves IOS crash on reload

<img width="763" alt="Screenshot 2023-07-12 at 4 19 15 pm" src="https://github.com/mrousavy/react-native-vision-camera/assets/1883374/4e7b5fd8-5ca6-4311-856a-7f4db7b9b073">

## Changes

Store reference to viewTag
Clear `CameraView.frameProcessorCallback` on `RCTBridgeDidInvalidateModulesNotification`

## Tested on

iPad Pro 2017

## Related issues
Fixes https://github.com/mrousavy/react-native-vision-camera/issues/1360

Inspired by 
https://github.com/software-mansion/react-native-reanimated/pull/3932

Note that this fix isn't perfect: 
1. There is no further cleanup being done
2. There is definitively a memory leak

However despite this it should improve things considerably (Until v3), I was able to get around 15 reloads with no memory issues.
