### PR TITLE
hotfix issue #2291 - Getting black screen when using camera

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -205,7 +205,7 @@ class CameraView(context: Context) :
         config.zoom = zoom
 
         // isActive
-        config.isActive = isActive && isAttachedToWindow
+        config.isActive = isActive
       }
     }
   }


### PR DESCRIPTION
My first PR on project!  🎉

## What
This PR fix a issue #2291 that turn the camera screen black because an error on isAttachedWindow.  but the config isActive was checkin both parameters: isActive && isAttachedWindow

I'm still searching for to understand why isAttachedWindow is change the state. When active, start with true, but changes for false itself


## Changes
- CameraView.kt on `config.isActive`

## Tested on
 - Galaxy Fold 3
 - Galaxy A32
 - Moto G32

## Related issues
Fixes #2291
