### PR TITLE
feat: Add `depth` to `Frame`

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1768,16 +1768,16 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.0)
-  - VisionCamera (4.6.1):
-    - VisionCamera/Core (= 4.6.1)
-    - VisionCamera/FrameProcessors (= 4.6.1)
-    - VisionCamera/React (= 4.6.1)
-  - VisionCamera/Core (4.6.1)
-  - VisionCamera/FrameProcessors (4.6.1):
+  - VisionCamera (4.6.3):
+    - VisionCamera/Core (= 4.6.3)
+    - VisionCamera/FrameProcessors (= 4.6.3)
+    - VisionCamera/React (= 4.6.3)
+  - VisionCamera/Core (4.6.3)
+  - VisionCamera/FrameProcessors (4.6.3):
     - React
     - React-callinvoker
     - react-native-worklets-core
-  - VisionCamera/React (4.6.1):
+  - VisionCamera/React (4.6.3):
     - React-Core
     - VisionCamera/FrameProcessors
   - Yoga (0.0.0)
@@ -2097,9 +2097,9 @@ SPEC CHECKSUMS:
   RNStaticSafeAreaInsets: 055ddbf5e476321720457cdaeec0ff2ba40ec1b8
   RNVectorIcons: 6382277afab3c54658e9d555ee0faa7a37827136
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  VisionCamera: ec141897a88c2e95e8b83cf97b8e4db801e02fd6
-  Yoga: 055f92ad73f8c8600a93f0e25ac0b2344c3b07e6
+  VisionCamera: 88df4dae7196c93ecd331f105f0e5d7d95702cb3
+  Yoga: aa3df615739504eebb91925fc9c58b4922ea9a08
 
 PODFILE CHECKSUM: 2ad84241179871ca890f7c65c855d117862f1a68
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraDeviceDetails.kt
@@ -103,6 +103,7 @@ class CameraDeviceDetails(private val cameraInfo: CameraInfo, extensionsManager:
     map.putString("hardwareLevel", hardwareLevel.unionValue)
     map.putString("sensorOrientation", sensorOrientation.unionValue)
     map.putArray("formats", formats)
+    map.putBoolean("supportsDepthData", false)
     return map
   }
 

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -182,6 +182,7 @@ final class CameraConfiguration {
     var enableBufferCompression = false
     var enableHdr = false
     var enableFrameProcessor = false
+    var enableDepth = false
   }
 
   /**

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -110,7 +110,6 @@ extension CameraSession {
       captureSession.addOutput(videoOutput)
 
       // 2. Configure Video
-      videoOutput.alwaysDiscardsLateVideoFrames = true
       if configuration.isMirrored {
         // 2.1. If mirroring is enabled, mirror all connections along the vertical axis
         videoOutput.isMirrored = true
@@ -126,6 +125,9 @@ extension CameraSession {
         // Video is synchronized with depth data - use a joined delegate!
         // 3.1. Create depth output
         let depthOutput = AVCaptureDepthDataOutput()
+        depthOutput.orientation = videoOutput.orientation
+        videoOutput.alwaysDiscardsLateVideoFrames = false
+        depthOutput.alwaysDiscardsLateDepthData = false
         depthOutput.isFilteringEnabled = false
         // 3.2. Add depth output to session
         captureSession.addOutput(depthOutput)
@@ -135,6 +137,7 @@ extension CameraSession {
         self.depthOutput = depthOutput
       } else {
         // Video is the only output - use it's own delegate
+        videoOutput.alwaysDiscardsLateVideoFrames = true
         videoOutput.setSampleBufferDelegate(self, queue: CameraQueues.videoQueue)
       }
 

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -125,12 +125,12 @@ extension CameraSession {
         // Video is synchronized with depth data - use a joined delegate!
         // 3.1. Create depth output
         let depthOutput = AVCaptureDepthDataOutput()
-        depthOutput.orientation = videoOutput.orientation
         videoOutput.alwaysDiscardsLateVideoFrames = false
         depthOutput.alwaysDiscardsLateDepthData = false
         depthOutput.isFilteringEnabled = false
         // 3.2. Add depth output to session
         captureSession.addOutput(depthOutput)
+        depthOutput.orientation = videoOutput.orientation
         // 3.3. Set up a synchronizer between video and depth data
         outputSynchronizer = AVCaptureDataOutputSynchronizer(dataOutputs: [depthOutput, videoOutput])
         outputSynchronizer!.setDelegate(self, queue: CameraQueues.videoQueue)

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -126,7 +126,6 @@ extension CameraSession {
         // Video is synchronized with depth data - use a joined delegate!
         // 3.1. Create depth output
         let depthOutput = AVCaptureDepthDataOutput()
-        depthOutput.alwaysDiscardsLateDepthData = true
         depthOutput.isFilteringEnabled = false
         // 3.2. Add depth output to session
         captureSession.addOutput(depthOutput)

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -128,11 +128,11 @@ extension CameraSession {
         let depthOutput = AVCaptureDepthDataOutput()
         depthOutput.alwaysDiscardsLateDepthData = true
         depthOutput.isFilteringEnabled = false
-        // 3.2. Set up a synchronizer between video and depth data
+        // 3.2. Add depth output to session
+        captureSession.addOutput(depthOutput)
+        // 3.3. Set up a synchronizer between video and depth data
         outputSynchronizer = AVCaptureDataOutputSynchronizer(dataOutputs: [depthOutput, videoOutput])
         outputSynchronizer!.setDelegate(self, queue: CameraQueues.videoQueue)
-        // 3.3. Add depth output to session
-        captureSession.addOutput(depthOutput)
         self.depthOutput = depthOutput
       } else {
         // Video is the only output - use it's own delegate

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -120,7 +120,7 @@ extension CameraSession {
           VisionLogger.log(level: .info, message: "AVCaptureVideoDataOutput will rotate Frames to \(videoOutput.orientation)...")
         }
       }
-      
+
       // 3. Configure Depth
       if video.enableDepth {
         // Video is synchronized with depth data - use a joined delegate!

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -13,7 +13,11 @@ import Foundation
  A fully-featured Camera Session supporting preview, video, photo, frame processing, and code scanning outputs.
  All changes to the session have to be controlled via the `configure` function.
  */
