### PR TITLE
Fix/fix third party ndk headers not found with REACT_NATIVE_DOWNLOADS_DIR setted

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -449,18 +449,10 @@ if (ENABLE_FRAME_PROCESSORS) {
   }
 
   task prepareThirdPartyNdkHeaders {
-    if (!boost_file.exists()) {
-      dependsOn(prepareBoost)
-    }
-    if (!double_conversion_file.exists()) {
-      dependsOn(prepareDoubleConversion)
-    }
-    if (!folly_file.exists()) {
-      dependsOn(prepareFolly)
-    }
-    if (!glog_file.exists()) {
-      dependsOn(prepareGlog)
-    }
+    dependsOn(prepareBoost)
+    dependsOn(prepareDoubleConversion)
+    dependsOn(prepareFolly)
+    dependsOn(prepareGlog)
   }
 
   prepareThirdPartyNdkHeaders.mustRunAfter createNativeDepsDirectories


### PR DESCRIPTION
## What

After setting REACT_NATIVE_DOWNLOADS_DIR environment variable, rebuilding will be failed with follow reasons:
![image](https://github.com/mrousavy/react-native-vision-camera/assets/87120132/86adf0f8-b0c7-4e76-a899-7328f3695e6f)
This is just because we forget to unzip the cached resources and copy them into the thirdPartyNdkDir dir

## Changes

Remove the dependOn guard in prepareThirdPartyNdkHeaders task so that the prepare tasks could be done.

## Tested on

* Pixel 7 Pro emulator, SDK 34

## Related issues

