### PR TITLE
feat: Add the option to enable idle timer on iOS

### DIFF
--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -50,6 +50,8 @@ final class CameraConfiguration {
   // isActive (Start/Stop)
   var isActive = false
 
+  var enableIdleTimer = false
+
   // Audio Session
   var audio: OutputConfiguration<Audio> = .disabled
 
@@ -72,6 +74,7 @@ final class CameraConfiguration {
       zoom = other.zoom
       exposure = other.exposure
       isActive = other.isActive
+      enableIdleTimer = other.enableIdleTimer
       audio = other.audio
     } else {
       // self will just be initialized with the default values.

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -58,6 +58,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
 
   // other props
   @objc var isActive = false
+  @objc var enableIdleTimer = false
   @objc var torch = "off"
   @objc var zoom: NSNumber = 1.0 // in "factor"
   @objc var exposure: NSNumber = 0.0
@@ -280,7 +281,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
     }
 
     // Prevent phone from going to sleep
-    UIApplication.shared.isIdleTimerDisabled = isActive
+    UIApplication.shared.isIdleTimerDisabled = isActive && !enableIdleTimer
   }
 
   func updatePreview() {

--- a/package/ios/React/CameraViewManager.m
+++ b/package/ios/React/CameraViewManager.m
@@ -25,6 +25,7 @@ RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(installFrameProcessorBindings);
 
 // Camera View Properties
 RCT_EXPORT_VIEW_PROPERTY(isActive, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(enableIdleTimer, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(cameraId, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enableDepthData, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(enablePortraitEffectsMatteDelivery, BOOL);

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -276,6 +276,15 @@ export interface CameraProps extends ViewProps {
   //#endregion
 
   /**
+   * Enables or disables the idle timer, allowing the phone to go to sleep according to the system settings.
+   *
+   * @platform iOS
+   *
+   * @default false
+   */
+  enableIdleTimer?: boolean
+
+  /**
    * Enables or disables depth data delivery for photo capture.
    *
    * Make sure the given {@linkcode format} supports depth data (see {@linkcode CameraDeviceFormat.supportsDepthCapture format.supportsDepthCapture}).


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
Added support for enabling the idle timer while the camera is active on iOS. Use case is I am using this for barcode scanning and I want the phone to go to sleep if the user prefers it, in case they leave their phone on and leave it alone. On android it seems like the phone does go to sleep when left alone so I have left it as is.

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->
Added `enableIdleTimer` prop (defaults to false) and implemented it for iOS. 

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->
* iPhone 15 Pro Max, iOS 18.3

Tested both with enableIdleTimer set to true as well as false to see if everything works as expected.

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
