### PR TITLE
fix: Double check HardwareBuffer creation if it is actually supported

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/VideoPipeline.kt
@@ -238,7 +238,14 @@ class VideoPipeline(
   private fun supportsHardwareBufferFlags(flags: Long): Boolean {
     val hardwareBufferFormat = format.toHardwareBufferFormat()
     try {
-      return HardwareBuffer.isSupported(width, height, hardwareBufferFormat, 1, flags)
+      val isSupported = HardwareBuffer.isSupported(width, height, hardwareBufferFormat, 1, flags)
+      if (!isSupported) return false
+
+      // double check if we can actually use those HardwareBuffers because we can't trust these APIs on Samsung.
+      val testBuffer = HardwareBuffer.create(width, height, hardwareBufferFormat, 1, flags)
+      testBuffer.format // <-- if this doesn't crash it's probably fine
+      testBuffer.close()
+      return true
     } catch (_: Throwable) {
       return false
     }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

When using `enableGpuBuffers={true}`, the pipeline tries to use GPU based buffers for the `ImageReader`/`ImageWriter` pipeline.

Previously we used [`HardwareBuffer.isSupported(...)`](https://developer.android.com/reference/android/hardware/HardwareBuffer#isSupported(int,%20int,%20int,%20int,%20long)) to check if we can use those GPU buffers (the `HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE` flag), but for some reason on some Samsung devices this returned `true` and then crashed later on - which is either really stupid from Samsung's side (because they are simply lying in their APIs), or I am missing something on my side.

Either way, with this PR we now also additionally create a test HardwareBuffer using [`HardwareBuffer.create(...)`](https://developer.android.com/reference/android/hardware/HardwareBuffer#create(int,%20int,%20int,%20int,%20long)) to see if creation goes successfully. If this fails, then we can avoid crashing the app since it means GPU buffers are not supported, even though the `isSupported(...)` API said they are.

**I need help from the community** for this one though:

- If your app crashes with `enableGpuBuffers={true}` when starting a Video Recording while having a Frame Processor, can you try if this PR fixes the issue? 
- Can anyone create a bug report on Android or Samsung forums to see if this is a bug in Android, or maybe an error on my side? There's just no documentation on this available.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
