### PR TITLE
fix: Fix CMake C/C++ cache clean loop

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -155,8 +155,6 @@ dependencies {
 task deleteCmakeCache() {
   doFirst {
     delete "${projectDir}/.cxx"
-    delete "${nodeModules}/react-native-vision-camera/android/.cxx"
-    delete "${nodeModules}/react-native-vision-camera/android/build"
   }
 }
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes a loop that recursively cleans the gradle cache when building

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #1941

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
