### PR TITLE
fix: CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE might be empty

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -8,6 +8,7 @@ import android.hardware.camera2.params.DynamicRangeProfiles
 import android.os.Build
 import android.util.Range
 import android.util.Size
+import android.util.SizeF
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -39,7 +40,11 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
     characteristics.get(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)
       // 35mm is the film standard sensor size
       ?: floatArrayOf(35f)
-  private val sensorSize = characteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE)!!
+
+  // 35mm is 135 film format, a standard in which focal lengths are usually measured
+  private val size35mm = SizeF(36f, 24f)
+
+  private val sensorSize = characteristics.get(CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE) ?: size35mm
   private val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION)!!
   private val name = (
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -104,9 +109,6 @@ class CameraDeviceDetails(private val cameraManager: CameraManager, private val 
     }
     return array
   }
-
-  // 35mm is 135 film format, a standard in which focal lengths are usually measured
-  private val size35mm = Size(36, 24)
 
   private fun getDeviceTypes(): ReadableArray {
     // To get valid focal length standards we have to upscale to the 35mm measurement (film standard)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
This PR fixes "CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE might be empty" problem

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->
* This PR changes size35mm to SizeF from Size
* This PR set size35mm as default value of CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->
Unknown-brand Pad,  Landscape Mode, 1280x800, Android 11

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
None.