### PR TITLE
chore: Disable SwiftFormat `forEach` conversion

### DIFF
--- a/package/ios/.swiftformat
+++ b/package/ios/.swiftformat
@@ -6,6 +6,7 @@
 --disable redundantReturn
 --disable wrapMultilineStatementBraces
 --disable organizeDeclarations
+--disable preferForLoop
 
 --enable markTypes
 

--- a/package/ios/.swiftlint.yml
+++ b/package/ios/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
   - type_body_length
   - cyclomatic_complexity
   - function_body_length
+  - for_where
 opt_in_rules:
   - contains_over_filter_count
   - contains_over_filter_is_empty

--- a/package/ios/.swiftlint.yml
+++ b/package/ios/.swiftlint.yml
@@ -5,7 +5,6 @@ disabled_rules:
   - type_body_length
   - cyclomatic_complexity
   - function_body_length
-  - for_where
 opt_in_rules:
   - contains_over_filter_count
   - contains_over_filter_is_empty

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -19,7 +19,7 @@ extension CameraSession {
     ReactLogger.log(level: .info, message: "Configuring Input Device...")
 
     // Remove all inputs
-    for input in captureSession.inputs {
+    captureSession.inputs.forEach { input in
       captureSession.removeInput(input)
     }
     videoDeviceInput = nil
@@ -57,7 +57,7 @@ extension CameraSession {
     ReactLogger.log(level: .info, message: "Configuring Outputs...")
 
     // Remove all outputs
-    for output in captureSession.outputs {
+    captureSession.outputs.forEach { output in
       captureSession.removeOutput(output)
     }
     photoOutput = nil
@@ -130,7 +130,7 @@ extension CameraSession {
       // 2. Configure
       let options = codeScanner.options
       codeScannerOutput.setMetadataObjectsDelegate(self, queue: CameraQueues.codeScannerQueue)
-      for type in codeScanner.options.codeTypes {
+      try codeScanner.options.codeTypes.forEach { type in
         // CodeScanner::availableMetadataObjectTypes depends on the connection to the
         // AVCaptureSession, so this list is only available after we add the output to the session.
         if !codeScannerOutput.availableMetadataObjectTypes.contains(type) {
@@ -151,8 +151,8 @@ extension CameraSession {
 
   // pragma MARK: Video Stabilization
   func configureVideoStabilization(configuration: CameraConfiguration) {
-    for output in captureSession.outputs {
-      for connection in output.connections {
+    captureSession.outputs.forEach { output in
+      output.connections.forEach { connection in
         if connection.isVideoStabilizationSupported {
           connection.preferredVideoStabilizationMode = configuration.videoStabilizationMode.toAVCaptureVideoStabilizationMode()
         }
@@ -166,7 +166,7 @@ extension CameraSession {
     // Set up orientation and mirroring for all outputs.
     // Note: Photos are only rotated through EXIF tags, and Preview through view transforms
     let isMirrored = videoDeviceInput?.device.position == .front
-    for output in captureSession.outputs {
+    captureSession.outputs.forEach { output in
       if isMirrored {
         output.mirror()
       }
@@ -320,7 +320,7 @@ extension CameraSession {
     }
 
     // Remove all current inputs
-    for input in audioCaptureSession.inputs {
+    audioCaptureSession.inputs.forEach { input in
       audioCaptureSession.removeInput(input)
     }
     audioDeviceInput = nil
@@ -340,7 +340,7 @@ extension CameraSession {
     }
 
     // Remove all current outputs
-    for output in audioCaptureSession.outputs {
+    audioCaptureSession.outputs.forEach { output in
       audioCaptureSession.removeOutput(output)
     }
     audioOutput = nil

--- a/package/ios/Extensions/AVCaptureOutput+mirror.swift
+++ b/package/ios/Extensions/AVCaptureOutput+mirror.swift
@@ -13,7 +13,7 @@ extension AVCaptureOutput {
    Mirrors the video output if possible.
    */
   func mirror() {
-    for connection in connections {
+    connections.forEach { connection in
       if connection.isVideoMirroringSupported {
         connection.automaticallyAdjustsVideoMirroring = false
         connection.isVideoMirrored = true
@@ -31,7 +31,7 @@ extension AVCaptureOutput {
    */
   func setOrientation(_ orientation: Orientation) {
     // Set orientation for each connection
-    for connection in connections {
+    connections.forEach { connection in
       #if swift(>=5.9)
         if #available(iOS 17.0, *) {
           // Camera Sensors are always in landscape rotation (90deg).


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
