### PR TITLE
feat: Use `setExternalMemoryPressure` to notify JS VM about `Frame`'s actual size (on GPU)

### DIFF
--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -1,8 +1,10 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+$config = find_config()
 
 nodeModules = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
+reactNativeVersion = $config[:react_native_minor_version]
 
 Pod::UI.puts "[VisionCamera] Thank you for using VisionCamera ❤️"
 Pod::UI.puts "[VisionCamera] If you enjoy using VisionCamera, please consider sponsoring this project: https://github.com/sponsors/mrousavy"
@@ -24,6 +26,7 @@ else
 end
 
 Pod::UI.puts("[VisionCamera] node modules #{Dir.exist?(nodeModules) ? "found at #{nodeModules}" : "not found!"}")
+Pod::UI.puts "[VisionCamera] React Native Version: 0.#{reactNativeVersion}"
 workletsPath = File.join(nodeModules, "react-native-worklets-core")
 hasWorklets = File.exist?(workletsPath)
 if hasWorklets
@@ -46,7 +49,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/mrousavy/react-native-vision-camera.git", :tag => "#{s.version}" }
 
   s.pod_target_xcconfig = {
-    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) VISION_CAMERA_ENABLE_FRAME_PROCESSORS=#{enableFrameProcessors}",
+    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) VISION_CAMERA_ENABLE_FRAME_PROCESSORS=#{enableFrameProcessors} REACT_NATIVE_VERSION=#{reactNativeVersion}",
     "SWIFT_ACTIVE_COMPILATION_CONDITIONS" => "$(inherited) #{enableFrameProcessors ? "VISION_CAMERA_ENABLE_FRAME_PROCESSORS" : ""}",
   }
 

