### PR TITLE
fix: Fix preview image stretched in contain/cover mode

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/PreviewView.kt
@@ -40,34 +40,34 @@ class PreviewView(
 
   private fun coverSize(contentSize: Size, containerWidth: Int, containerHeight: Int): Size {
     val contentAspectRatio = contentSize.height.toDouble() / contentSize.width
-    val containerAspectRatio = containerWidth.toDouble() / containerHeight
+    val containerAspectRatio = containerHeight.toDouble() / containerWidth
 
     Log.d(TAG, "coverSize :: $contentSize ($contentAspectRatio), ${containerWidth}x$containerHeight ($containerAspectRatio)")
 
-    return if (contentAspectRatio > containerAspectRatio) {
+    return if (contentAspectRatio < containerAspectRatio) {
       // Scale by width to cover height
-      val scaledWidth = containerHeight * contentAspectRatio
+      val scaledWidth = containerHeight / contentAspectRatio
       Size(scaledWidth.roundToInt(), containerHeight)
     } else {
       // Scale by height to cover width
-      val scaledHeight = containerWidth / contentAspectRatio
+      val scaledHeight = containerWidth * contentAspectRatio
       Size(containerWidth, scaledHeight.roundToInt())
     }
   }
 
   private fun containSize(contentSize: Size, containerWidth: Int, containerHeight: Int): Size {
     val contentAspectRatio = contentSize.height.toDouble() / contentSize.width
-    val containerAspectRatio = containerWidth.toDouble() / containerHeight
+    val containerAspectRatio = containerHeight.toDouble() / containerWidth
 
     Log.d(TAG, "containSize :: $contentSize ($contentAspectRatio), ${containerWidth}x$containerHeight ($containerAspectRatio)")
 
-    return if (contentAspectRatio > containerAspectRatio) {
+    return if (contentAspectRatio < containerAspectRatio) {
       // Scale by height to fit within width
-      val scaledHeight = containerWidth / contentAspectRatio
+      val scaledHeight = containerWidth * contentAspectRatio
       return Size(containerWidth, scaledHeight.roundToInt())
     } else {
       // Scale by width to fit within height
-      val scaledWidth = containerHeight * contentAspectRatio
+      val scaledWidth = containerHeight / contentAspectRatio
       return Size(scaledWidth.roundToInt(), containerHeight)
     }
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
This PR fixes the stretch problem in PreviewView, scaled width and height was mis-calculated.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->
* This PR changes the containerAspectRatio from W:H to H:W,  to keep the consistence to contentAspectRatio

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

Android Pad, Landscape, 1280x800, Android 11

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->

I found it myself, did not submit the issue yet.