-final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate, AVCaptureDataOutputSynchronizerDelegate {
+final class CameraSession:
+  NSObject,
+  AVCaptureVideoDataOutputSampleBufferDelegate,
+  AVCaptureAudioDataOutputSampleBufferDelegate,
+  AVCaptureDataOutputSynchronizerDelegate {
   // Configuration
   private var isInitialized = false
   var configuration: CameraConfiguration?
@@ -277,11 +281,11 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
       break
     }
   }
-  
-  func dataOutputSynchronizer(_ synchronizer: AVCaptureDataOutputSynchronizer, didOutput synchronizedDataCollection: AVCaptureSynchronizedDataCollection) {
+
+  func dataOutputSynchronizer(_: AVCaptureDataOutputSynchronizer, didOutput synchronizedDataCollection: AVCaptureSynchronizedDataCollection) {
     guard let videoOutput else { return }
     guard let videoData = synchronizedDataCollection.synchronizedData(for: videoOutput) as? AVCaptureSynchronizedSampleBufferData else { return }
-    
+
     if let depthOutput {
       // We have depth data as well
       guard let depthData = synchronizedDataCollection.synchronizedData(for: videoOutput) as? AVCaptureSynchronizedSampleBufferData else { return }

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -288,18 +288,18 @@ final class CameraSession:
 
     if let depthOutput {
       // We have depth data as well
-      guard let depthData = synchronizedDataCollection.synchronizedData(for: videoOutput) as? AVCaptureSynchronizedSampleBufferData else { return }
+      guard let depthData = synchronizedDataCollection.synchronizedData(for: depthOutput) as? AVCaptureSynchronizedDepthData else { return }
       onVideoFrame(sampleBuffer: videoData.sampleBuffer,
                    orientation: videoOutput.orientation,
                    isMirrored: videoOutput.isMirrored,
-                   depthData: depthData.sampleBuffer)
+                   depthData: depthData.depthData)
     } else {
       // We only have video data
       onVideoFrame(sampleBuffer: videoData.sampleBuffer, orientation: videoOutput.orientation, isMirrored: videoOutput.isMirrored)
     }
   }
 
-  private final func onVideoFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthData: CMSampleBuffer? = nil) {
+  private final func onVideoFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthData: AVDepthData? = nil) {
     if let recordingSession {
       do {
         // Write the Video Buffer to the .mov/.mp4 file
@@ -316,7 +316,7 @@ final class CameraSession:
       delegate.onFrame(sampleBuffer: sampleBuffer,
                        orientation: orientation,
                        isMirrored: isMirrored,
-                       depthBuffer: depthData)
+                       depthData: depthData)
     }
   }
 

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -13,7 +13,7 @@ import Foundation
  A fully-featured Camera Session supporting preview, video, photo, frame processing, and code scanning outputs.
  All changes to the session have to be controlled via the `configure` function.
  */
