### PR TITLE
feat: Don't play shutter sound if phone is on silent

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView+TakePhoto.kt
@@ -7,6 +7,7 @@ import android.graphics.BitmapFactory
 import android.graphics.ImageFormat
 import android.graphics.Matrix
 import android.hardware.camera2.*
+import android.media.AudioManager
 import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
@@ -32,7 +33,12 @@ suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
   val flash = options["flash"] as? String ?: "off"
   val enableAutoRedEyeReduction = options["enableAutoRedEyeReduction"] == true
   val enableAutoStabilization = options["enableAutoStabilization"] == true
-  val enableShutterSound = options["enableShutterSound"] as? Boolean ?: true
+  var enableShutterSound = options["enableShutterSound"] as? Boolean ?: true
+
+  val canPlaySound = audioManager.ringerMode == AudioManager.RINGER_MODE_NORMAL
+  if (!canPlaySound) {
+    enableShutterSound = false
+  }
 
   val flashMode = Flash.fromUnionValue(flash)
   val qualityPrioritizationMode = QualityPrioritization.fromUnionValue(qualityPrioritization)

--- a/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/CameraView.kt
@@ -3,6 +3,7 @@ package com.mrousavy.camera
 import android.annotation.SuppressLint
 import android.content.Context
 import android.hardware.camera2.CameraManager
+import android.media.AudioManager
 import android.util.Log
 import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
@@ -89,6 +90,7 @@ class CameraView(context: Context) :
   // private properties
   private var isMounted = false
   internal val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+  internal val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
   // session
   internal val cameraSession: CameraSession

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -14,6 +14,7 @@ import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.CaptureResult
 import android.hardware.camera2.TotalCaptureResult
 import android.hardware.camera2.params.MeteringRectangle
+import android.media.AudioManager
 import android.media.Image
 import android.media.ImageReader
 import android.os.Build
@@ -55,7 +56,9 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-class CameraSession(private val context: Context, private val cameraManager: CameraManager, private val callback: CameraSessionCallback) :
+class CameraSession(private val context: Context,
+                    private val cameraManager: CameraManager,
+                    private val callback: CameraSessionCallback) :
   CameraManager.AvailabilityCallback(),
   Closeable,
   CoroutineScope {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Based off of https://github.com/mrousavy/react-native-vision-camera/pull/2433, author said there were errors if the phone is on silent.

I just restructured the code a bit to move the logic into CameraView (where it belongs imo) - it does the same thing.

I have yet to verify if this is actually an issue though.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
