### PR TITLE
Better orientation management for iOS

### DIFF
--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -72,7 +72,6 @@ class CameraConfiguration {
     let inputChanged: Bool
     let outputsChanged: Bool
     let videoStabilizationChanged: Bool
-    let orientationChanged: Bool
     let formatChanged: Bool
     let sidePropsChanged: Bool
     let torchChanged: Bool
@@ -85,7 +84,7 @@ class CameraConfiguration {
      [`inputChanged`, `outputsChanged`, `orientationChanged`]
      */
     var isSessionConfigurationDirty: Bool {
-      return inputChanged || outputsChanged || videoStabilizationChanged || orientationChanged
+      return inputChanged || outputsChanged || videoStabilizationChanged
     }
 
     /**
@@ -103,8 +102,6 @@ class CameraConfiguration {
       outputsChanged = inputChanged || left?.photo != right.photo || left?.video != right.video || left?.codeScanner != right.codeScanner
       // videoStabilizationMode
       videoStabilizationChanged = outputsChanged || left?.videoStabilizationMode != right.videoStabilizationMode
-      // orientation
-      orientationChanged = outputsChanged || left?.orientation != right.orientation
       // format (depends on cameraId)
       formatChanged = inputChanged || left?.format != right.format
       // side-props (depends on format)

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -144,7 +144,15 @@ extension CameraSession {
 
       self.codeScannerOutput = codeScannerOutput
     }
-
+    
+    // Set up mirroring for all outputs.
+    let isMirrored = videoDeviceInput?.device.isMirrored ?? false
+    if isMirrored {
+      captureSession.outputs.forEach { output in
+        output.mirror()
+      }
+    }
+    
     // Done!
     ReactLogger.log(level: .info, message: "Successfully configured all outputs!")
   }
@@ -157,20 +165,6 @@ extension CameraSession {
           connection.preferredVideoStabilizationMode = configuration.videoStabilizationMode.toAVCaptureVideoStabilizationMode()
         }
       }
-    }
-  }
-
-  // pragma MARK: Orientation
-
-  func configureOrientation(configuration: CameraConfiguration) {
-    // Set up orientation and mirroring for all outputs.
-    // Note: Photos are only rotated through EXIF tags, and Preview through view transforms
-    let isMirrored = videoDeviceInput?.device.position == .front
-    captureSession.outputs.forEach { output in
-      if isMirrored {
-        output.mirror()
-      }
-      output.setOrientation(configuration.orientation)
     }
   }
 

--- a/package/ios/Core/CameraSession+Photo.swift
+++ b/package/ios/Core/CameraSession+Photo.swift
@@ -37,6 +37,8 @@ extension CameraSession {
       }
 
       ReactLogger.log(level: .info, message: "Capturing photo...")
+      
+      photoOutput.applyPhotoOrientation(configuration.orientation, isMirrored: videoDeviceInput.device.isMirrored)
 
       // Create photo settings
       let photoSettings = AVCapturePhotoSettings()
@@ -88,7 +90,7 @@ extension CameraSession {
       }
 
       // stabilization
-      if let enableAutoStabilization = options["enableAutoStabilization"] as? Bool {
+        if let enableAutoStabilization = options["enableAutoStabilization"] as? Bool {
         photoSettings.isAutoStillImageStabilizationEnabled = enableAutoStabilization
       }
 

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -127,10 +127,6 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
             if difference.videoStabilizationChanged {
               self.configureVideoStabilization(configuration: config)
             }
-            // 4. Update output orientation
-            if difference.orientationChanged {
-              self.configureOrientation(configuration: config)
-            }
           }
         }
 

--- a/package/ios/Core/RecordingSession.swift
+++ b/package/ios/Core/RecordingSession.swift
@@ -76,7 +76,7 @@ class RecordingSession {
   /**
    Initializes an AssetWriter for video frames (CMSampleBuffers).
    */
-  func initializeVideoWriter(withSettings settings: [String: Any], pixelFormat: OSType) {
+  func initializeVideoWriter(withSettings settings: [String: Any], pixelFormat: OSType, orientation: Orientation, isMirrored: Bool) {
     guard !settings.isEmpty else {
       ReactLogger.log(level: .error, message: "Tried to initialize Video Writer with empty settings!")
       return
@@ -88,11 +88,13 @@ class RecordingSession {
 
     let videoWriter = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
     videoWriter.expectsMediaDataInRealTime = true
+    videoWriter.applyVideoOrientation(orientation: orientation, isMirrored: isMirrored)
 
     assetWriter.add(videoWriter)
     bufferAdaptor = AVAssetWriterInputPixelBufferAdaptor(assetWriterInput: videoWriter,
                                                          withVideoSettings: settings,
                                                          pixelFormat: pixelFormat)
+      
     ReactLogger.log(level: .info, message: "Initialized Video AssetWriter.")
   }
 

--- a/package/ios/Extensions/AVAssetWriterInput+applyVideoOrientation.swift
+++ b/package/ios/Extensions/AVAssetWriterInput+applyVideoOrientation.swift
@@ -1,0 +1,31 @@
+//
+//  AVAssetWriterInput+applyOrientation.swift
+//  VisionCamera
+//
+//  Created by Maxime Blanchard on 17/11/2023.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVAssetWriterInput {
+  /**
+   Apply the transform based on the orientation of the camera
+   */
+  func applyVideoOrientation(orientation: Orientation, isMirrored: Bool) {
+    var transform: CGAffineTransform = .identity
+    
+    switch orientation {
+    case .portrait:
+      transform = CGAffineTransform(rotationAngle: .pi/2)
+    case .portraitUpsideDown:
+      transform = CGAffineTransform(rotationAngle: -.pi/2)
+    case .landscapeLeft:
+      transform = CGAffineTransform(rotationAngle: .pi)
+    case .landscapeRight:
+      transform = .identity
+    }
+    
+    self.transform = isMirrored ? transform.rotated(by: .pi) : transform
+  }
+}

--- a/package/ios/Extensions/AVCaptureDevice+isMirrored.swift
+++ b/package/ios/Extensions/AVCaptureDevice+isMirrored.swift
@@ -1,0 +1,18 @@
+//
+//  AVCaptureDevice+isMirrored.swift
+//  VisionCamera
+//
+//  Created by Maxime Blanchard on 17/11/2023.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVCaptureDevice {
+  /**
+   Returns true if the device is a front camera.
+   */
+  var isMirrored: Bool {
+    self.position == .front
+  }
+}

--- a/package/ios/Extensions/AVCaptureOutput+applyPhotoOrientation.swift
+++ b/package/ios/Extensions/AVCaptureOutput+applyPhotoOrientation.swift
@@ -1,0 +1,46 @@
+//
+//  AVCaptureOutput+applyPhotoOrientation.swift
+//  VisionCamera
+//
+//  Created by Maxime Blanchard on 17/11/2023.
+//  Copyright © 2023 mrousavy. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVCaptureOutput {
+  /**
+   Sets the target orientation of the video output.
+   */
+  func applyPhotoOrientation(_ orientation: Orientation, isMirrored: Bool) {
+    // Set orientation for each connection
+    connections.forEach { connection in
+      #if swift(>=5.9)
+        if #available(iOS 17.0, *) {
+          // Camera Sensors are always in landscape rotation (90deg).
+          // We are setting the target rotation here, so we need to rotate by landscape once.
+          let cameraOrientation = orientation.rotateBy(orientation: .landscapeLeft)
+          var degrees = cameraOrientation.toDegrees()
+          
+          // When Camera is mirrored, we need to rotate the output image 180 degrees
+          let isLandscape = orientation == .landscapeLeft || orientation == .landscapeRight
+          if isMirrored && isLandscape {
+            degrees = (degrees + 180).truncatingRemainder(dividingBy: 360)
+          }
+          
+          if connection.isVideoRotationAngleSupported(degrees) {
+            connection.videoRotationAngle = degrees
+          }
+        } else {
+          if connection.isVideoOrientationSupported {
+            connection.videoOrientation = orientation.toAVCaptureVideoOrientation()
+          }
+        }
+      #else
+        if connection.isVideoOrientationSupported {
+          connection.videoOrientation = orientation.toAVCaptureVideoOrientation()
+        }
+      #endif
+    }
+  }
+}

--- a/package/ios/Extensions/AVCaptureOutput+mirror.swift
+++ b/package/ios/Extensions/AVCaptureOutput+mirror.swift
@@ -20,40 +20,4 @@ extension AVCaptureOutput {
       }
     }
   }
