### PR TITLE
fix: Fix delay in `startRecording()` by eagerly starting AssetWriter

### DIFF
--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -105,7 +105,6 @@ extension CameraSession {
         onError(.capture(.createRecorderError(message: error.description)))
         return
       }
-      self.recordingSession = recordingSession
 
       // Init Video
       guard var videoSettings = self.recommendedVideoSettings(videoOutput: videoOutput,
@@ -152,6 +151,7 @@ extension CameraSession {
       // start recording session with or without audio.
       do {
         try recordingSession.startAssetWriter()
+        self.recordingSession = recordingSession
         self.isRecording = true
       } catch let error as NSError {
         onError(.capture(.createRecorderError(message: "RecordingSession failed to start asset writer. \(error.description)")))


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the delay in `startRecording()` by eagerly starting the AVAssetWriter session instead of lazily starting it in the `onFrame` callback.

The difference is that by eagerly starting it we are blocking the native module camera  queue (async), whereas the lazy start would block the video streaming queue (effectively causing a delay to the user)

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
