### PR TITLE
feat: Rename `VisionCameraProxyHolder` -> `VisionCameraContext`

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSORS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS.mdx
@@ -159,8 +159,8 @@ A Frame Processor Plugin is a single native class which contains an initializer 
 public class FaceDetectorPlugin: FrameProcessorPlugin {
   private let sensitivity: Double
 
-  public override init(proxy: VisionCameraProxyHolder, options: [AnyHashable: Any]) {
-    super.init(proxy: proxy, options: options)
+  public override init(context: VisionCameraContext, options: [AnyHashable: Any]) {
+    super.init(context: context, options: options)
     sensitivity = options["sensitivity"] as Double
   }
 
@@ -180,7 +180,7 @@ public class FaceDetectorPlugin: FrameProcessorPlugin {
 public class FaceDetectorPlugin extends FrameProcessorPlugin {
   private final Double sensitivity;
 
-  public FaceDetectorPlugin(VisionCameraProxyHolder proxy, Map<String, Object> options) {
+  public FaceDetectorPlugin(VisionCameraContext context, Map<String, Object> options) {
     super();
     sensitivity = options.get("sensitivity") as Double;
   }

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
@@ -51,9 +51,9 @@ For reference see the [CLI's docs](https://github.com/mateusz1913/vision-camera-
 
 @implementation FaceDetectorFrameProcessorPlugin
 
-- (instancetype) initWithProxy:(VisionCameraProxyHolder*)proxy
-                   withOptions:(NSDictionary* _Nullable)options {
-  self = [super initWithProxy:proxy options:options];
+- (instancetype) initWithContext:(VisionCameraContext*)context
+                     withOptions:(NSDictionary* _Nullable)options {
+  self = [super initWithContext:context options:options];
   return self;
 }
 
@@ -92,8 +92,8 @@ import VisionCamera
 
 @objc(FaceDetectorFrameProcessorPlugin)
 public class FaceDetectorFrameProcessorPlugin: FrameProcessorPlugin {
-  public override init(proxy: VisionCameraProxyHolder, options: [AnyHashable : Any]! = [:]) {
-    super.init(proxy: proxy, options: options)
+  public override init(context: VisionCameraContext, options: [AnyHashable : Any]! = [:]) {
+    super.init(context: context, options: options)
   }
 
   public override func callback(_ frame: Frame, withArguments arguments: [AnyHashable : Any]?) -> Any {

--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -93,7 +93,7 @@ Pod::Spec.new do |s|
         "ios/FrameProcessors/FrameProcessorPluginRegistry.h",
         "ios/FrameProcessors/SharedArray.h",
         "ios/FrameProcessors/VisionCameraProxyDelegate.h",
-        "ios/FrameProcessors/VisionCameraProxyHolder.h",
+        "ios/FrameProcessors/VisionCameraContext.h",
         "ios/FrameProcessors/VisionCameraInstaller.h",
       ]
 

--- a/package/example/ios/Frame Processor Plugins/Example Plugin/ExampleFrameProcessorPlugin.m
+++ b/package/example/ios/Frame Processor Plugins/Example Plugin/ExampleFrameProcessorPlugin.m
@@ -20,11 +20,11 @@
   SharedArray* _sharedArray;
 }
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
-                  withOptions:(NSDictionary* _Nullable)options {
-  if (self = [super initWithProxy:proxy withOptions:options]) {
-    _sharedArray = [[SharedArray alloc] initWithProxy:proxy
-                                     allocateWithSize:5];
+- (instancetype)initWithContext:(VisionCameraContext*)context
+                    withOptions:(NSDictionary* _Nullable)options {
+  if (self = [super initWithContext:context withOptions:options]) {
+    _sharedArray = [[SharedArray alloc] initWithContext:context
+                                       allocateWithSize:5];
     NSLog(@"ExampleFrameProcessorPlugin initialized with options: %@", options);
   }
   return self;

--- a/package/example/ios/Frame Processor Plugins/Example Swift Plugin/ExampleSwiftFrameProcessor.swift
+++ b/package/example/ios/Frame Processor Plugins/Example Swift Plugin/ExampleSwiftFrameProcessor.swift
@@ -11,8 +11,8 @@ import VisionCamera
 // Example for a Swift Frame Processor plugin
 @objc(ExampleSwiftFrameProcessorPlugin)
 public class ExampleSwiftFrameProcessorPlugin: FrameProcessorPlugin {
-  public override init(proxy: VisionCameraProxyHolder, options: [AnyHashable: Any]! = [:]) {
-    super.init(proxy: proxy, options: options)
+  public override init(context: VisionCameraContext, options: [AnyHashable: Any]! = [:]) {
+    super.init(context: context, options: options)
 
     print("ExampleSwiftFrameProcessorPlugin initialized with options: \(String(describing: options))")
   }

--- a/package/ios/FrameProcessors/FrameProcessorPlugin.h
+++ b/package/ios/FrameProcessors/FrameProcessorPlugin.h
@@ -10,7 +10,7 @@
 
 #import "Frame.h"
 #import "FrameProcessorPluginRegistry.h"
-#import "VisionCameraProxyHolder.h"
+#import "VisionCameraContext.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,11 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
  * This is called everytime this Frame Processor Plugin is loaded from the JS side (`initFrameProcessorPlugin(..)`).
  * Optionally override this method to implement custom initialization logic.
  * - Parameters:
- *   - proxy: The VisionCameraProxy instance for using the Frame Processor Context, e.g. to initialize SharedArrays.
+ *   - context: The VisionCameraContext instance, e.g. to initialize SharedArrays.
  *   - options: An options dictionary passed from the JS side, or `nil` if none.
  */
-- (instancetype _Nonnull)initWithProxy:(VisionCameraProxyHolder*)proxy
-                           withOptions:(NSDictionary* _Nullable)options NS_SWIFT_NAME(init(proxy:options:));
+- (instancetype _Nonnull)initWithContext:(VisionCameraContext*)context
+                             withOptions:(NSDictionary* _Nullable)options NS_SWIFT_NAME(init(context:options:));
 
 - (instancetype _Nonnull)init NS_UNAVAILABLE;
 
@@ -65,8 +65,8 @@ NS_ASSUME_NONNULL_END
   +(void)load {                                                                                                                            \
     [FrameProcessorPluginRegistry                                                                                                          \
         addFrameProcessorPlugin:@ #frame_processor_plugin_name                                                                             \
-                withInitializer:^FrameProcessorPlugin*(VisionCameraProxyHolder* _Nonnull proxy, NSDictionary* _Nullable options) {         \
-                  return [[frame_processor_class alloc] initWithProxy:proxy withOptions:options];                                          \
+                withInitializer:^FrameProcessorPlugin*(VisionCameraContext* _Nonnull context, NSDictionary* _Nullable options) {           \
+                  return [[frame_processor_class alloc] initWithContext:context withOptions:options];                                      \
                 }];                                                                                                                        \
   }
 
@@ -79,9 +79,9 @@ NS_ASSUME_NONNULL_END
                                                                                                                                            \
   __attribute__((constructor)) static void VISION_CONCAT(initialize_, frame_processor_plugin_name)(void) {                                 \
     [FrameProcessorPluginRegistry addFrameProcessorPlugin:@ #frame_processor_plugin_name                                                   \
-                                          withInitializer:^FrameProcessorPlugin* _Nonnull(VisionCameraProxyHolder* _Nonnull proxy,         \
+                                          withInitializer:^FrameProcessorPlugin* _Nonnull(VisionCameraContext* _Nonnull context,           \
                                                                                           NSDictionary* _Nullable options) {               \
-                                            return [[frame_processor_class alloc] initWithProxy:proxy withOptions:options];                \
+                                            return [[frame_processor_class alloc] initWithContext:context withOptions:options];            \
                                           }];                                                                                              \
   }                                                                                                                                        \
                                                                                                                                            \

--- a/package/ios/FrameProcessors/FrameProcessorPlugin.m
+++ b/package/ios/FrameProcessors/FrameProcessorPlugin.m
@@ -11,7 +11,7 @@
 // Base implementation (empty)
 @implementation FrameProcessorPlugin
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder* _Nonnull)proxy withOptions:(NSDictionary* _Nullable)options {
+- (instancetype)initWithContext:(VisionCameraContext* _Nonnull)context withOptions:(NSDictionary* _Nullable)options {
   self = [super init];
   return self;
 }

--- a/package/ios/FrameProcessors/FrameProcessorPluginRegistry.h
+++ b/package/ios/FrameProcessors/FrameProcessorPluginRegistry.h
@@ -10,7 +10,7 @@
 
 #import "Frame.h"
 #import "FrameProcessorPlugin.h"
-#import "VisionCameraProxyHolder.h"
+#import "VisionCameraContext.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -20,12 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FrameProcessorPluginRegistry : NSObject
 
-typedef FrameProcessorPlugin* _Nonnull (^PluginInitializerFunction)(VisionCameraProxyHolder* proxy, NSDictionary* _Nullable options);
+typedef FrameProcessorPlugin* _Nonnull (^PluginInitializerFunction)(VisionCameraContext* context, NSDictionary* _Nullable options);
 
 + (void)addFrameProcessorPlugin:(NSString*)name withInitializer:(PluginInitializerFunction)pluginInitializer;
 
 + (FrameProcessorPlugin* _Nullable)getPlugin:(NSString*)name
-                                   withProxy:(VisionCameraProxyHolder*)proxy
+                                 withContext:(VisionCameraContext*)context
                                  withOptions:(NSDictionary* _Nullable)options;
 
 @end

--- a/package/ios/FrameProcessors/FrameProcessorPluginRegistry.m
+++ b/package/ios/FrameProcessors/FrameProcessorPluginRegistry.m
@@ -32,7 +32,7 @@
 }
 
 + (FrameProcessorPlugin*)getPlugin:(NSString* _Nonnull)name
-                         withProxy:(VisionCameraProxyHolder* _Nonnull)proxy
+                       withContext:(VisionCameraContext* _Nonnull)context
                        withOptions:(NSDictionary* _Nullable)options {
   NSLog(@"Looking up Frame Processor Plugin \"%@\"...", name);
   PluginInitializerFunction initializer = [[FrameProcessorPluginRegistry frameProcessorPlugins] objectForKey:name];
@@ -42,7 +42,7 @@
   }
 
   NSLog(@"Frame Processor Plugin \"%@\" found! Initializing...", name);
-  return initializer(proxy, options);
+  return initializer(context, options);
 }
 
 @end

--- a/package/ios/FrameProcessors/SharedArray.h
+++ b/package/ios/FrameProcessors/SharedArray.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#import "VisionCameraProxyHolder.h"
+#import "VisionCameraContext.h"
 #import <Foundation/Foundation.h>
 
 #ifdef __cplusplus
@@ -29,16 +29,16 @@ NS_ASSUME_NONNULL_BEGIN
  * Allocates a new SharedArray with the given size.
  * Use `data` to write to the SharedArray.
  */
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy allocateWithSize:(NSInteger)size;
+- (instancetype)initWithContext:(VisionCameraContext*)context allocateWithSize:(NSInteger)size;
 
 /**
  * Wraps the given data in a SharedArray without copying.
  * Use `data` to write to the SharedArray.
  */
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
-                     wrapData:(uint8_t*)data
-                     withSize:(NSInteger)size
-                freeOnDealloc:(BOOL)freeOnDealloc;
+- (instancetype)initWithContext:(VisionCameraContext*)context
+                       wrapData:(uint8_t*)data
+                       withSize:(NSInteger)size
+                  freeOnDealloc:(BOOL)freeOnDealloc;
 
 #ifdef __cplusplus
 /**

--- a/package/ios/FrameProcessors/SharedArray.mm
+++ b/package/ios/FrameProcessors/SharedArray.mm
@@ -19,17 +19,17 @@ using namespace facebook;
   std::shared_ptr<jsi::ArrayBuffer> _arrayBuffer;
 }
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy allocateWithSize:(NSInteger)size {
+- (instancetype)initWithContext:(VisionCameraContext*)context allocateWithSize:(NSInteger)size {
   uint8_t* data = (uint8_t*)malloc(size * sizeof(uint8_t));
-  return [self initWithProxy:proxy wrapData:data withSize:size freeOnDealloc:YES];
+  return [self initWithContext:context wrapData:data withSize:size freeOnDealloc:YES];
 }
 
-- (instancetype)initWithProxy:(VisionCameraProxyHolder*)proxy
-                     wrapData:(uint8_t*)data
-                     withSize:(NSInteger)size
-                freeOnDealloc:(BOOL)freeOnDealloc {
+- (instancetype)initWithContext:(VisionCameraContext*)context
+                       wrapData:(uint8_t*)data
+                       withSize:(NSInteger)size
+                  freeOnDealloc:(BOOL)freeOnDealloc {
   if (self = [super init]) {
-    jsi::Runtime& runtime = proxy.proxy->getWorkletRuntime();
+    jsi::Runtime& runtime = context.context->getWorkletRuntime();
 
     auto mutableBuffer = std::make_shared<vision::MutableRawBuffer>(data, size, freeOnDealloc);
     _arrayBuffer = std::make_shared<jsi::ArrayBuffer>(runtime, mutableBuffer);

--- a/package/ios/FrameProcessors/VisionCameraContext.h
+++ b/package/ios/FrameProcessors/VisionCameraContext.h
@@ -1,5 +1,5 @@
 //
-//  VisionCameraProxyHolder.h
+//  VisionCameraContext.h
 //  Pods
 //
 //  Created by Marc Rousavy on 20.04.24.
@@ -17,9 +17,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- An Objective-C/Swift class that holds the C++ VisionCameraProxy.
+ * An Objective-C/Swift class that holds VisionCamera-related context.
  */
-@interface VisionCameraProxyHolder : NSObject
+@interface VisionCameraContext : NSObject
 
 - (_Nonnull instancetype)initWithProxy:(void*)proxy;
 

--- a/package/ios/FrameProcessors/VisionCameraContext.mm
+++ b/package/ios/FrameProcessors/VisionCameraContext.mm
@@ -1,15 +1,15 @@
 //
-//  VisionCameraProxyHolder.mm
+//  VisionCameraContext.mm
 //  DoubleConversion
 //
 //  Created by Marc Rousavy on 20.04.24.
 //
 
-#import "VisionCameraProxyHolder.h"
+#import "VisionCameraContext.h"
 #import "VisionCameraProxy.h"
 #import <Foundation/Foundation.h>
 
-@implementation VisionCameraProxyHolder {
+@implementation VisionCameraContext {
   VisionCameraProxy* _proxy;
 }
 

--- a/package/ios/FrameProcessors/VisionCameraProxy.mm
+++ b/package/ios/FrameProcessors/VisionCameraProxy.mm
@@ -14,7 +14,7 @@
 #import "FrameProcessorPluginHostObject.h"
 #import "FrameProcessorPluginRegistry.h"
 #import "JSINSObjectConversion.h"
-#import "VisionCameraProxyHolder.h"
+#import "VisionCameraContext.h"
 #import "WKTJsiWorklet.h"
 
 using namespace facebook;
@@ -65,10 +65,10 @@ jsi::Value VisionCameraProxy::initFrameProcessorPlugin(jsi::Runtime& runtime, co
   std::string nameString = name.utf8(runtime);
   NSString* key = [NSString stringWithUTF8String:nameString.c_str()];
   NSDictionary* optionsObjc = JSINSObjectConversion::convertJSIObjectToObjCDictionary(runtime, options);
-  VisionCameraProxyHolder* proxy = [[VisionCameraProxyHolder alloc] initWithProxy:this];
+  VisionCameraContext* context = [[VisionCameraContext alloc] initWithProxy:this];
 
   @try {
-    FrameProcessorPlugin* plugin = [FrameProcessorPluginRegistry getPlugin:key withProxy:proxy withOptions:optionsObjc];
+    FrameProcessorPlugin* plugin = [FrameProcessorPluginRegistry getPlugin:key withContext:context withOptions:optionsObjc];
     if (plugin == nil) {
       return jsi::Value::undefined();
     }

--- a/package/ios/React/CameraBridge.h
+++ b/package/ios/React/CameraBridge.h
@@ -22,5 +22,5 @@
 #import "SharedArray.h"
 #import "VisionCameraInstaller.h"
 #import "VisionCameraProxyDelegate.h"
-#import "VisionCameraProxyHolder.h"
+#import "VisionCameraContext.h"
 #endif


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

**BREAKING CHANGE**: Renames `VisionCameraProxyHolder` to `VisionCameraContext`.

This is unfortunately a breaking change, but needs to happen because I'm gonna rewrite `VisionCameraProxy` to be a C++ TurboModule soon.

Unfortunately all Frame Processor Plugins will have to change `VisionCameraProxyHolder` to `VisionCameraContext` as well, but no APIs changed.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
