### PR TITLE
Backport changes to focus on iOS

### DIFF
--- a/ios/CameraView+Focus.swift
+++ b/ios/CameraView+Focus.swift
@@ -1,5 +1,5 @@
 //
-//  CameraView+focus.swift
+//  CameraView+Focus.swift
 //  mrousavy
 //
 //  Created by Marc Rousavy on 19.02.21.

--- a/ios/CameraView+Focus.swift
+++ b/ios/CameraView+Focus.swift
@@ -22,20 +22,61 @@ extension CameraView {
 
       do {
         try device.lockForConfiguration()
+        defer {
+          device.unlockForConfiguration()
+        }
 
+        // Set Focus
         device.focusPointOfInterest = normalizedPoint
         device.focusMode = .autoFocus
 
+        // Set Exposure
         if device.isExposurePointOfInterestSupported {
           device.exposurePointOfInterest = normalizedPoint
           device.exposureMode = .autoExpose
         }
+        
+        // Remove any existing listeners
+        NotificationCenter.default.removeObserver(self,
+                                                  name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange,
+                                                  object: nil)
 
-        device.unlockForConfiguration()
+        // Listen for focus completion
+        device.isSubjectAreaChangeMonitoringEnabled = true
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(subjectAreaDidChange),
+                                               name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange,
+                                               object: nil)
+
         return nil
       } catch {
         throw CameraError.device(DeviceError.configureError)
       }
     }
+  }
+  
+  @objc
+  func subjectAreaDidChange(notification _: NSNotification) {
+    guard let device = videoDeviceInput?.device else {
+      return
+    }
+
+    try? device.lockForConfiguration()
+    defer {
+      device.unlockForConfiguration()
+    }
+
+    // Reset Focus to continuous/auto
+    if device.isFocusPointOfInterestSupported {
+      device.focusMode = .continuousAutoFocus
+    }
+
+    // Reset Exposure to continuous/auto
+    if device.isExposurePointOfInterestSupported {
+      device.exposureMode = .continuousAutoExposure
+    }
+
+    // Disable listeners
+    device.isSubjectAreaChangeMonitoringEnabled = false
   }
 }

--- a/ios/CameraView+Focus.swift
+++ b/ios/CameraView+Focus.swift
@@ -24,11 +24,11 @@ extension CameraView {
         try device.lockForConfiguration()
 
         device.focusPointOfInterest = normalizedPoint
-        device.focusMode = .continuousAutoFocus
+        device.focusMode = .autoFocus
 
         if device.isExposurePointOfInterestSupported {
           device.exposurePointOfInterest = normalizedPoint
-          device.exposureMode = .continuousAutoExposure
+          device.exposureMode = .autoExpose
         }
 
         device.unlockForConfiguration()

--- a/ios/CameraView+Focus.swift
+++ b/ios/CameraView+Focus.swift
@@ -35,7 +35,7 @@ extension CameraView {
           device.exposurePointOfInterest = normalizedPoint
           device.exposureMode = .autoExpose
         }
-        
+
         // Remove any existing listeners
         NotificationCenter.default.removeObserver(self,
                                                   name: NSNotification.Name.AVCaptureDeviceSubjectAreaDidChange,
@@ -54,7 +54,7 @@ extension CameraView {
       }
     }
   }
-  
+
   @objc
   func subjectAreaDidChange(notification _: NSNotification) {
     guard let device = videoDeviceInput?.device else {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Use the same method for focus in v2 that we use in v3

## Changes

Use .autoFocus and .autoExpose like in v3

## Tested on

iPhone 15 pro

## Related issues

N/A
