### PR TITLE
feat: Use low-level `MediaCodec` + `MediaMuxer` instead of `MediaRecorder` for recording videos

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -10,6 +10,7 @@ import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.CaptureResult
 import android.hardware.camera2.TotalCaptureResult
+import android.hardware.camera2.params.DynamicRangeProfiles
 import android.hardware.camera2.params.MeteringRectangle
 import android.media.Image
 import android.os.Build
@@ -287,7 +288,17 @@ class CameraSession(
       val outputs = outputs ?: throw CameraNotReadyError()
       val videoOutput = outputs.videoOutput ?: throw VideoNotEnabledError()
 
-      val recording = RecordingSession(context, videoOutput.size, enableAudio, fps, codec, orientation, fileType, callback, onError)
+      val dynamicRangeProfile = DynamicRangeProfiles.STANDARD
+      val recording = RecordingSession(context,
+          videoOutput.size,
+          enableAudio,
+          fps ?: 30,
+          dynamicRangeProfile,
+          codec,
+          orientation,
+          fileType,
+          callback,
+          onError)
       recording.start()
       this.recording = recording
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -289,16 +289,18 @@ class CameraSession(
       val videoOutput = outputs.videoOutput ?: throw VideoNotEnabledError()
 
       val dynamicRangeProfile = DynamicRangeProfiles.STANDARD
-      val recording = RecordingSession(context,
-          videoOutput.size,
-          enableAudio,
-          fps ?: 30,
-          dynamicRangeProfile,
-          codec,
-          orientation,
-          fileType,
-          callback,
-          onError)
+      val recording = RecordingSession(
+        context,
+        videoOutput.size,
+        enableAudio,
+        fps ?: 30,
+        dynamicRangeProfile,
+        codec,
+        orientation,
+        fileType,
+        callback,
+        onError
+      )
       recording.start()
       this.recording = recording
     }

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -96,14 +96,15 @@ class RecordingSession(
       }
     } else {
       // SDR
-      if (codec == VideoCodec.H264) {
-        format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileHigh)
-        format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.AVCLevel31)
-      } else if (codec == VideoCodec.H265) {
-        format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.HEVCProfileMain)
-        format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.HEVCHighTierLevel31)
-      } else {
-        throw InvalidTypeScriptUnionError("videoCodec", codec.unionValue)
+      when (codec) {
+        VideoCodec.H264 -> {
+          format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileHigh)
+          format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.AVCLevel31)
+        }
+        VideoCodec.H265 -> {
+          format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.HEVCProfileMain)
+          format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.HEVCHighTierLevel31)
+        }
       }
     }
     Log.i(TAG, "Configuring MediaCodec with format: $format")

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -39,7 +39,8 @@ class RecordingSession(
   private val recorder: MediaRecorder
   private val outputFile: File
   private var startTime: Long? = null
-  val surface: Surface = MediaCodec.createPersistentInputSurface()
+  val surface: Surface
+    get() = recorder.surface
 
   init {
 
@@ -67,6 +68,7 @@ class RecordingSession(
       recorder.setAudioSamplingRate(AUDIO_SAMPLING_RATE)
       recorder.setAudioChannels(AUDIO_CHANNELS)
     }
+    val surface = MediaCodec.createPersistentInputSurface()
     recorder.setInputSurface(surface)
     // recorder.setOrientationHint(orientation.toDegrees())
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -5,16 +5,23 @@ import android.hardware.camera2.params.DynamicRangeProfiles
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
 import android.media.MediaFormat
+import android.media.MediaMuxer
 import android.media.MediaRecorder
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
 import android.util.Log
 import android.util.Size
 import android.view.Surface
+import com.mrousavy.camera.InvalidTypeScriptUnionError
 import com.mrousavy.camera.RecorderError
 import com.mrousavy.camera.parsers.Orientation
 import com.mrousavy.camera.parsers.VideoCodec
 import com.mrousavy.camera.parsers.VideoFileType
 import java.io.File
+import java.lang.ref.WeakReference
+import java.nio.ByteBuffer
 
 class RecordingSession(
   context: Context,
@@ -37,13 +44,17 @@ class RecordingSession(
     private const val AUDIO_SAMPLING_RATE = 44_100
     private const val AUDIO_BIT_RATE = 16 * AUDIO_SAMPLING_RATE
     private const val AUDIO_CHANNELS = 1
+
+    private const val VERBOSE = true
   }
 
   data class Video(val path: String, val durationMs: Long)
 
   private val recorder: MediaCodec
   private val outputFile: File
+  private val encoderThread: EncoderThread
   private var startTime: Long? = null
+  private var isRecording = false
   val surface: Surface
 
   init {
@@ -74,12 +85,25 @@ class RecordingSession(
       else -> -1
     }
     if (codecProfile != -1) {
+      // HDR
       format.setInteger(MediaFormat.KEY_PROFILE, codecProfile)
+      format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.HEVCHighTierLevel31)
       format.setInteger(MediaFormat.KEY_COLOR_STANDARD, MediaFormat.COLOR_STANDARD_BT2020)
       format.setInteger(MediaFormat.KEY_COLOR_RANGE, MediaFormat.COLOR_RANGE_FULL)
       format.setInteger(MediaFormat.KEY_COLOR_TRANSFER, getTransferFunction(codecProfile))
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         format.setFeatureEnabled(MediaCodecInfo.CodecCapabilities.FEATURE_HdrEditing, true)
+      }
+    } else {
+      // SDR
+      if (codec == VideoCodec.H264) {
+        format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileHigh)
+        format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.AVCLevel31)
+      } else if (codec == VideoCodec.H265) {
+        format.setInteger(MediaFormat.KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.HEVCProfileMain)
+        format.setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.HEVCHighTierLevel31)
+      } else {
+        throw InvalidTypeScriptUnionError("videoCodec", codec.unionValue)
       }
     }
     Log.i(TAG, "Configuring MediaCodec with format: $format")