--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -4,7 +4,8 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 $config = find_config()
 
 nodeModules = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`), '..')
-reactNativeVersion = $config[:react_native_minor_version]
+reactNativePackage = JSON.parse(File.read(File.join(nodeModules, "react-native", "package.json")))
+reactNativeVersion = reactNativePackage["version"]
 
 Pod::UI.puts "[VisionCamera] Thank you for using VisionCamera ❤️"
 Pod::UI.puts "[VisionCamera] If you enjoy using VisionCamera, please consider sponsoring this project: https://github.com/sponsors/mrousavy"

--- a/package/example/ios/Podfile.lock
+++ b/package/example/ios/Podfile.lock
@@ -1391,16 +1391,16 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.0)
-  - VisionCamera (4.4.3):
-    - VisionCamera/Core (= 4.4.3)
-    - VisionCamera/FrameProcessors (= 4.4.3)
-    - VisionCamera/React (= 4.4.3)
-  - VisionCamera/Core (4.4.3)
-  - VisionCamera/FrameProcessors (4.4.3):
+  - VisionCamera (4.5.0):
+    - VisionCamera/Core (= 4.5.0)
+    - VisionCamera/FrameProcessors (= 4.5.0)
+    - VisionCamera/React (= 4.5.0)
+  - VisionCamera/Core (4.5.0)
+  - VisionCamera/FrameProcessors (4.5.0):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.4.3):
+  - VisionCamera/React (4.5.0):
     - React-Core
     - VisionCamera/FrameProcessors
   - Yoga (0.0.0)
@@ -1688,7 +1688,7 @@ SPEC CHECKSUMS:
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNVectorIcons: 2a2f79274248390b80684ea3c4400bd374a15c90
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  VisionCamera: 7435f20f7ee7756a1e307e986195a97764da5142
+  VisionCamera: dfdaf784ba5010e3351fb724a8aa6c8fc379018e
   Yoga: 2f71ecf38d934aecb366e686278102a51679c308
 
 PODFILE CHECKSUM: 49584be049764895189f1f88ebc9769116621103

--- a/package/ios/FrameProcessors/FrameProcessor.h
+++ b/package/ios/FrameProcessors/FrameProcessor.h
@@ -28,8 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 #ifdef __cplusplus
 - (instancetype _Nonnull)initWithWorklet:(std::shared_ptr<RNWorklet::JsiWorklet>)worklet
                                  context:(std::shared_ptr<RNWorklet::JsiWorkletContext>)context;
-
-- (void)callWithFrameHostObject:(std::shared_ptr<FrameHostObject>)frameHostObject;
 #endif
 
 - (void)call:(Frame*)frame;

--- a/package/ios/FrameProcessors/FrameProcessor.mm
+++ b/package/ios/FrameProcessors/FrameProcessor.mm
@@ -13,6 +13,7 @@
 #import "WKTJsiWorklet.h"
 #import <jsi/jsi.h>
 #import <memory>
+#import "JSINSObjectConversion.h"
 
 using namespace facebook;
 
@@ -30,25 +31,15 @@ using namespace facebook;
   return self;
 }
 
-- (void)callWithFrameHostObject:(std::shared_ptr<FrameHostObject>)frameHostObject {
+- (void)call:(Frame* _Nonnull)frame {
   // Call the Frame Processor on the Worklet Runtime
   jsi::Runtime& runtime = _workletContext->getWorkletRuntime();
 
-  // Use a jsi::Scope to indicate that all values allocated in a Frame Processor shall be picked up by GC if possible
-  jsi::Scope scope(runtime);
-
   // Wrap HostObject as JSI Value
-  auto argument = jsi::Object::createFromHostObject(runtime, frameHostObject);
-  jsi::Value jsValue(std::move(argument));
+  jsi::Value jsValue = JSINSObjectConversion::convertObjCObjectToJSIValue(runtime, frame);
 
   // Call the Worklet with the Frame JS Host Object as an argument
   _workletInvoker->call(runtime, jsi::Value::undefined(), &jsValue, 1);
-}
-
-- (void)call:(Frame* _Nonnull)frame {
-  // Create the Frame Host Object wrapping the internal Frame
-  auto frameHostObject = std::make_shared<FrameHostObject>(frame);
-  [self callWithFrameHostObject:frameHostObject];
 }
 
 @end

--- a/package/ios/FrameProcessors/FrameProcessor.mm
+++ b/package/ios/FrameProcessors/FrameProcessor.mm
@@ -10,10 +10,10 @@
 #import <Foundation/Foundation.h>
 
 #import "FrameHostObject.h"
+#import "JSINSObjectConversion.h"
 #import "WKTJsiWorklet.h"
 #import <jsi/jsi.h>
 #import <memory>
-#import "JSINSObjectConversion.h"
 
 using namespace facebook;
 

--- a/package/ios/FrameProcessors/JSINSObjectConversion.mm
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.mm
@@ -72,7 +72,12 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value) {
 
     Frame* frame = (Frame*)value;
     auto frameHostObject = std::make_shared<FrameHostObject>(frame);
-    return jsi::Object::createFromHostObject(runtime, frameHostObject);
+    jsi::Object object = jsi::Object::createFromHostObject(runtime, frameHostObject);
+#if REACT_NATIVE_VERSION >= 74
+    size_t frameSize = frame.bytesPerRow * frame.height;
+    object.setExternalMemoryPressure(runtime, frameSize);
+#endif
+    return object;
   } else if ([value isKindOfClass:[SharedArray class]]) {
     // SharedArray
 

--- a/package/ios/FrameProcessors/JSINSObjectConversion.mm
+++ b/package/ios/FrameProcessors/JSINSObjectConversion.mm
@@ -29,7 +29,18 @@ using namespace facebook::react;
 namespace JSINSObjectConversion {
 
 jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value) {
-  if (value == nil || value == (id)kCFNull) {
+  if ([value isKindOfClass:[Frame class]]) {
+    // Frame
+
+    Frame* frame = (Frame*)value;
+    auto frameHostObject = std::make_shared<FrameHostObject>(frame);
+    jsi::Object object = jsi::Object::createFromHostObject(runtime, frameHostObject);
+#if REACT_NATIVE_VERSION >= 74
+    size_t frameSize = frame.bytesPerRow * frame.height;
+    object.setExternalMemoryPressure(runtime, frameSize);
+#endif
+    return object;
+  } else if (value == nil || value == (id)kCFNull) {
     // null
 
     return jsi::Value::undefined();
@@ -67,17 +78,6 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime& runtime, id value) {
       result.setValueAtIndex(runtime, i, convertObjCObjectToJSIValue(runtime, value[i]));
     }
     return result;
-  } else if ([value isKindOfClass:[Frame class]]) {
-    // Frame
-
-    Frame* frame = (Frame*)value;
-    auto frameHostObject = std::make_shared<FrameHostObject>(frame);
-    jsi::Object object = jsi::Object::createFromHostObject(runtime, frameHostObject);
-#if REACT_NATIVE_VERSION >= 74
-    size_t frameSize = frame.bytesPerRow * frame.height;
-    object.setExternalMemoryPressure(runtime, frameSize);
-#endif
-    return object;
   } else if ([value isKindOfClass:[SharedArray class]]) {
     // SharedArray
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Uses `setExternalMemoryPressure` to notify the JS VM about the `Frame`'s actual size (the byte buffer on the GPU, which is `bytesPerRow * height`).

If the JS VM (e.g. Hermes) knows the true size of the `Frame` in memory, it will delete old stale `FrameHostObject`s sooner instead of just keeping them floating around in memory because it thinks it's just a few bytes in size. (right now around 400 of those pile up until GC hits, with this PR only 3 pile up at a time)

This doesn't really matter for us since we need to eagerly delete the Frame after the Frame Processor is done, because the Camera pipeline stalls otherwise.

So we still need to keep the manual ref counting stuff. Make sure to use it properly!

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