-
-  /**
-   Sets the target orientation of the video output.
-   This does not always physically rotate image buffers.
-
-   - For Preview, an orientation hint is used to rotate the layer/view itself.
-   - For Photos, an EXIF tag is used.
-   - For Videos, the buffers are physically rotated if available, since we use an AVCaptureVideoDataOutput instead of an AVCaptureMovieFileOutput.
-   */
-  func setOrientation(_ orientation: Orientation) {
-    // Set orientation for each connection
-    connections.forEach { connection in
-      #if swift(>=5.9)
-        if #available(iOS 17.0, *) {
-          // Camera Sensors are always in landscape rotation (90deg).
-          // We are setting the target rotation here, so we need to rotate by landscape once.
-          let cameraOrientation = orientation.rotateBy(orientation: .landscapeLeft)
-          let degrees = cameraOrientation.toDegrees()
-
-          // TODO: Don't rotate the video output because it adds overhead. Instead just use EXIF flags for the .mp4 file if recording.
-          //       Does that work when we flip the camera?
-          if connection.isVideoRotationAngleSupported(degrees) {
-            connection.videoRotationAngle = degrees
-          }
-        } else {
-          if connection.isVideoOrientationSupported {
-            connection.videoOrientation = orientation.toAVCaptureVideoOrientation()
-          }
-        }
-      #else
-        if connection.isVideoOrientationSupported {
-          connection.videoOrientation = orientation.toAVCaptureVideoOrientation()
-        }
-      #endif
-    }
-  }
 }

