### PR TITLE
fix: Pause Preview while reconfiguring to avoid flashing

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -298,6 +298,25 @@ extension CameraSession {
     let clamped = max(min(exposure, device.maxExposureTargetBias), device.minExposureTargetBias)
     device.setExposureTargetBias(clamped)
   }
+  
+  // pragma MARK: Preview Pausing
+  
+  /**
+   Enables or disables the Preview streaming.
+   This is useful to stop the preview streaming half-exposed frames while the session is still starting.
+   */
+  func setPreviewEnabled(enabled: Bool) {
+    ReactLogger.log(level: .info, message: "Preview Enabled: \(enabled)")
+    
+    if #available(iOS 13.0, *) {
+      captureSession.connections.forEach { connection in
+        if connection.videoPreviewLayer != nil {
+          // Connection to the Preview Layer
+          connection.isEnabled = enabled
+        }
+      }
+    }
+  }
 
   // pragma MARK: Audio
 

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -114,6 +114,7 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
       do {
         // If needed, configure the AVCaptureSession (inputs, outputs)
         if difference.isSessionConfigurationDirty {
+          self.setPreviewEnabled(enabled: false)
           try self.withSessionLock {
             // 1. Update input device
             if difference.inputChanged {
@@ -249,7 +250,11 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
     // Start/Stop session
     if configuration.isActive {
       captureSession.startRunning()
+      // Continue streaming into the Preview once the session started
+      self.setPreviewEnabled(enabled: true)
     } else {
+      // Stop streaming into the Preview
+      self.setPreviewEnabled(enabled: false)
       captureSession.stopRunning()
     }
   }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Pauses the Preview Stream once the session gets inactive so that it doesn't look so flickery.
The goal is to make it similar to how Snap/Instagram works, where the Preview turns black and smoothly turns into color again once the session is back running

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
