### PR TITLE
feat: Allow focusing to only AF, AE, or AWB

### DIFF
--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -507,7 +507,7 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.6.1)
-  - VisionCamera (3.6.9):
+  - VisionCamera (3.6.10):
     - React
     - React-callinvoker
     - React-Core
@@ -747,9 +747,9 @@ SPEC CHECKSUMS:
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  VisionCamera: aa2ce576c146a5e9afcbfe30e5464a311e275b8a
+  VisionCamera: b9f470768f0336e55347631744d29efd04ac475c
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 
 PODFILE CHECKSUM: 27f53791141a3303d814e09b55770336416ff4eb
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/package/ios/CameraView+Focus.swift
+++ b/package/ios/CameraView+Focus.swift
@@ -10,10 +10,11 @@ import AVFoundation
 import Foundation
 
 extension CameraView {
-  func focus(point: CGPoint, promise: Promise) {
+  func focus(options: FocusOptions, promise: Promise) {
     withPromise(promise) {
-      let normalized = previewView.captureDevicePointConverted(fromLayerPoint: point)
-      try cameraSession.focus(point: normalized)
+      let normalizedPoint = previewView.captureDevicePointConverted(fromLayerPoint: options.point)
+      let newOptions = FocusOptions(point: normalizedPoint, modes: options.modes)
+      try cameraSession.focus(options: newOptions)
       return nil
     }
   }

--- a/package/ios/CameraViewManager.swift
+++ b/package/ios/CameraViewManager.swift
@@ -73,14 +73,14 @@ final class CameraViewManager: RCTViewManager {
   }
 
   @objc
-  final func focus(_ node: NSNumber, point: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+  final func focus(_ node: NSNumber, jsOptions: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
     let promise = Promise(resolver: resolve, rejecter: reject)
-    guard let x = point["x"] as? NSNumber, let y = point["y"] as? NSNumber else {
-      promise.reject(error: .parameter(.invalid(unionName: "point", receivedValue: point.description)))
+    guard let options = try? FocusOptions(fromJsValue: jsOptions) else {
+      promise.reject(error: .parameter(.invalid(unionName: "options", receivedValue: jsOptions.description)))
       return
     }
     let component = getCameraView(withTag: node)
-    component.focus(point: CGPoint(x: x.doubleValue, y: y.doubleValue), promise: promise)
+    component.focus(options: options, promise: promise)
   }
 
   @objc

--- a/package/ios/Core/CameraSession+Focus.swift
+++ b/package/ios/Core/CameraSession+Focus.swift
@@ -13,7 +13,7 @@ extension CameraSession {
   /**
    Focuses the Camera to the specified point. The point must be in the Camera coordinate system, so {0...1} on both axis.
    */
-  func focus(point: CGPoint) throws {
+  func focus(options: FocusOptions) throws {
     guard let device = videoDeviceInput?.device else {
       throw CameraError.session(SessionError.cameraNotReady)
     }
@@ -21,7 +21,7 @@ extension CameraSession {
       throw CameraError.device(DeviceError.focusNotSupported)
     }
 
-    ReactLogger.log(level: .info, message: "Focusing (\(point.x), \(point.y))...")
+    ReactLogger.log(level: .info, message: "Focusing \(options.point) (\(options.modes))...")
 
     do {
       try device.lockForConfiguration()
@@ -30,14 +30,14 @@ extension CameraSession {
       }
 
       // Set Focus
-      if device.isFocusPointOfInterestSupported {
-        device.focusPointOfInterest = point
+      if options.modes.contains(.af) && device.isFocusPointOfInterestSupported {
+        device.focusPointOfInterest = options.point
         device.focusMode = .autoFocus
       }
-
+      
       // Set Exposure
-      if device.isExposurePointOfInterestSupported {
-        device.exposurePointOfInterest = point
+      if options.modes.contains(.ae) && device.isExposurePointOfInterestSupported {
+        device.exposurePointOfInterest = options.point
         device.exposureMode = .autoExpose
       }
 

--- a/package/ios/Types/FocusOptions.swift
+++ b/package/ios/Types/FocusOptions.swift
@@ -1,0 +1,66 @@
+//
+//  FocusOptions.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 27.11.23.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+
+struct FocusOptions: Equatable {
+  let point: CGPoint
+  let modes: Mode
+  
+  struct Mode: OptionSet {
+    let rawValue: Int
+    
+    static let af = Mode(rawValue: 1 << 0)
+    static let ae = Mode(rawValue: 1 << 1)
+    static let awb = Mode(rawValue: 1 << 2)
+    
+    static func from(jsValue: String) throws -> Mode {
+      switch (jsValue) {
+      case "af":
+        return .af
+      case "ae":
+        return .ae
+      case "awb":
+        return .awb
+      default:
+        throw CameraError.parameter(.invalid(unionName: "modes", receivedValue: jsValue))
+      }
+    }
+    
+    static func from(jsValue: [String]) throws -> Mode {
+      var modes: Mode = []
+      try jsValue.forEach { value in
+        let mode = try Mode.from(jsValue: value)
+        modes.insert(mode)
+      }
+      return modes
+    }
+  }
+  
+  init(point: CGPoint, modes: Mode) {
+    self.point = point
+    self.modes = modes
+  }
+
+  init(fromJsValue dictionary: NSDictionary) throws {
+    if let point = dictionary["point"] as? [String: Any],
+       let x = point["x"] as? NSNumber,
+       let y = point["y"] as? NSNumber {
+      self.point = CGPointMake(x.doubleValue, y.doubleValue)
+    } else {
+      throw CameraError.parameter(.invalid(unionName: "point", receivedValue: dictionary.description))
+    }
+    
+    if let modes = dictionary["modes"] as? [String] {
+      self.modes = try Mode.from(jsValue: modes)
+    } else {
+      self.modes = [.ae, .awb, .af]
+    }
+  }
+}

--- a/package/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/package/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		B8446E502ABA14C900E56077 /* CameraDevicesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B8446E4F2ABA14C900E56077 /* CameraDevicesManager.m */; };
 		B84760A62608EE7C004C3180 /* FrameHostObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = B84760A52608EE7C004C3180 /* FrameHostObject.mm */; };
 		B84760DF2608F57D004C3180 /* CameraQueues.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84760DE2608F57D004C3180 /* CameraQueues.swift */; };
+		B849BC692B14F5AF005C80B9 /* FocusOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B849BC682B14F5AF005C80B9 /* FocusOptions.swift */; };
 		B85882322AD966FC00317161 /* CameraDeviceFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85882312AD966FC00317161 /* CameraDeviceFormat.swift */; };
 		B85882342AD969E000317161 /* VideoStabilizationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85882332AD969E000317161 /* VideoStabilizationMode.swift */; };
 		B85882362AD96AFF00317161 /* AutoFocusSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85882352AD96AFF00317161 /* AutoFocusSystem.swift */; };
@@ -111,6 +112,7 @@
 		B84760A22608EE38004C3180 /* FrameHostObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameHostObject.h; sourceTree = "<group>"; };
 		B84760A52608EE7C004C3180 /* FrameHostObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameHostObject.mm; sourceTree = "<group>"; };
 		B84760DE2608F57D004C3180 /* CameraQueues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraQueues.swift; sourceTree = "<group>"; };
+		B849BC682B14F5AF005C80B9 /* FocusOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusOptions.swift; sourceTree = "<group>"; };
 		B85882312AD966FC00317161 /* CameraDeviceFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraDeviceFormat.swift; sourceTree = "<group>"; };
 		B85882332AD969E000317161 /* VideoStabilizationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoStabilizationMode.swift; sourceTree = "<group>"; };
 		B85882352AD96AFF00317161 /* AutoFocusSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFocusSystem.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				B85882352AD96AFF00317161 /* AutoFocusSystem.swift */,
 				B87B11BE2A8E63B700732EBF /* PixelFormat.swift */,
 				B85882372AD96B4400317161 /* JSUnionValue.swift */,
+				B849BC682B14F5AF005C80B9 /* FocusOptions.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 				B85882382AD96B4400317161 /* JSUnionValue.swift in Sources */,
 				B887518E25E0102000DB86D6 /* AVFrameRateRange+includes.swift in Sources */,
 				B88751A125E0102000DB86D6 /* AVCaptureDevice.Position+descriptor.swift in Sources */,
+				B849BC692B14F5AF005C80B9 /* FocusOptions.swift in Sources */,
 				B882721026AEB1A100B14107 /* AVCaptureConnection+setInterfaceOrientation.swift in Sources */,
 				B881D3602ABC8E4E009B21C8 /* AVCaptureVideoDataOutput+findPixelFormat.swift in Sources */,
 				B88103DB2AD6F0A00087F063 /* CameraSession+Audio.swift in Sources */,

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -6,12 +6,12 @@ import { CameraCaptureError, CameraRuntimeError, tryParseNativeCameraError, isEr
 import type { CameraProps, FrameProcessor } from './CameraProps'
 import { CameraModule } from './NativeCameraModule'
 import type { PhotoFile, TakePhotoOptions } from './PhotoFile'
-import type { Point } from './Point'
 import type { RecordVideoOptions, VideoFile } from './VideoFile'
 import { VisionCameraProxy } from './FrameProcessorPlugins'
 import { CameraDevices } from './CameraDevices'
 import type { EmitterSubscription } from 'react-native'
 import { Code, CodeScanner, CodeScannerFrame } from './CodeScanner'
+import { FocusOptions } from './FocusOptions'
 
 //#region Types
 export type CameraPermissionStatus = 'granted' | 'not-determined' | 'denied' | 'restricted'
@@ -263,25 +263,21 @@ export class Camera extends React.PureComponent<CameraProps> {
 
   /**
    * Focus the camera to a specific point in the coordinate system.
-   * @param {Point} point The point to focus to. This should be relative
-   * to the Camera view's coordinate system and is expressed in points.
-   *  * `(0, 0)` means **top left**.
-   *  * `(CameraView.width, CameraView.height)` means **bottom right**.
-   *
-   * Make sure the value doesn't exceed the CameraView's dimensions.
    *
    * @throws {@linkcode CameraRuntimeError} When any kind of error occured while focussing. Use the {@linkcode CameraRuntimeError.code | code} property to get the actual error
    * @example
    * ```ts
    * await camera.current.focus({
-   *   x: tapEvent.x,
-   *   y: tapEvent.y
+   *   point: {
+   *     x: tapEvent.x,
+   *     y: tapEvent.y
+   *   }
    * })
    * ```
    */
-  public async focus(point: Point): Promise<void> {
+  public async focus(options: FocusOptions): Promise<void> {
     try {
-      return await CameraModule.focus(this.handle, point)
+      return await CameraModule.focus(this.handle, options)
     } catch (e) {
       throw tryParseNativeCameraError(e)
     }

--- a/package/src/FocusOptions.ts
+++ b/package/src/FocusOptions.ts
@@ -1,0 +1,44 @@
+import { Point } from './Point'
+
+/**
+ * * `af`: Auto-Focus (depth)
+ * * `ae`: Auto-Exposure (brightness)
+ * * `awb`: Auto-White-Balance (colors)
+ */
+export type FocusMode = 'af' | 'ae' | 'awb'
+
+export interface FocusOptions {
+  /**
+   * The point to focus AE, AF or AWB to. This should be relative
+   * to the Camera view's coordinate system and is expressed in points.
+   *  * `(0, 0)` means **top left**.
+   *  * `(CameraView.width, CameraView.height)` means **bottom right**.
+   *
+   * Make sure the value doesn't exceed the CameraView's dimensions.
+   */
+  point: Point
+  /**
+   * The setting modes to focus to the specified point.
+   *
+   * If not set, all settings will be used for focusing.
+   *
+   * * `af`: Auto-Focus (depth)
+   * * `ae`: Auto-Exposure (brightness)
+   * * `awb`: Auto-White-Balance (colors)
+   *
+   * For example, if you only want to focus the AF (auto-focus/depth) setting but not exposure/colors, use:
+   *
+   * ```ts
+   * camera.current.focus({
+   *   point: {
+   *     x: x,
+   *     y: y
+   *   },
+   *   modes: ['af']
+   * })
+   * ```
+   *
+   * @default ['af', 'ae', 'awb']
+   */
+  modes?: FocusMode[]
+}


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Before:

```ts
await camera.current.focus({
  x: tapEvent.x,
  y: tapEvent.y
})
```

After:

```ts
await camera.current.focus({
  point: {
    x: tapEvent.x,
    y: tapEvent.y
  },
  modes: ['af', 'ae', 'awb']
})
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