-final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate {
+final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAudioDataOutputSampleBufferDelegate, AVCaptureDataOutputSynchronizerDelegate {
   // Configuration
   private var isInitialized = false
   var configuration: CameraConfiguration?
@@ -27,7 +27,9 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
   var photoOutput: AVCapturePhotoOutput?
   var videoOutput: AVCaptureVideoDataOutput?
   var audioOutput: AVCaptureAudioDataOutput?
+  var depthOutput: AVCaptureDepthDataOutput?
   var codeScannerOutput: AVCaptureMetadataOutput?
+  var outputSynchronizer: AVCaptureDataOutputSynchronizer?
   // State
   var metadataProvider = MetadataProvider()
   var recordingSession: RecordingSession?
@@ -273,6 +275,12 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
       onAudioFrame(sampleBuffer: sampleBuffer)
     default:
       break
+    }
+  }
+  
+  func dataOutputSynchronizer(_ synchronizer: AVCaptureDataOutputSynchronizer, didOutput synchronizedDataCollection: AVCaptureSynchronizedDataCollection) {
+    for frame in synchronizedDataCollection {
+      // TODO: Cast to CMSampleBuffer!
     }
   }
 

--- a/package/ios/Core/CameraSessionDelegate.swift
+++ b/package/ios/Core/CameraSessionDelegate.swift
@@ -44,7 +44,7 @@ protocol CameraSessionDelegate: AnyObject {
   /**
    Called for every frame (if video or frameProcessor is enabled)
    */
-  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool)
+  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthBuffer: CMSampleBuffer?)
   /**
    Called whenever a QR/Barcode has been scanned. Only if the CodeScanner Output is enabled
    */

--- a/package/ios/Core/CameraSessionDelegate.swift
+++ b/package/ios/Core/CameraSessionDelegate.swift
@@ -44,7 +44,7 @@ protocol CameraSessionDelegate: AnyObject {
   /**
    Called for every frame (if video or frameProcessor is enabled)
    */
-  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthBuffer: CMSampleBuffer?)
+  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthData: AVDepthData?)
   /**
    Called whenever a QR/Barcode has been scanned. Only if the CodeScanner Output is enabled
    */

--- a/package/ios/Core/Extensions/AVCaptureDevice+toDictionary.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+toDictionary.swift
@@ -32,7 +32,7 @@ extension AVCaptureDevice {
       "hardwareLevel": HardwareLevel.full.jsValue,
       "sensorOrientation": sensorOrientation.jsValue,
       "formats": formats.map { $0.toJSValue() },
-      "supportsDepthData": self.hasMediaType(.depthData)
+      "supportsDepthData": hasMediaType(.depthData),
     ]
   }
 }

--- a/package/ios/Core/Extensions/AVCaptureDevice+toDictionary.swift
+++ b/package/ios/Core/Extensions/AVCaptureDevice+toDictionary.swift
@@ -32,6 +32,7 @@ extension AVCaptureDevice {
       "hardwareLevel": HardwareLevel.full.jsValue,
       "sensorOrientation": sensorOrientation.jsValue,
       "formats": formats.map { $0.toJSValue() },
+      "supportsDepthData": self.hasMediaType(.depthData)
     ]
   }
 }

