### PR TITLE
feat: Flash

### DIFF
--- a/android/src/main/java/com/mrousavy/camera/CameraSession.kt
+++ b/android/src/main/java/com/mrousavy/camera/CameraSession.kt
@@ -21,6 +21,7 @@ import com.mrousavy.camera.extensions.capture
 import com.mrousavy.camera.extensions.createCaptureSession
 import com.mrousavy.camera.extensions.createPhotoCaptureRequest
 import com.mrousavy.camera.extensions.openCamera
+import com.mrousavy.camera.extensions.triggerFlashAE
 import com.mrousavy.camera.extensions.tryClose
 import com.mrousavy.camera.extensions.zoomed
 import com.mrousavy.camera.frameprocessor.Frame
@@ -195,24 +196,37 @@ class CameraSession(private val context: Context,
                         outputOrientation: Orientation): CapturedPhoto {
     val captureSession = captureSession ?: throw CameraNotReadyError()
     val outputs = outputs ?: throw CameraNotReadyError()
-
+    val previewRequest = previewRequest ?: throw CameraNotReadyError()
     val photoOutput = outputs.photoOutput ?: throw PhotoNotEnabledError()
 
     val cameraCharacteristics = cameraManager.getCameraCharacteristics(captureSession.device.id)
-    val orientation = outputOrientation.toSensorRelativeOrientation(cameraCharacteristics)
-    val captureRequest = captureSession.device.createPhotoCaptureRequest(cameraManager,
-                                                                         photoOutput.surface,
-                                                                         zoom,
-                                                                         qualityPrioritization,
-                                                                         flashMode,
-                                                                         enableRedEyeReduction,
-                                                                         enableAutoStabilization,
-                                                                         orientation)
-    Log.i(TAG, "Photo capture 0/2 - starting capture...")
-    val result = captureSession.capture(captureRequest, enableShutterSound)
-    val timestamp = result[CaptureResult.SENSOR_TIMESTAMP]!!
-    Log.i(TAG, "Photo capture 1/2 complete - received metadata with timestamp $timestamp")
+    val supportedAeModes = cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES)!!
+
+    // Update auto-exposure mode for repeating request so that it has time to focus
+    val aeMode = flashMode.toControlAeMode(enableRedEyeReduction)
+    if (flashMode != Flash.OFF) {
+      if (!supportedAeModes.contains(aeMode)) throw NoFlashAvailableError()
+      previewRequest.set(CaptureRequest.CONTROL_AE_MODE, aeMode)
+      updateRepeatingRequest()
+
+      // Flash once to adjust auto-exposure (AE)
+      captureSession.triggerFlashAE(flashMode, previewRequest)
+    }
+
     try {
+      val orientation = outputOrientation.toSensorRelativeOrientation(cameraCharacteristics)
+      val captureRequest = captureSession.device.createPhotoCaptureRequest(cameraManager,
+        photoOutput.surface,
+        zoom,
+        qualityPrioritization,
+        aeMode,
+        enableAutoStabilization,
+        orientation)
+      Log.i(TAG, "Photo capture 0/2 - starting capture...")
+      val result = captureSession.capture(captureRequest, enableShutterSound)
+      val timestamp = result[CaptureResult.SENSOR_TIMESTAMP]!!
+      Log.i(TAG, "Photo capture 1/2 complete - received metadata with timestamp $timestamp")
+
       val image = photoOutputSynchronizer.await(timestamp)
 
       val isMirrored = cameraCharacteristics.get(CameraCharacteristics.LENS_FACING) == CameraCharacteristics.LENS_FACING_FRONT
@@ -220,7 +234,14 @@ class CameraSession(private val context: Context,
       Log.i(TAG, "Photo capture 2/2 complete - received ${image.width} x ${image.height} image.")
       return CapturedPhoto(image, result, orientation, isMirrored, image.format)
     } catch (e: CancellationException) {
+      // Photo was never
       throw CaptureAbortedError(false)
+    } finally {
+      // Reset auto-exposure mode for repeating request so that it doesn't adjust focus for flash anymore
+      if (flashMode != Flash.OFF) {
+        previewRequest.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
+        updateRepeatingRequest()
+      }
     }
   }
 
@@ -447,8 +468,8 @@ class CameraSession(private val context: Context,
     }
 
     // Torch Mode
