### PR TITLE
fix: Destroy Camera under lock

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -156,23 +156,27 @@ class CameraSession(private val context: Context, private val cameraManager: Cam
 
   private fun destroy() {
     Log.i(TAG, "Destroying session..")
-    captureSession?.stopRepeating()
-    captureSession?.close()
-    captureSession = null
+    runBlocking {
+      mutex.withLock {
+        captureSession?.stopRepeating()
+        captureSession?.close()
+        captureSession = null
 
-    cameraDevice?.close()
-    cameraDevice = null
+        cameraDevice?.close()
+        cameraDevice = null
 
-    previewOutput?.close()
-    previewOutput = null
-    photoOutput?.close()
-    photoOutput = null
-    videoOutput?.close()
-    videoOutput = null
-    codeScannerOutput?.close()
-    codeScannerOutput = null
+        previewOutput?.close()
+        previewOutput = null
+        photoOutput?.close()
+        photoOutput = null
+        videoOutput?.close()
+        videoOutput = null
+        codeScannerOutput?.close()
+        codeScannerOutput = null
 
-    isRunning = false
+        isRunning = false
+      }
+    }
   }
 
   fun createPreviewView(context: Context): PreviewView {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Might fix https://github.com/mrousavy/react-native-vision-camera/issues/1958

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