--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -11,6 +11,7 @@
 #import <CoreMedia/CMSampleBuffer.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIImage.h>
+#import <AVFoundation/AVDepthData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,14 +20,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithBuffer:(CMSampleBufferRef)buffer
                    orientation:(UIImageOrientation)orientation
                     isMirrored:(BOOL)isMirrored
-                     depthData:(nullable CMSampleBufferRef)depth;
+                     depthData:(nullable AVDepthData*)depth;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (void)incrementRefCount;
 - (void)decrementRefCount;
 
 @property(nonatomic, readonly) CMSampleBufferRef buffer;
-@property(nonatomic, readonly, nullable) CMSampleBufferRef depth;
+@property(nonatomic, readonly, nullable) AVDepthData* depth;
 @property(nonatomic, readonly) UIImageOrientation orientation;
 
 @property(nonatomic, readonly) NSString* pixelFormat;

--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -16,13 +16,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Frame : NSObject
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored;
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored depthData:(nullable CMSampleBufferRef)depth;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (void)incrementRefCount;
 - (void)decrementRefCount;
 
 @property(nonatomic, readonly) CMSampleBufferRef buffer;
+@property(nonatomic, readonly, nullable) CMSampleBufferRef depth;
 @property(nonatomic, readonly) UIImageOrientation orientation;
 
 @property(nonatomic, readonly) NSString* pixelFormat;

--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
+#import <AVFoundation/AVDepthData.h>
 #import <CoreMedia/CMSampleBuffer.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIImage.h>
-#import <AVFoundation/AVDepthData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/package/ios/FrameProcessors/Frame.h
+++ b/package/ios/FrameProcessors/Frame.h
@@ -16,7 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Frame : NSObject
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored depthData:(nullable CMSampleBufferRef)depth;
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer
+                   orientation:(UIImageOrientation)orientation
+                    isMirrored:(BOOL)isMirrored
+                     depthData:(nullable CMSampleBufferRef)depth;
 - (instancetype)init NS_UNAVAILABLE;
 
 - (void)incrementRefCount;

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -33,10 +33,16 @@
 
 - (void)incrementRefCount {
   CFRetain(_buffer);
+  if (_depth) {
+    CFRetain(_depth);
+  }
 }
 
 - (void)decrementRefCount {
   CFRelease(_buffer);
+  if (_depth) {
+    CFRelease(_depth);
+  }
 }
 
 - (CMSampleBufferRef)buffer {

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -14,13 +14,13 @@
   CMSampleBufferRef _Nonnull _buffer;
   UIImageOrientation _orientation;
   BOOL _isMirrored;
-  CMSampleBufferRef _Nullable _depth;
+  AVDepthData* _Nullable _depth;
 }
 
 - (instancetype)initWithBuffer:(CMSampleBufferRef)buffer
                    orientation:(UIImageOrientation)orientation
                     isMirrored:(BOOL)isMirrored