-    val torchMode = if (torch == true) CaptureRequest.FLASH_MODE_TORCH else CaptureRequest.FLASH_MODE_OFF
-    captureRequest.set(CaptureRequest.FLASH_MODE, torchMode)
+    // val torchMode = if (torch == true) CaptureRequest.FLASH_MODE_TORCH else CaptureRequest.FLASH_MODE_OFF
+    // captureRequest.set(CaptureRequest.FLASH_MODE, torchMode)
 
     return captureRequest.build()
   }

--- a/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+triggerFlashAE.kt
+++ b/android/src/main/java/com/mrousavy/camera/extensions/CameraCaptureSession+triggerFlashAE.kt
@@ -1,0 +1,54 @@
+package com.mrousavy.camera.extensions
+
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraCaptureSession.CaptureCallback
+import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.CaptureRequest.Builder
+import android.hardware.camera2.CaptureRequest.CONTROL_AE_STATE_PRECAPTURE
+import android.hardware.camera2.CaptureResult
+import android.hardware.camera2.TotalCaptureResult
+import android.util.Log
+import com.mrousavy.camera.CameraQueues
+import com.mrousavy.camera.parsers.Flash
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+suspend fun CameraCaptureSession.triggerFlashAE(flashMode: Flash, repeatingRequestBuilder: Builder) {
+  if (flashMode == Flash.OFF) return
+
+  return suspendCancellableCoroutine { continuation ->
+    // Start a pre-capture sequence
+    repeatingRequestBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START)
+
+    capture(repeatingRequestBuilder.build(), object: CaptureCallback() {
+      var didStartPrecapture = false
+
+      private fun process(result: CaptureResult) {
+        val aeState = result.get(CaptureResult.CONTROL_AE_STATE)
+        Log.i("FLASH___", "AE-State: $aeState")
+        if (aeState == CONTROL_AE_STATE_PRECAPTURE) {
+          if (!didStartPrecapture) {
+            // First time this is triggered, it started the precapture. We wait until it finished.
+            didStartPrecapture = true
+          } else {
+            // Second time this is triggered, it finished the precapture.
+            continuation.resume(Unit)
+          }
+        }
+      }
+
+      override fun onCaptureProgressed(session: CameraCaptureSession, request: CaptureRequest, partialResult: CaptureResult) {
+        super.onCaptureProgressed(session, request, partialResult)
+        process(partialResult)
+      }
+
+      override fun onCaptureCompleted(session: CameraCaptureSession, request: CaptureRequest, result: TotalCaptureResult) {
+        super.onCaptureCompleted(session, request, result)
+        process(result)
+      }
+    }, CameraQueues.cameraQueue.handler)
+
+    // Reset it back to it's default value
+    repeatingRequestBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE)
+  }
+}

--- a/android/src/main/java/com/mrousavy/camera/parsers/Flash.kt
+++ b/android/src/main/java/com/mrousavy/camera/parsers/Flash.kt
@@ -1,11 +1,20 @@
 package com.mrousavy.camera.parsers
 
+import android.hardware.camera2.CaptureRequest
 import com.mrousavy.camera.InvalidTypeScriptUnionError
 
 enum class Flash(override val unionValue: String): JSUnionValue {
   OFF("off"),
   ON("on"),
   AUTO("auto");
+
+  fun toControlAeMode(enableRedEyeReduction: Boolean? = false): Int {
+    return when (this) {
+      OFF -> CaptureRequest.CONTROL_AE_MODE_ON
+      ON -> CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH
+      AUTO -> if (enableRedEyeReduction == true) CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH_REDEYE else CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH
+    }
+  }
 
   companion object: JSUnionValue.Companion<Flash> {
     override fun fromUnionValue(unionValue: String?): Flash {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Flash is **waaaaaaaaaay** more complicated than I thought.

On iOS, this is a simple `flash: .on` parameter to the take photo options.

On Android, you need to:

1. Set the auto-exposure to `CONTROL_AE_MODE_ON_ALWAYS_FLASH`
2. Restart the repeating request (preview) with that auto-exposure mode so it is ready to adjust auto-exposure when the flash fires
3. Create a single **PRECAPTURE** request with `CONTROL_AE_PRECAPTURE_TRIGGER_START` 
4. Capture a single output with that **PRECAPTURE** request to trigger an auto-exposure event (effectively firing the flash)
5. Wait until the **PRECAPTURE** state went on, and then off again
6. Reset the auto-exposure to it's original state
7. Then take a photo


![](https://miro.medium.com/v2/resize:fit:720/format:webp/1*5ZNtdqngmX8FvQckkV9qLw.png)


This is so much callback/waiting stuff. Insane. Good luck finding any documentation on that online 😂 

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
