### PR TITLE
feat: Lower `minSdkVersion` from 26 to 23

### DIFF
--- a/docs/docs/guides/TROUBLESHOOTING.mdx
+++ b/docs/docs/guides/TROUBLESHOOTING.mdx
@@ -87,7 +87,7 @@ If you're experiencing build issues or runtime issues in VisionCamera, make sure
    2. Set `buildToolsVersion` to `33.0.0` or higher
    3. Set `compileSdkVersion` to `33` or higher
    4. Set `targetSdkVersion` to `33` or higher
-   5. Set `minSdkVersion` to `26` or higher
+   5. Set `minSdkVersion` to `23` or higher (although `26` or higher is recommended)
    6. Set `ndkVersion` to `"23.1.7779620"` or higher
    7. Update the Gradle Build-Tools version to `7.3.1` or higher:
       ```

--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -104,7 +104,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion safeExtGet("minSdkVersion", 26)
+    minSdkVersion safeExtGet("minSdkVersion", 23)
     compileSdkVersion safeExtGet("compileSdkVersion", 33)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1

--- a/package/example/android/build.gradle
+++ b/package/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "33.0.0"
-        minSdkVersion = 26
+        minSdkVersion = 23
         compileSdkVersion = 33
         targetSdkVersion = 33
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Lowers the minimum required SDK version from 26 to 23.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
