### PR TITLE
Fix Android build error on RN 0.77

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -90,7 +90,7 @@ class CameraSession(internal val context: Context, internal val callback: Callba
     }
   }
 
-  override fun getLifecycle(): Lifecycle = lifecycleRegistry
+  override val lifecycle: Lifecycle get() = lifecycleRegistry
 
   /**
    * Configures the [CameraSession] with new values in one batch.


### PR DESCRIPTION
## What

Fixes the following kotlin build errors on Android with React Native 0.77.

CameraSession.kt:34:1 Class 'CameraSession' is not abstract and does not implement abstract member 'lifecycle'.
CameraSession.kt:93:3 'getLifecycle' overrides nothing.

## Changes

* androidx.lifecycle LifecycleOwner interface has changed, CameraSession has been updated accordingly. See https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.0

## Tested on

-

## Related issues

-
