### PR TITLE
feat: Added option to consider ringer mode in Android

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+TakePhoto.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+TakePhoto.kt
@@ -16,10 +16,12 @@ suspend fun CameraView.takePhoto(optionsMap: ReadableMap): WritableMap {
 
   val flash = options["flash"] as? String ?: "off"
   val enableShutterSound = options["enableShutterSound"] as? Boolean ?: true
+  val isAppliedRingerMode = options["isAppliedRingerMode"] as? Boolean ?: false
 
   val photo = cameraSession.takePhoto(
     Flash.fromUnionValue(flash),
     enableShutterSound,
+    isAppliedRingerMode,
     orientation
   )
 

--- a/package/src/types/PhotoFile.ts
+++ b/package/src/types/PhotoFile.ts
@@ -29,6 +29,15 @@ export interface TakePhotoOptions {
    * @default true
    */
   enableShutterSound?: boolean
+  /**
+   * (android)
+   * If this option is set to true,
+   * When ringerMode is RINGER_MODE_NORMAL, the shutterSound option is applied.
+   * When the ringer mode is RINGER_MODE_SILENT or RINGER MODE VIBRATE, the shutter Sound option is ignored.
+   *
+   * @default false
+   */
+  isAppliedRingerMode?: boolean
 }
 
 /**


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
When using the takePhoto function in Android, ringerMode is not applied by default, but is applied when a value is received as an option

If isAppliedRingerMode option is set to true in takePhoto function,
When ringerMode is RINGER_MODE_NORMAL, the shutterSound option is applied.
When the ringer mode is RINGER_MODE_SILENT or RINGER MODE VIBRATE, the shutter Sound option is ignored.
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
