### PR TITLE
Fix bug with getWorkletsLibraryPath

### DIFF
--- a/package/VisionCamera.podspec
+++ b/package/VisionCamera.podspec
@@ -22,12 +22,17 @@ else
 end
 
 def Pod::getWorkletsLibraryPath
-  output = `cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "try { require.resolve('react-native-worklets-core/package.json') } catch(e) { /* returning undefined, if package not found */ }"`
+  installation_root = Pod::Config.instance.installation_root.to_s
+  command = "cd \"#{installation_root}\" && node --print \"try { console.log(require.resolve('react-native-worklets-core/package.json')) } catch(e) { console.log('PACKAGE_NOT_FOUND') }\""
   
-  if output.strip == "undefined"
+  output = `#{command}`
+  lines = output.split("\n").map(&:strip)
+  
+  if lines.include?('PACKAGE_NOT_FOUND')
     return nil
   else
-    return File.dirname(output)
+    package_line = lines.find { |line| line.include?('react-native-worklets-core/package.json') }
+    return package_line ? File.dirname(package_line) : nil
   end
 end
 


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR improves the Ruby check for searching for getWorkletsLibraryPath

## Changes
This accounts for outputs that sometimes have multiple lines.  It explicitly includes fail text to search for.

## Tested on
`pod install` on MacBook Pro M3

## Related issues
Fixes: https://github.com/mrousavy/react-native-vision-camera/issues/3187
