### PR TITLE
feat: Lazily start Preview using deferred Output Configurations

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraConfiguration.kt
@@ -13,7 +13,7 @@ data class CameraConfiguration(
   var cameraId: String? = null,
 
   // Outputs
-  var preview: Output<Preview> = Output.Disabled.create(),
+  var preview: Output<Preview> = Output.Enabled.create(Preview(Unit)),
   var photo: Output<Photo> = Output.Disabled.create(),
   var video: Output<Video> = Output.Disabled.create(),
   var codeScanner: Output<CodeScanner> = Output.Disabled.create(),
@@ -38,7 +38,10 @@ data class CameraConfiguration(
   var isActive: Boolean = false,
 
   // Audio Session
-  var audio: Output<Audio> = Output.Disabled.create()
+  var audio: Output<Audio> = Output.Disabled.create(),
+
+  // Preview Surface (lazily created)
+  var previewSurface: Surface? = null
 ) {
 
   // Output<T> types, those need to be comparable
@@ -46,7 +49,7 @@ data class CameraConfiguration(
   data class Photo(val nothing: Unit)
   data class Video(val pixelFormat: PixelFormat, val enableFrameProcessor: Boolean)
   data class Audio(val nothing: Unit)
-  data class Preview(val surface: Surface)
+  data class Preview(val nothing: Unit)
 
   @Suppress("EqualsOrHashCode")
   sealed class Output<T> {
@@ -71,7 +74,7 @@ data class CameraConfiguration(
     val deviceChanged: Boolean,
     // Outputs & Session (Photo, Video, CodeScanner, HDR, Format)
     val outputsChanged: Boolean,
-    // Side-Props for CaptureRequest (fps, low-light-boost, torch, zoom, videoStabilization)
+    // Side-Props for CaptureRequest (fps, low-light-boost, torch, zoom, videoStabilization, previewSurface)
     val sidePropsChanged: Boolean
   ) {
     val hasAnyDifference: Boolean
@@ -91,7 +94,8 @@ data class CameraConfiguration(
 
       val sidePropsChanged = outputsChanged || // depend on outputs
         left?.torch != right.torch || left.enableLowLightBoost != right.enableLowLightBoost || left.fps != right.fps ||
-        left.zoom != right.zoom || left.videoStabilizationMode != right.videoStabilizationMode || left.isActive != right.isActive
+        left.zoom != right.zoom || left.videoStabilizationMode != right.videoStabilizationMode || left.isActive != right.isActive ||
+        left.previewSurface != right.previewSurface
 
       return Difference(
         deviceChanged,

--- a/package/android/src/main/java/com/mrousavy/camera/core/outputs/PreviewOutput.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/outputs/PreviewOutput.kt
@@ -1,0 +1,19 @@
+package com.mrousavy.camera.core.outputs
+
+import android.hardware.camera2.params.OutputConfiguration
+import android.util.Size
+import android.view.Surface
+import android.view.SurfaceHolder
+
+class PreviewOutput(val size: Size, enableHdr: Boolean) {
+  val outputConfiguration = OutputConfiguration(size, SurfaceHolder::class.java)
+  var surface: Surface? = null
+    get() = outputConfiguration.surface
+    set(value) {
+      outputConfiguration.surfaces.forEach { outputConfiguration.removeSurface(it) }
+      if (value != null) {
+        outputConfiguration.addSurface(value)
+      }
+      field = value
+    }
+}


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Instead of waiting for the Preview Surface to get created, and then initializing the Camera Session, this PR now eagerly initializes the Camera session with a "deferred output configuration".

This specifies the size of the surface, and the Camera can load while the Preview Surface initializes freely in parallel.

Once the Preview Surface is ready, we finalize the deferred output configuration and start streaming frames into the Preview.

This should improve Camera startup time by a lot, as it is quite a fancy optimization tactic that no other Camera library does.

A few things I'm worried about:

1. Is it supported on every phone? Docs say it is, but if no one is using it I can see Samsungs breaking.
2. Are edge cases like navigation, surface tear down, etc working fine?
3. Is the code too complex now?

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