@@ -87,6 +111,8 @@ class RecordingSession(
     // Configure MediaCodec, after that the Surface is ready
     recorder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
     surface = recorder.createInputSurface()
+    encoderThread = EncoderThread(recorder, outputFile, 0)
+
 
     Log.i(TAG, "Created $this!")
   }
@@ -102,6 +128,9 @@ class RecordingSession(
     synchronized(this) {
       Log.i(TAG, "Starting RecordingSession..")
       recorder.start()
+      encoderThread.start()
+      encoderThread.waitUntilReady()
+      isRecording = true
       startTime = System.currentTimeMillis()
     }
   }
@@ -110,6 +139,7 @@ class RecordingSession(
     synchronized(this) {
       Log.i(TAG, "Stopping RecordingSession..")
       try {
+        isRecording = false
         recorder.stop()
         recorder.release()
       } catch (e: Error) {
@@ -126,6 +156,7 @@ class RecordingSession(
     synchronized(this) {
       Log.i(TAG, "Pausing Recording Session..")
       // TODO: Confirm pause() works
+      isRecording = false
       recorder.stop()
     }
   }
@@ -135,11 +166,265 @@ class RecordingSession(
       Log.i(TAG, "Resuming Recording Session..")
       // TODO: Confirm resume() works
       recorder.start()
+      isRecording = true
     }
   }
 
   override fun toString(): String {
     val audio = if (enableAudio) "with audio" else "without audio"
     return "${size.width} x ${size.height} @ $fps FPS $codec $fileType $orientation RecordingSession ($audio)"
+  }
+
+  /**
+   * Notifies the encoder thread that a new frame is available to the encoder.
+   */
+  public fun frameAvailable() {
+    synchronized(this) {
+      if (!isRecording) return
+      val handler = encoderThread.getHandler()
+      handler.sendMessage(handler.obtainMessage(
+          EncoderThread.EncoderHandler.MSG_FRAME_AVAILABLE))
+    }
+  }
+
+
+  /**
+   * Object that encapsulates the encoder thread.
+   * <p>
+   * We want to sleep until there's work to do.  We don't actually know when a new frame
+   * arrives at the encoder, because the other thread is sending frames directly to the
+   * input surface.  We will see data appear at the decoder output, so we can either use
+   * an infinite timeout on dequeueOutputBuffer() or wait() on an object and require the
+   * calling app wake us.  It's very useful to have all of the buffer management local to
+   * this thread -- avoids synchronization -- so we want to do the file muxing in here.
+   * So, it's best to sleep on an object and do something appropriate when awakened.
+   * <p>
+   * This class does not manage the MediaCodec encoder startup/shutdown.  The encoder
+   * should be fully started before the thread is created, and not shut down until this
+   * thread has been joined.
+   */
+  private class EncoderThread(mediaCodec: MediaCodec,
+                              outputFile: File,
+                              orientationHint: Int): Thread() {
+    val mEncoder = mediaCodec
+    var mEncodedFormat: MediaFormat? = null
+    val mBufferInfo = MediaCodec.BufferInfo()
+    val mMuxer = MediaMuxer(outputFile.getPath(), MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+    val mOrientationHint = orientationHint
+    var mVideoTrack: Int = -1
+
+    var mHandler: EncoderHandler? = null
+    var mFrameNum: Int = 0
+
+    val mLock: Object = Object()
+
+    @Volatile
+    var mReady: Boolean = false
+
+    /**
+     * Thread entry point.
+     * <p>
+     * Prepares the Looper, Handler, and signals anybody watching that we're ready to go.
+     */
+    public override fun run() {
+      Looper.prepare()
+      mHandler = EncoderHandler(this)    // must create on encoder thread
+      Log.d(TAG, "encoder thread ready")
+      synchronized (mLock) {
+        mReady = true
+        mLock.notify()    // signal waitUntilReady()
+      }
+
+      Looper.loop()
+
+      synchronized (mLock) {
+        mReady = false
+        mHandler = null
+      }
+      Log.d(TAG, "looper quit")
+    }
+
+    /**
+     * Waits until the encoder thread is ready to receive messages.
+     * <p>
+     * Call from non-encoder thread.
+     */
+    public fun waitUntilReady() {
+      synchronized (mLock) {
+        while (!mReady) {
+          try {
+            mLock.wait()
+          } catch (ie: InterruptedException) { /* not expected */ }
+        }
+      }
+    }
+
+    /**
+     * Waits until the encoder has processed a single frame.
+     * <p>
+     * Call from non-encoder thread.
+     */
+    public fun waitForFirstFrame() {
+      synchronized (mLock) {
+        while (mFrameNum < 1) {
+          try {
+            mLock.wait()
+          } catch (ie: InterruptedException) {
+            ie.printStackTrace();
+          }
+        }
+      }
+      Log.d(TAG, "Waited for first frame");
+    }
+
+    /**
+     * Returns the Handler used to send messages to the encoder thread.
+     */
+    public fun getHandler(): EncoderHandler {
+      synchronized (mLock) {
+        // Confirm ready state.
+        if (!mReady) {
+          throw RuntimeException("not ready")
+        }
+      }
+      return mHandler!!
+    }
+
+    /**
+     * Drains all pending output from the encoder, and adds it to the circular buffer.
+     */
+    public fun drainEncoder(): Boolean {
+      val TIMEOUT_USEC: Long = 0     // no timeout -- check for buffers, bail if none
+      var encodedFrame = false
+
+      while (true) {
+        var encoderStatus: Int = mEncoder.dequeueOutputBuffer(mBufferInfo, TIMEOUT_USEC)
+        if (encoderStatus == MediaCodec.INFO_TRY_AGAIN_LATER) {
+          // no output available yet
+          break;
+        } else if (encoderStatus == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+          // Should happen before receiving buffers, and should only happen once.
+          // The MediaFormat contains the csd-0 and csd-1 keys, which we'll need
+          // for MediaMuxer.  It's unclear what else MediaMuxer might want, so
+          // rather than extract the codec-specific data and reconstruct a new
+          // MediaFormat later, we just grab it here and keep it around.
+          mEncodedFormat = mEncoder.getOutputFormat()
+          Log.d(TAG, "encoder output format changed: " + mEncodedFormat)
+        } else if (encoderStatus < 0) {
+          Log.w(TAG, "unexpected result from encoder.dequeueOutputBuffer: " +
+              encoderStatus)
+          // let's ignore it
+        } else {
+          var encodedData: ByteBuffer? = mEncoder.getOutputBuffer(encoderStatus)
+          if (encodedData == null) {
+            throw RuntimeException("encoderOutputBuffer " + encoderStatus +
+                " was null");
+          }
+
+          if ((mBufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+            // The codec config data was pulled out when we got the
+            // INFO_OUTPUT_FORMAT_CHANGED status.  The MediaMuxer won't accept
+            // a single big blob -- it wants separate csd-0/csd-1 chunks --
+            // so simply saving this off won't work.
+            if (VERBOSE) Log.d(TAG, "ignoring BUFFER_FLAG_CODEC_CONFIG")
+            mBufferInfo.size = 0
+          }
+
+          if (mBufferInfo.size != 0) {
+            // adjust the ByteBuffer values to match BufferInfo (not needed?)
+            encodedData.position(mBufferInfo.offset)
+            encodedData.limit(mBufferInfo.offset + mBufferInfo.size)
+
+            if (mVideoTrack == -1) {
+              mVideoTrack = mMuxer.addTrack(mEncodedFormat!!)
+              mMuxer.setOrientationHint(mOrientationHint)
+              mMuxer.start()
+              Log.d(TAG, "Started media muxer")
+            }
+
+            // mEncBuffer.add(encodedData, mBufferInfo.flags,
+            //         mBufferInfo.presentationTimeUs)
+            mMuxer.writeSampleData(mVideoTrack, encodedData, mBufferInfo)
+            encodedFrame = true
+
+            if (VERBOSE) {
+              Log.d(TAG, "sent " + mBufferInfo.size + " bytes to muxer, ts=" +
+                  mBufferInfo.presentationTimeUs)
+            }
+          }
+
+          mEncoder.releaseOutputBuffer(encoderStatus, false)
+
+          if ((mBufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+            Log.w(TAG, "reached end of stream unexpectedly")
+            break      // out of while
+          }
+        }
+      }
+
+      return encodedFrame
+    }
+
+    /**
+     * Drains the encoder output.
+     * <p>
+     * See notes for {@link EncoderWrapper#frameAvailable()}.
+     */
+    fun frameAvailable() {
+      if (VERBOSE) Log.d(TAG, "frameAvailable")
+      if (drainEncoder()) {
+        synchronized (mLock) {
+          mFrameNum++
+          mLock.notify()
+        }
+      }
+    }
+
+    /**
+     * Tells the Looper to quit.
+     */
+    fun shutdown() {
+      if (VERBOSE) Log.d(TAG, "shutdown")
+      Looper.myLooper()!!.quit()
+      mMuxer.stop()
+      mMuxer.release()
+    }
+
+    /**
+     * Handler for EncoderThread.  Used for messages sent from the UI thread (or whatever
+     * is driving the encoder) to the encoder thread.
+     * <p>
+     * The object is created on the encoder thread.
+     */
+    public class EncoderHandler(et: EncoderThread): Handler() {
+      companion object {
+        val MSG_FRAME_AVAILABLE: Int = 0
+        val MSG_SHUTDOWN: Int = 1
+      }
+
+      // This shouldn't need to be a weak ref, since we'll go away when the Looper quits,
+      // but no real harm in it.
+      private val mWeakEncoderThread = WeakReference<EncoderThread>(et)
+
+      // runs on encoder thread
+      public override fun handleMessage(msg: Message) {
+        val what: Int = msg.what
+        if (VERBOSE) {
+          Log.v(TAG, "EncoderHandler: what=" + what)
+        }
+
+        val encoderThread: EncoderThread? = mWeakEncoderThread.get()
+        if (encoderThread == null) {
+          Log.w(TAG, "EncoderHandler.handleMessage: weak ref is null")
+          return
+        }
+
+        when (what) {
+          MSG_FRAME_AVAILABLE -> encoderThread.frameAvailable()
+          MSG_SHUTDOWN -> encoderThread.shutdown()
+          else -> throw RuntimeException("unknown message " + what)
+        }
+      }
+    }
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -1,7 +1,6 @@
 package com.mrousavy.camera.core
 
 import android.content.Context
-import android.media.ImageWriter
 import android.media.MediaCodec
 import android.media.MediaRecorder
 import android.os.Build
@@ -40,7 +39,6 @@ class RecordingSession(
   private val recorder: MediaRecorder
   private val outputFile: File
   private var startTime: Long? = null
-  private var imageWriter: ImageWriter? = null
   val surface: Surface = MediaCodec.createPersistentInputSurface()
 
   init {
@@ -104,9 +102,6 @@ class RecordingSession(
       try {
         recorder.stop()
         recorder.release()
-
-        imageWriter?.close()
-        imageWriter = null
       } catch (e: Error) {
         Log.e(TAG, "Failed to stop MediaRecorder!", e)
       }

--- a/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/RecordingSession.kt
@@ -13,6 +13,7 @@ import android.os.Message
 import android.util.Log
 import android.util.Size
 import android.view.Surface
+import com.mrousavy.camera.CameraQueues
 import com.mrousavy.camera.RecorderError
 import com.mrousavy.camera.parsers.Orientation
 import com.mrousavy.camera.parsers.VideoCodec
@@ -50,9 +51,9 @@ class RecordingSession(
 
   private val recorder: MediaCodec
   private val outputFile: File
-  private val encoderThread: EncoderThread
   private var startTime: Long? = null
   private var isRecording = false
+  private val lock = Any()
   val surface: Surface
 
   init {
@@ -110,7 +111,32 @@ class RecordingSession(
     // Configure MediaCodec, after that the Surface is ready
     recorder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
     surface = recorder.createInputSurface()
-    encoderThread = EncoderThread(recorder, outputFile, 0)
+
+    recorder.setCallback(object: MediaCodec.Callback() {
+      override fun onInputBufferAvailable(codec: MediaCodec, index: Int) {
+        synchronized(lock) {
+          Log.i(TAG, "onInputBufferAvailable($index)")
+          val buffer = codec.getInputBuffer(index)!!
+          codec.queueInputBuffer(index, 0, buffer.remaining(), System.nanoTime(), 0)
+        }
+      }
+
+      override fun onOutputBufferAvailable(codec: MediaCodec, index: Int, info: MediaCodec.BufferInfo) {
+        Log.i(TAG, "onOutputBufferAvailable($index @ ${info.presentationTimeUs})")
+        synchronized(lock) {
+          val buffer = codec.getOutputBuffer(index)
+          codec.releaseOutputBuffer(index, false)
+        }
+      }
+
+      override fun onError(codec: MediaCodec, e: MediaCodec.CodecException) {
+        Log.e(TAG, "onError(${e.errorCode}: ${e.diagnosticInfo})", e)
+      }
+
+      override fun onOutputFormatChanged(codec: MediaCodec, format: MediaFormat) {
+        Log.i(TAG, "onOutputFormatChanged($format)")
+      }
+    }, CameraQueues.videoQueue.handler)
 
     Log.i(TAG, "Created $this!")
   }
@@ -124,18 +150,16 @@ class RecordingSession(
     }
 
   fun start() {
-    synchronized(this) {
+    synchronized(lock) {
       Log.i(TAG, "Starting RecordingSession..")
       recorder.start()
-      encoderThread.start()
-      encoderThread.waitUntilReady()
       isRecording = true
       startTime = System.currentTimeMillis()
     }
   }
 
   fun stop() {
-    synchronized(this) {
+    synchronized(lock) {
       Log.i(TAG, "Stopping RecordingSession..")
       try {
         isRecording = false
@@ -152,7 +176,7 @@ class RecordingSession(
   }
 
   fun pause() {
-    synchronized(this) {
+    synchronized(lock) {
       Log.i(TAG, "Pausing Recording Session..")
       // TODO: Confirm pause() works
       isRecording = false
@@ -161,7 +185,7 @@ class RecordingSession(
   }
 
   fun resume() {
-    synchronized(this) {
+    synchronized(lock) {
       Log.i(TAG, "Resuming Recording Session..")
       // TODO: Confirm resume() works
       recorder.start()
@@ -172,266 +196,5 @@ class RecordingSession(
   override fun toString(): String {
     val audio = if (enableAudio) "with audio" else "without audio"
     return "${size.width} x ${size.height} @ $fps FPS $codec $fileType $orientation RecordingSession ($audio)"
-  }
-
-  /**
-   * Notifies the encoder thread that a new frame is available to the encoder.
-   */
-  public fun frameAvailable() {
-    synchronized(this) {
-      if (!isRecording) return
-      val handler = encoderThread.getHandler()
-      handler.sendMessage(
-        handler.obtainMessage(
-          EncoderThread.EncoderHandler.MSG_FRAME_AVAILABLE
-        )
-      )
-    }
-  }
-
-  /**
-   * Object that encapsulates the encoder thread.
-   * <p>
-   * We want to sleep until there's work to do.  We don't actually know when a new frame
-   * arrives at the encoder, because the other thread is sending frames directly to the
-   * input surface.  We will see data appear at the decoder output, so we can either use
-   * an infinite timeout on dequeueOutputBuffer() or wait() on an object and require the
-   * calling app wake us.  It's very useful to have all of the buffer management local to
-   * this thread -- avoids synchronization -- so we want to do the file muxing in here.
-   * So, it's best to sleep on an object and do something appropriate when awakened.
-   * <p>
-   * This class does not manage the MediaCodec encoder startup/shutdown.  The encoder
-   * should be fully started before the thread is created, and not shut down until this
-   * thread has been joined.
-   */
-  private class EncoderThread(mediaCodec: MediaCodec, outputFile: File, orientationHint: Int) : Thread() {
-    val mEncoder = mediaCodec
-    var mEncodedFormat: MediaFormat? = null
-    val mBufferInfo = MediaCodec.BufferInfo()
-    val mMuxer = MediaMuxer(outputFile.getPath(), MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
-    val mOrientationHint = orientationHint
-    var mVideoTrack: Int = -1
-
-    var mHandler: EncoderHandler? = null
-    var mFrameNum: Int = 0
-
-    val mLock: Object = Object()
-
-    @Volatile
-    var mReady: Boolean = false
-
-    /**
-     * Thread entry point.
-     * <p>
-     * Prepares the Looper, Handler, and signals anybody watching that we're ready to go.
-     */
-    public override fun run() {
-      Looper.prepare()
-      mHandler = EncoderHandler(this) // must create on encoder thread
-      Log.d(TAG, "encoder thread ready")
-      synchronized(mLock) {
-        mReady = true
-        mLock.notify() // signal waitUntilReady()
-      }
-
-      Looper.loop()
-
-      synchronized(mLock) {
-        mReady = false
-        mHandler = null
-      }
-      Log.d(TAG, "looper quit")
-    }
-
-    /**
-     * Waits until the encoder thread is ready to receive messages.
-     * <p>
-     * Call from non-encoder thread.
-     */
-    public fun waitUntilReady() {
-      synchronized(mLock) {
-        while (!mReady) {
-          try {
-            mLock.wait()
-          } catch (ie: InterruptedException) { /* not expected */ }
-        }
-      }
-    }
-
-    /**
-     * Waits until the encoder has processed a single frame.
-     * <p>
-     * Call from non-encoder thread.
-     */
-    public fun waitForFirstFrame() {
-      synchronized(mLock) {
-        while (mFrameNum < 1) {
-          try {
-            mLock.wait()
-          } catch (ie: InterruptedException) {
-            ie.printStackTrace()
-          }
-        }
-      }
-      Log.d(TAG, "Waited for first frame")
-    }
-
-    /**
-     * Returns the Handler used to send messages to the encoder thread.
-     */
-    public fun getHandler(): EncoderHandler {
-      synchronized(mLock) {
-        // Confirm ready state.
-        if (!mReady) {
-          throw RuntimeException("not ready")
-        }
-      }
-      return mHandler!!
-    }
-
-    /**
-     * Drains all pending output from the encoder, and adds it to the circular buffer.
-     */
-    public fun drainEncoder(): Boolean {
-      val timeoutUs: Long = 0 // no timeout -- check for buffers, bail if none
-      var encodedFrame = false
-
-      while (true) {
-        val encoderStatus: Int = mEncoder.dequeueOutputBuffer(mBufferInfo, timeoutUs)
-        if (encoderStatus == MediaCodec.INFO_TRY_AGAIN_LATER) {
-          // no output available yet
-          break
-        } else if (encoderStatus == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
-          // Should happen before receiving buffers, and should only happen once.
-          // The MediaFormat contains the csd-0 and csd-1 keys, which we'll need
-          // for MediaMuxer.  It's unclear what else MediaMuxer might want, so
-          // rather than extract the codec-specific data and reconstruct a new
-          // MediaFormat later, we just grab it here and keep it around.
-          mEncodedFormat = mEncoder.getOutputFormat()
-          Log.d(TAG, "encoder output format changed: " + mEncodedFormat)
-        } else if (encoderStatus < 0) {
-          Log.w(
-            TAG,
-            "unexpected result from encoder.dequeueOutputBuffer: " +
-              encoderStatus
-          )
-          // let's ignore it
-        } else {
-          var encodedData: ByteBuffer? = mEncoder.getOutputBuffer(encoderStatus)
-          if (encodedData == null) {
-            throw RuntimeException(
-              "encoderOutputBuffer " + encoderStatus +
-                " was null"
-            )
-          }
-
-          if ((mBufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
-            // The codec config data was pulled out when we got the
-            // INFO_OUTPUT_FORMAT_CHANGED status.  The MediaMuxer won't accept
-            // a single big blob -- it wants separate csd-0/csd-1 chunks --
-            // so simply saving this off won't work.
-            if (VERBOSE) Log.d(TAG, "ignoring BUFFER_FLAG_CODEC_CONFIG")
-            mBufferInfo.size = 0
-          }
-
-          if (mBufferInfo.size != 0) {
-            // adjust the ByteBuffer values to match BufferInfo (not needed?)
-            encodedData.position(mBufferInfo.offset)
-            encodedData.limit(mBufferInfo.offset + mBufferInfo.size)
-
-            if (mVideoTrack == -1) {
-              mVideoTrack = mMuxer.addTrack(mEncodedFormat!!)
-              mMuxer.setOrientationHint(mOrientationHint)
-              mMuxer.start()
-              Log.d(TAG, "Started media muxer")
-            }
-
-            // mEncBuffer.add(encodedData, mBufferInfo.flags,
-            //         mBufferInfo.presentationTimeUs)
-            mMuxer.writeSampleData(mVideoTrack, encodedData, mBufferInfo)
-            encodedFrame = true
-
-            if (VERBOSE) {
-              Log.d(
-                TAG,
-                "sent " + mBufferInfo.size + " bytes to muxer, ts=" +
-                  mBufferInfo.presentationTimeUs
-              )
-            }
-          }
-
-          mEncoder.releaseOutputBuffer(encoderStatus, false)
-
-          if ((mBufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-            Log.w(TAG, "reached end of stream unexpectedly")
-            break // out of while
-          }
-        }
-      }
-
-      return encodedFrame
-    }
-
-    /**
-     * Drains the encoder output.
-     * <p>
-     * See notes for {@link EncoderWrapper#frameAvailable()}.
-     */
-    fun frameAvailable() {
-      if (VERBOSE) Log.d(TAG, "frameAvailable")
-      if (drainEncoder()) {
-        synchronized(mLock) {
-          mFrameNum++
-          mLock.notify()
-        }
-      }
-    }
-
-    /**
-     * Tells the Looper to quit.
-     */
-    fun shutdown() {
-      if (VERBOSE) Log.d(TAG, "shutdown")
-      Looper.myLooper()!!.quit()
-      mMuxer.stop()
-      mMuxer.release()
-    }
-
-    /**
-     * Handler for EncoderThread.  Used for messages sent from the UI thread (or whatever
-     * is driving the encoder) to the encoder thread.
-     * <p>
-     * The object is created on the encoder thread.
-     */
-    public class EncoderHandler(et: EncoderThread) : Handler() {
-      companion object {
-        val MSG_FRAME_AVAILABLE: Int = 0
-        val MSG_SHUTDOWN: Int = 1
-      }
-
-      // This shouldn't need to be a weak ref, since we'll go away when the Looper quits,
-      // but no real harm in it.
-      private val mWeakEncoderThread = WeakReference<EncoderThread>(et)
-
-      // runs on encoder thread
-      public override fun handleMessage(msg: Message) {
-        val what: Int = msg.what
-        if (VERBOSE) {
-          Log.v(TAG, "EncoderHandler: what=" + what)
-        }
-
-        val encoderThread: EncoderThread? = mWeakEncoderThread.get()
-        if (encoderThread == null) {
-          Log.w(TAG, "EncoderHandler.handleMessage: weak ref is null")
-          return
-        }
-
-        when (what) {
-          MSG_FRAME_AVAILABLE -> encoderThread.frameAvailable()
-          MSG_SHUTDOWN -> encoderThread.shutdown()
-          else -> throw RuntimeException("unknown message " + what)
-        }
-      }
-    }
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -8,12 +8,9 @@ import android.media.ImageWriter
 import android.os.Build
 import android.util.Log
 import android.view.Surface
-import com.mrousavy.camera.CameraError
 import com.mrousavy.camera.CameraQueues
 import com.mrousavy.camera.PixelFormatNotSupportedError
-import com.mrousavy.camera.frameprocessor.Frame
 import com.mrousavy.camera.frameprocessor.FrameProcessor
-import com.mrousavy.camera.parsers.Orientation
 import com.mrousavy.camera.parsers.PixelFormat
 import java.io.Closeable
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -72,7 +72,7 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
         Log.w(TAG, "ImageReader failed to acquire a new image!")
         return
       }
-    } catch (e: Throwable) {
+    } catch (e: IllegalStateException) {
       Log.w(TAG, "Failed to acquire a new Image, previous calls might be taking too long! Dropping a Frame..")
       return
     }
@@ -85,7 +85,7 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
 
     // If we have a RecordingSession, pass the image through
     recordingSessionImageWriter?.queueInputImage(frame.image)
-    
+
     frame.decrementRefCount()
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -70,15 +70,20 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
       return
     }
 
+    val frame = Frame(image, image.timestamp, Orientation.PORTRAIT, isMirrored)
+
     // If we have a Frame Processor, call it
     frameProcessor?.let { fp ->
-      val frame = Frame(image, image.timestamp, Orientation.PORTRAIT, isMirrored)
       frame.incrementRefCount()
       fp.call(frame)
       frame.decrementRefCount()
     }
 
     // If we have a RecordingSession, pass the image through
-    recordingSessionImageWriter?.queueInputImage(image)
+    recordingSessionImageWriter?.let { recorder ->
+      frame.incrementRefCount()
+      recorder.queueInputImage(frame.image)
+      frame.decrementRefCount()
+    }
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -78,19 +78,14 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
     }
 
     val frame = Frame(image, image.timestamp, Orientation.PORTRAIT, isMirrored)
+    frame.incrementRefCount()
 
     // If we have a Frame Processor, call it
-    frameProcessor?.let { fp ->
-      frame.incrementRefCount()
-      fp.call(frame)
-      frame.decrementRefCount()
-    }
+    frameProcessor?.call(frame)
 
     // If we have a RecordingSession, pass the image through
-    recordingSessionImageWriter?.let { recorder ->
-      frame.incrementRefCount()
-      recorder.queueInputImage(frame.image)
-      frame.decrementRefCount()
-    }
+    recordingSessionImageWriter?.queueInputImage(frame.image)
+    
+    frame.decrementRefCount()
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -1,6 +1,7 @@
 package com.mrousavy.camera.core
 
 import android.graphics.ImageFormat
+import android.media.Image
 import android.media.ImageReader
 import android.media.ImageWriter
 import android.util.Log
@@ -16,7 +17,7 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
   ImageReader.OnImageAvailableListener,
   Closeable {
   companion object {
-    private const val MAX_IMAGES = 3
+    private const val MAX_IMAGES = 5
     private const val TAG = "VideoPipeline"
   }
 
@@ -64,9 +65,15 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
   }
 
   override fun onImageAvailable(reader: ImageReader) {
-    val image = reader.acquireLatestImage()
-    if (image == null) {
-      Log.w(TAG, "ImageReader failed to acquire a new image!")
+    val image: Image?
+    try {
+      image = reader.acquireLatestImage()
+      if (image == null) {
+        Log.w(TAG, "ImageReader failed to acquire a new image!")
+        return
+      }
+    } catch (e: Throwable) {
+      Log.w(TAG, "Failed to acquire a new Image, previous calls might be taking too long! Dropping a Frame..")
       return
     }
 

--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -93,7 +93,7 @@ class VideoPipeline(val width: Int, val height: Int, val format: Int = ImageForm
             }
           }
           recordingSessionImageWriter!!.setOnImageReleasedListener({
-            recordingSession?.frameAvailable()
+            Log.i(TAG, "ImageWriter: Image consumed by MediaCodec!")
           }, CameraQueues.videoQueue.handler)
         }
         recordingSessionImageWriter!!.queueInputImage(image)

--- a/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
+++ b/package/android/src/main/java/com/mrousavy/camera/frameprocessor/Frame.java
@@ -8,7 +8,7 @@ import com.mrousavy.camera.parsers.Orientation;
 
 import java.nio.ByteBuffer;
 
-public class Frame {
+public final class Frame {
     private final Image image;
     private final boolean isMirrored;
     private final long timestamp;


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Uses the really low-level `MediaCodec` class combined with a `MediaMuxer` to mix in Audio in favor of the simpler to use but less flexible `MediaRecorder` API.

The `MediaCodec` API is insanely hard to use, hardly documented, does not throw any helpful errors at all (always UNKNOWN_ERROR) and requires huge amounts of boilerplate. This is really painful.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
