### PR TITLE
fix: codeScanner unsupported ios version error handing

### DIFF
--- a/docs/docs/guides/CODE_SCANNING.mdx
+++ b/docs/docs/guides/CODE_SCANNING.mdx
@@ -148,4 +148,23 @@ Interleaved2of5 (ITF) barcodes are supported by both, Android and iOS, where And
 
 ITF-14 is a sub type of interleaved2of5 which always encodes 14 characters. The ITF-14 type is only supported by iOS. If you want to have the restriction to 14 characters in Android as well, you have to handle this in your own code.
 
+## Supported Code Types
+
+| Code Type            | iOS                | Android            |
+|----------------------|--------------------|--------------------|
+| qr                   | :white_check_mark: | :white_check_mark: |
+| aztec                | :white_check_mark: | :white_check_mark: |
+| data-matrix          | :white_check_mark: | :white_check_mark: |
+| ean-13               | :white_check_mark: | :white_check_mark: |
+| ean-8                | :white_check_mark: | :white_check_mark: |
+| code-128             | :white_check_mark: | :white_check_mark: |
+| code-39              | :white_check_mark: | :white_check_mark: |
+| code-93              | :white_check_mark: | :white_check_mark: |
+| codabar              | 15.4+              | :white_check_mark: |
+| itf                  | :white_check_mark: | :white_check_mark: |
+| itf-14               | :white_check_mark: | :white_check_mark: |
+| upc-e                | :white_check_mark: | :white_check_mark: |
+| upc-a                | :white_check_mark: | :white_check_mark: |
+| pdf-417              | :white_check_mark: | :white_check_mark: |
+
 #### 🚀 Next section: [Frame Processors](frame-processors)

--- a/example/src/CodeScannerPage.tsx
+++ b/example/src/CodeScannerPage.tsx
@@ -62,7 +62,7 @@ export function CodeScannerPage({ navigation }: Props): React.ReactElement {
 
   // 5. Initialize the Code Scanner to scan QR codes and Barcodes
   const codeScanner = useCodeScanner({
-    codeTypes: ['qr', 'ean-13'],
+    codeTypes: ['qr', 'ean-13', 'codabar'],
     onCodeScanned: onCodeScanned,
   })
 

--- a/package/ios/Core/Parsers/AVMetadataObject.ObjectType+descriptor.swift
+++ b/package/ios/Core/Parsers/AVMetadataObject.ObjectType+descriptor.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Foundation
 
 extension AVMetadataObject.ObjectType {
-  init(withString string: String) throws {
+  init?(withString string: String) throws {
     switch string {
     case "code-128":
       self = .code128
@@ -25,7 +25,7 @@ extension AVMetadataObject.ObjectType {
       if #available(iOS 15.4, *) {
         self = .codabar
       } else {
-        throw CameraError.codeScanner(.codeTypeNotSupported(codeType: string))
+        return nil
       }
       return
     case "ean-13":

--- a/package/ios/Core/Types/CodeScannerOptions.swift
+++ b/package/ios/Core/Types/CodeScannerOptions.swift
@@ -16,7 +16,7 @@ struct CodeScannerOptions: Equatable {
 
   init(fromJsValue dictionary: NSDictionary) throws {
     if let codeTypes = dictionary["codeTypes"] as? [String] {
-      self.codeTypes = try codeTypes.map { value in
+      self.codeTypes = try codeTypes.compactMap { value in
         return try AVMetadataObject.ObjectType(withString: value)
       }
     } else {


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
Enabling `codabar` format in code scanner is dangerous

Scenario: You set up the code scanner with several formats, including `codabar`. On Android and iOS 15.4 and above, everything works well. However, on iOS 15.3 or below, you get a black screen, and the scanner doesn't work at all.

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

On iOS 15.3 or below, if you enable an unsupported code scanner format (e.g., `codabar`), the scanner works without this format, instead of a black screen.
<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on
- iphone SE (second rev.), iOS 15.0
- iphone X, ios 15.5
<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