--- a/package/ios/Types/Orientation.swift
+++ b/package/ios/Types/Orientation.swift
@@ -83,7 +83,7 @@ enum Orientation: String, JSUnionValue {
 
   func rotateBy(orientation: Orientation) -> Orientation {
     let added = toDegrees() + orientation.toDegrees()
-    let degress = added.truncatingRemainder(dividingBy: 360)
-    return Orientation(degrees: degress)
+    let degrees = added.truncatingRemainder(dividingBy: 360)
+    return Orientation(degrees: degrees)
   }
 }

--- a/package/ios/VisionCamera.xcodeproj/project.pbxproj
+++ b/package/ios/VisionCamera.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0087B9D62B078E9F00F2B9BF /* AVCaptureDevice+isMirrored.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087B9D52B078E9F00F2B9BF /* AVCaptureDevice+isMirrored.swift */; };
+		0087B9D82B07911200F2B9BF /* AVAssetWriterInput+applyVideoOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087B9D72B07911200F2B9BF /* AVAssetWriterInput+applyVideoOrientation.swift */; };
+		0087B9DA2B0791F700F2B9BF /* AVCaptureOutput+applyPhotoOrientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087B9D92B0791F700F2B9BF /* AVCaptureOutput+applyPhotoOrientation.swift */; };
 		B80175EC2ABDEBD000E7DE90 /* ResizeMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80175EB2ABDEBD000E7DE90 /* ResizeMode.swift */; };
 		B80C0E00260BDDF7001699AB /* FrameProcessorPluginRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = B80C0DFF260BDDF7001699AB /* FrameProcessorPluginRegistry.m */; };
 		B80E06A0266632F000728644 /* AVAudioSession+updateCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E069F266632F000728644 /* AVAudioSession+updateCategory.swift */; };
