### PR TITLE
fix: Fix `CamcorderProfile` out of range error

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -96,7 +96,11 @@ private fun getResolutionForCamcorderProfileQuality(camcorderProfile: Int): Int 
 private fun findClosestCamcorderProfileQuality(resolution: Size): Int {
   // Iterate through all available CamcorderProfiles and find the one that matches the closest
   val targetResolution = resolution.width * resolution.height
-  val closestProfile = (CamcorderProfile.QUALITY_QCIF..CamcorderProfile.QUALITY_8KUHD).minBy { profile ->
+
+  val profiles = (CamcorderProfile.QUALITY_QCIF..CamcorderProfile.QUALITY_8KUHD).filter { profile ->
+    return@filter CamcorderProfile.hasProfile(profile)
+  }
+  val closestProfile = profiles.minBy { profile ->
     val currentResolution = getResolutionForCamcorderProfileQuality(profile)
     return@minBy abs(currentResolution - targetResolution)
   }

--- a/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/extensions/RecordingSession+getRecommendedBitRate.kt
@@ -23,7 +23,7 @@ fun RecordingSession.getRecommendedBitRate(fps: Int, codec: VideoCodec, hdr: Boo
   val targetResolution = size
   val encoder = codec.toVideoEncoder()
   val bitDepth = if (hdr) 10 else 8
-  val quality = findClosestCamcorderProfileQuality(targetResolution)
+  val quality = findClosestCamcorderProfileQuality(cameraId, targetResolution)
   Log.i("CamcorderProfile", "Closest matching CamcorderProfile: $quality")
 
   var recommendedProfile: RecommendedProfile? = null
@@ -93,12 +93,17 @@ private fun getResolutionForCamcorderProfileQuality(camcorderProfile: Int): Int 
     else -> throw Error("Invalid CamcorderProfile \"$camcorderProfile\"!")
   }
 
-private fun findClosestCamcorderProfileQuality(resolution: Size): Int {
+private fun findClosestCamcorderProfileQuality(cameraId: String, resolution: Size): Int {
   // Iterate through all available CamcorderProfiles and find the one that matches the closest
   val targetResolution = resolution.width * resolution.height
+  val cameraIdInt = cameraId.toIntOrNull()
 
   val profiles = (CamcorderProfile.QUALITY_QCIF..CamcorderProfile.QUALITY_8KUHD).filter { profile ->
-    return@filter CamcorderProfile.hasProfile(profile)
+    if (cameraIdInt != null) {
+      return@filter CamcorderProfile.hasProfile(cameraIdInt, profile)
+    } else {
+      return@filter CamcorderProfile.hasProfile(profile)
+    }
   }
   val closestProfile = profiles.minBy { profile ->
     val currentResolution = getResolutionForCamcorderProfileQuality(profile)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Fixes the `Error retrieving camcorder profile params` / `CamcorderProfile not available` error.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

- Fixes #2208

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