-                     depthData:(nullable CMSampleBufferRef)depth {
+                     depthData:(nullable AVDepthData*)depth {
   self = [super init];
   if (self) {
     _buffer = buffer;
@@ -52,7 +52,7 @@
   return _buffer;
 }
 
-- (nullable CMSampleBufferRef)depth {
+- (nullable AVDepthData*)depth {
   return _depth;
 }
 

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -17,7 +17,10 @@
   CMSampleBufferRef _Nullable _depth;
 }
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored depthData:(nullable CMSampleBufferRef)depth {
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer
+                   orientation:(UIImageOrientation)orientation
+                    isMirrored:(BOOL)isMirrored
+                     depthData:(nullable CMSampleBufferRef)depth {
   self = [super init];
   if (self) {
     _buffer = buffer;

--- a/package/ios/FrameProcessors/Frame.m
+++ b/package/ios/FrameProcessors/Frame.m
@@ -14,14 +14,16 @@
   CMSampleBufferRef _Nonnull _buffer;
   UIImageOrientation _orientation;
   BOOL _isMirrored;
+  CMSampleBufferRef _Nullable _depth;
 }
 
-- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored {
+- (instancetype)initWithBuffer:(CMSampleBufferRef)buffer orientation:(UIImageOrientation)orientation isMirrored:(BOOL)isMirrored depthData:(nullable CMSampleBufferRef)depth {
   self = [super init];
   if (self) {
     _buffer = buffer;
     _orientation = orientation;
     _isMirrored = isMirrored;
+    _depth = depth;
   }
   return self;
 }
@@ -45,6 +47,10 @@
                                     userInfo:nil];
   }
   return _buffer;
+}
+
+- (nullable CMSampleBufferRef)depth {
+  return _depth;
 }
 
 - (BOOL)isValid {

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -79,9 +79,9 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
       return jsi::Value::undefined();
     }
     jsi::Object object(runtime);
-    CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_frame.depth);
-    object.setProperty(runtime, "width", jsi::Value(static_cast<double>(CVPixelBufferGetWidth(imageBuffer))));
-    object.setProperty(runtime, "height", jsi::Value(static_cast<double>(CVPixelBufferGetHeight(imageBuffer))));
+    CVPixelBufferRef depthMap = _frame.depth.depthDataMap;
+    object.setProperty(runtime, "width", jsi::Value(static_cast<double>(CVPixelBufferGetWidth(depthMap))));
+    object.setProperty(runtime, "height", jsi::Value(static_cast<double>(CVPixelBufferGetHeight(depthMap))));
     return object;
   }
 

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -74,6 +74,16 @@ jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& pr
   if (name == "planesCount") {
     return jsi::Value((double)_frame.planesCount);
   }
+  if (name == "depth") {
+    if (_frame.depth == nil) {
+      return jsi::Value::undefined();
+    }
+    jsi::Object object(runtime);
+    CVPixelBufferRef imageBuffer = CMSampleBufferGetImageBuffer(_frame.depth);
+    object.setProperty(runtime, "width", jsi::Value(static_cast<double>(CVPixelBufferGetWidth(imageBuffer))));
+    object.setProperty(runtime, "height", jsi::Value(static_cast<double>(CVPixelBufferGetHeight(imageBuffer))));
+    return object;
+  }
 
   // Internal methods
   if (name == "incrementRefCount") {

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -211,7 +211,8 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
         config.video = .enabled(config: CameraConfiguration.Video(pixelFormat: getPixelFormat(),
                                                                   enableBufferCompression: enableBufferCompression,
                                                                   enableHdr: videoHdr,
-                                                                  enableFrameProcessor: enableFrameProcessor))
+                                                                  enableFrameProcessor: enableFrameProcessor,
+                                                                  enableDepth: enableDepthData))
       } else {
         config.video = .disabled
       }

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -363,7 +363,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
     ])
   }
 
-  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthBuffer: CMSampleBuffer?) {
+  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthData: AVDepthData?) {
     // Update latest frame that can be used for snapshot capture
     latestVideoFrame = Snapshot(imageBuffer: sampleBuffer, orientation: orientation)
 
@@ -376,7 +376,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
         let frame = Frame(buffer: sampleBuffer,
                           orientation: orientation.imageOrientation,
                           isMirrored: isMirrored,
-                          depthData: depthBuffer)
+                          depthData: depthData)
         frameProcessor.call(frame)
       }
     #endif

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -363,7 +363,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
     ])
   }
 
-  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool) {
+  func onFrame(sampleBuffer: CMSampleBuffer, orientation: Orientation, isMirrored: Bool, depthBuffer: CMSampleBuffer?) {
     // Update latest frame that can be used for snapshot capture
     latestVideoFrame = Snapshot(imageBuffer: sampleBuffer, orientation: orientation)
 

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -375,7 +375,8 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
         // Call Frame Processor
         let frame = Frame(buffer: sampleBuffer,
                           orientation: orientation.imageOrientation,
-                          isMirrored: isMirrored)
+                          isMirrored: isMirrored,
+                          depthData: depthBuffer)
         frameProcessor.call(frame)
       }
     #endif