@@ -91,6 +94,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0087B9D52B078E9F00F2B9BF /* AVCaptureDevice+isMirrored.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureDevice+isMirrored.swift"; sourceTree = "<group>"; };
+		0087B9D72B07911200F2B9BF /* AVAssetWriterInput+applyVideoOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAssetWriterInput+applyVideoOrientation.swift"; sourceTree = "<group>"; };
+		0087B9D92B0791F700F2B9BF /* AVCaptureOutput+applyPhotoOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVCaptureOutput+applyPhotoOrientation.swift"; sourceTree = "<group>"; };
 		134814201AA4EA6300B7C361 /* libVisionCamera.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVisionCamera.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B80175EB2ABDEBD000E7DE90 /* ResizeMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeMode.swift; sourceTree = "<group>"; };
 		B80C02EB2A6A954D001975E2 /* FrameProcessorPluginHostObject.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameProcessorPluginHostObject.mm; sourceTree = "<group>"; };
@@ -266,6 +272,7 @@
 				B887516325E0102000DB86D6 /* AVCaptureDevice+neutralZoom.swift */,
 				B81BE1BE26B936FF002696CC /* AVCaptureDevice.Format+dimensions.swift */,
 				B887516525E0102000DB86D6 /* AVCaptureDevice+isMultiCam.swift */,
+				0087B9D52B078E9F00F2B9BF /* AVCaptureDevice+isMirrored.swift */,
 				B887516625E0102000DB86D6 /* AVCaptureDevice+physicalDevices.swift */,
 				B887516725E0102000DB86D6 /* AVFrameRateRange+includes.swift */,
 				B887516825E0102000DB86D6 /* AVCaptureOutput+mirror.swift */,
@@ -275,6 +282,8 @@
 				B881D35F2ABC8E4E009B21C8 /* AVCaptureVideoDataOutput+findPixelFormat.swift */,
 				B8F127CF2ACF054A00B39EA3 /* CMVideoDimensions+toCGSize.swift */,
 				B8A1AEC32AD7EDE800169C0D /* AVCaptureVideoDataOutput+pixelFormat.swift */,
+				0087B9D72B07911200F2B9BF /* AVAssetWriterInput+applyVideoOrientation.swift */,
+				0087B9D92B0791F700F2B9BF /* AVCaptureOutput+applyPhotoOrientation.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -432,12 +441,14 @@
 			files = (
 				B887518625E0102000DB86D6 /* CameraView+RecordVideo.swift in Sources */,
 				B8A1AECA2AD8034E00169C0D /* RecordVideoOptions.swift in Sources */,
+				0087B9D82B07911200F2B9BF /* AVAssetWriterInput+applyVideoOrientation.swift in Sources */,
 				B85882322AD966FC00317161 /* CameraDeviceFormat.swift in Sources */,
 				B81BE1BF26B936FF002696CC /* AVCaptureDevice.Format+dimensions.swift in Sources */,
 				B8A1AEC82AD8005400169C0D /* CameraSession+Configuration.swift in Sources */,
 				B88685E92AD6A5D600E93869 /* CameraSession+Video.swift in Sources */,
 				B8DB3BCA263DC4D8004C18D7 /* RecordingSession.swift in Sources */,
 				B83D5EE729377117000AFD2F /* PreviewView.swift in Sources */,
+				0087B9DA2B0791F700F2B9BF /* AVCaptureOutput+applyPhotoOrientation.swift in Sources */,
 				B887518925E0102000DB86D6 /* Collection+safe.swift in Sources */,
 				B8A1AEC42AD7EDE800169C0D /* AVCaptureVideoDataOutput+pixelFormat.swift in Sources */,
 				B887519125E0102000DB86D6 /* AVCaptureDevice.Format+toDictionary.swift in Sources */,
@@ -454,6 +465,7 @@
 				B80E06A0266632F000728644 /* AVAudioSession+updateCategory.swift in Sources */,
 				B887519425E0102000DB86D6 /* MakeReactError.swift in Sources */,
 				B887519525E0102000DB86D6 /* ReactLogger.swift in Sources */,
+				0087B9D62B078E9F00F2B9BF /* AVCaptureDevice+isMirrored.swift in Sources */,
 				B88685EB2AD6A5DE00E93869 /* CameraSession+Photo.swift in Sources */,
 				B88751A725E0102000DB86D6 /* CameraView+Zoom.swift in Sources */,
 				B887518525E0102000DB86D6 /* PhotoCaptureDelegate.swift in Sources */,


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

When you give an `orientation` prop to VisionCamera, the Preview is reloaded every time it's updated. This causes a flicker when you tilt your device (when switching from portrait to landscape for example).

## Changes

I changed the logic to apply the orientation only when we effectively take a photo or start recording a video.


<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

iPhone 13 Pro Max

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