--- a/package/src/devices/getCameraFormat.ts
+++ b/package/src/devices/getCameraFormat.ts
@@ -74,6 +74,10 @@ export interface FormatFilter {
    * you might want to choose a different auto-focus system.
    */
   autoFocusSystem?: AutoFocusSystem
+  /**
+   * Specifies whether to prefer formats that support depth data capture.
+   */
+  depth?: boolean
 }
 
 type FilterWithPriority<T> = {
@@ -234,6 +238,12 @@ export function getCameraFormat(device: CameraDevice, filters: FormatFilter[]): 
     if (filter.autoFocusSystem != null) {
       if (bestFormat.autoFocusSystem === filter.autoFocusSystem.target) leftPoints += filter.autoFocusSystem.priority
       if (format.autoFocusSystem === filter.autoFocusSystem.target) rightPoints += filter.autoFocusSystem.priority
+    }
+
+    // Find depth data
+    if (filter.depth != null) {
+      if (bestFormat.supportsDepthCapture) leftPoints += filter.depth.priority
+      if (format.supportsDepthCapture) rightPoints += filter.depth.priority
     }
 
     if (rightPoints > leftPoints) bestFormat = format

--- a/package/src/devices/getCameraFormat.ts
+++ b/package/src/devices/getCameraFormat.ts
@@ -242,8 +242,8 @@ export function getCameraFormat(device: CameraDevice, filters: FormatFilter[]): 
 
     // Find depth data
     if (filter.depth != null) {
-      if (bestFormat.supportsDepthCapture) leftPoints += filter.depth.priority
-      if (format.supportsDepthCapture) rightPoints += filter.depth.priority
+      if (bestFormat.supportsDepthCapture === filter.depth.target) leftPoints += filter.depth.priority
+      if (format.supportsDepthCapture === filter.depth.target) rightPoints += filter.depth.priority
     }
 
     if (rightPoints > leftPoints) bestFormat = format

--- a/package/src/types/CameraDevice.ts
+++ b/package/src/types/CameraDevice.ts
@@ -216,6 +216,10 @@ export interface CameraDevice {
    */
   supportsFocus: boolean
   /**
+   * Specifies whether this devices supports depth data output streaming.
+   */
+  supportsDepthData: boolean
+  /**
    * The hardware level of the Camera.
    * - On Android, some older devices are running at a `legacy` or `limited` level which means they are running in a backwards compatible mode.
    * - On iOS, all devices are `full`.

--- a/package/src/types/Frame.ts
+++ b/package/src/types/Frame.ts
@@ -70,7 +70,6 @@ export interface Frame {
   readonly depth?: {
     readonly width: number
     readonly height: number
-    toArrayBuffer(): ArrayBuffer
   }
 
   /**

--- a/package/src/types/Frame.ts
+++ b/package/src/types/Frame.ts
@@ -65,6 +65,15 @@ export interface Frame {
   readonly pixelFormat: PixelFormat
 
   /**
+   * Represents the depth data of this Frame, if the Camera is configured to stream depth data.
+   */
+  readonly depth?: {
+    readonly width: number
+    readonly height: number
+    toArrayBuffer(): ArrayBuffer
+  }
+
+  /**
    * Get the underlying data of the Frame as a uint8 array buffer.
    *
    * The format of the buffer depends on the Frame's {@linkcode pixelFormat}.


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

TL;DR: Adds `Frame.depth`, a nullable `CMSampleBuffer` that holds depth data.

If `enableDepthData` is true (a prop passed to `<Camera>`), the Camera will be configured to set up a depth data output pipeline in addition to the video data output pipeline.
Ontop of that, a synchronizer output is created to sync depth data and video data buffers together for timestamps.

```tsx
const device = Camera.getAvailableCameraDevices().find((d) => d.formats.some((f) => f.supportsDepthCapture))
const format = useCameraFormat(device, [{ depth: true }])

const fp = useFrameProcessor((frame) => {
  'worklet'
  console.log(frame.depth)
})

if (device == null) throw new Error(`Device does not support depth data!`)
return (
  <Camera
    device={device}
    format={format}
    enableDepthData={true}
    video={true}
    frameProcessor={fp}
  />
)
```

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
