### PR TITLE
Feature | Support onBytesWrittenVideo to receive bytes on JS while recording Video

### DIFF
--- a/docs/docs/guides/RECORDING_VIDEOS.mdx
+++ b/docs/docs/guides/RECORDING_VIDEOS.mdx
@@ -42,6 +42,7 @@ To start a video recording you first have to enable video capture:
   {...props}
   video={true}
   audio={true} // <-- optional
+  onBytesWrittenVideo={(bytes) => {/*Whatever you need with bytes in realtime while it is recording*/}} // <-- optional
 />
 ```
 

--- a/example/src/CameraPage.tsx
+++ b/example/src/CameraPage.tsx
@@ -205,6 +205,7 @@ export function CameraPage({ navigation }: Props): React.ReactElement {
                 ref={camera}
                 onInitialized={onInitialized}
                 onError={onError}
+                onBytesWrittenVideo={(bytes) => console.log(`Bytes written: ${bytes / 1024 / 1024} MB!`)}
                 onStarted={() => console.log('Camera started!')}
                 onStopped={() => console.log('Camera stopped!')}
                 onPreviewStarted={() => console.log('Preview started!')}

--- a/package/android/src/main/cpp/frameprocessors/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessors/FrameHostObject.cpp
@@ -55,7 +55,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   return result;
 }
 
-#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value
+#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count)->jsi::Value
 
 jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
   auto name = propName.utf8(runtime);

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Video.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Video.kt
@@ -17,7 +17,8 @@ fun CameraSession.startRecording(
   enableAudio: Boolean,
   options: RecordVideoOptions,
   callback: (video: Video) -> Unit,
-  onError: (error: CameraError) -> Unit
+  onError: (error: CameraError) -> Unit,
+  onBytesWrittenCallback: (bytes: Long) -> Unit
 ) {
   if (camera == null) throw CameraNotReadyError()
   if (recording != null) throw RecordingInProgressError()
@@ -49,7 +50,10 @@ fun CameraSession.startRecording(
 
       is VideoRecordEvent.Pause -> Log.i(CameraSession.TAG, "Recording paused!")
 
-      is VideoRecordEvent.Status -> Log.i(CameraSession.TAG, "Status update! Recorded ${event.recordingStats.numBytesRecorded} bytes.")
+      is VideoRecordEvent.Status -> {
+        Log.i(CameraSession.TAG, "Status update! Recorded ${event.recordingStats.numBytesRecorded} bytes.")
+        onBytesWrittenCallback(event.recordingStats.numBytesRecorded)
+      }
 
       is VideoRecordEvent.Finalize -> {
         if (isRecordingCanceled) {

--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession.kt
@@ -221,5 +221,6 @@ class CameraSession(internal val context: Context, internal val callback: Callba
     fun onOutputOrientationChanged(outputOrientation: Orientation)
     fun onPreviewOrientationChanged(previewOrientation: Orientation)
     fun onCodeScanned(codes: List<Barcode>, scannerFrame: CodeScannerFrame)
+    fun onBytesWrittenVideo(bytesWritten: Double)
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Events.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+Events.kt
@@ -125,6 +125,17 @@ fun CameraView.invokeOnAverageFpsChanged(averageFps: Double) {
   this.sendEvent(event)
 }
 
+fun CameraView.invokeOnBytesWrittenVideo(bytesWritten: Double) {
+  Log.i(CameraView.TAG, "invokeOnBytesWrittenVideo($bytesWritten)")
+
+  val surfaceId = UIManagerHelper.getSurfaceId(this)
+  val data = Arguments.createMap()
+  data.putDouble("bytesWritten", bytesWritten)
+
+  val event = BytesWrittenVideoEvent(surfaceId, id, data)
+  this.sendEvent(event)
+}
+
 fun CameraView.invokeOnCodeScanned(barcodes: List<Barcode>, scannerFrame: CodeScannerFrame) {
   val codes = Arguments.createArray()
   barcodes.forEach { barcode ->

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
@@ -17,7 +17,11 @@ import com.mrousavy.camera.core.types.Video
 import com.mrousavy.camera.react.utils.makeErrorMap
 
 fun CameraView.startRecording(options: RecordVideoOptions, onRecordCallback: Callback) {
-  // check audio permission
+  val onBytesWrittenCallback = { bytes: Long ->
+    val map = Arguments.createMap()
+    map.putDouble("bytes", bytes.toDouble())
+    sendEvent("onBytesWritten", map)
+  }
   if (audio) {
     if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
       throw MicrophonePermissionError()
@@ -36,7 +40,7 @@ fun CameraView.startRecording(options: RecordVideoOptions, onRecordCallback: Cal
     val errorMap = makeErrorMap(error.code, error.message)
     onRecordCallback(null, errorMap)
   }
-  cameraSession.startRecording(audio, options, callback, onError)
+  cameraSession.startRecording(audio, options, callback, onError, onBytesWrittenCallback)
 }
 
 fun CameraView.pauseRecording() {

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView+RecordVideo.kt
@@ -18,9 +18,7 @@ import com.mrousavy.camera.react.utils.makeErrorMap
 
 fun CameraView.startRecording(options: RecordVideoOptions, onRecordCallback: Callback) {
   val onBytesWrittenCallback = { bytes: Long ->
-    val map = Arguments.createMap()
-    map.putDouble("bytes", bytes.toDouble())
-    sendEvent("onBytesWritten", map)
+    this.onBytesWrittenVideo(bytes.toDouble())
   }
   if (audio) {
     if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
@@ -7,9 +7,6 @@ import android.view.Gravity
 import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
 import androidx.camera.view.PreviewView
-import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.WritableMap
-import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.mrousavy.camera.core.CameraConfiguration
 import com.mrousavy.camera.core.CameraSession
@@ -80,6 +77,7 @@ class CameraView(context: Context) :
   var photoHdr = false
   var videoBitRateOverride: Double? = null
   var videoBitRateMultiplier: Double? = null
+
   // TODO: Use .BALANCED once CameraX fixes it https://issuetracker.google.com/issues/337214687
   var photoQualityBalance = QualityBalance.SPEED
   var lowLightBoost = false

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
@@ -80,7 +80,6 @@ class CameraView(context: Context) :
   var photoHdr = false
   var videoBitRateOverride: Double? = null
   var videoBitRateMultiplier: Double? = null
-  private var reactContext: ReactApplicationContext? = null
   // TODO: Use .BALANCED once CameraX fixes it https://issuetracker.google.com/issues/337214687
   var photoQualityBalance = QualityBalance.SPEED
   var lowLightBoost = false
@@ -128,10 +127,6 @@ class CameraView(context: Context) :
     updatePreview()
   }
 
-  fun setReactContext(reactContext: ReactApplicationContext) {
-    this.reactContext = reactContext
-  }
-
   override fun onAttachedToWindow() {
     Log.i(TAG, "CameraView attached to window!")
     super.onAttachedToWindow()
@@ -153,10 +148,6 @@ class CameraView(context: Context) :
 
   fun destroy() {
     cameraSession.close()
-  }
-
-  fun sendEvent(eventName: String, params: WritableMap?) {
-    reactContext?.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)?.emit(eventName, params)
   }
 
   fun update() {
@@ -360,5 +351,9 @@ class CameraView(context: Context) :
 
   override fun onAverageFpsChanged(averageFps: Double) {
     invokeOnAverageFpsChanged(averageFps)
+  }
+
+  override fun onBytesWrittenVideo(bytesWritten: Double) {
+    invokeOnBytesWrittenVideo(bytesWritten)
   }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraView.kt
@@ -7,6 +7,9 @@ import android.view.Gravity
 import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
 import androidx.camera.view.PreviewView
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.mrousavy.camera.core.CameraConfiguration
 import com.mrousavy.camera.core.CameraSession
@@ -77,7 +80,7 @@ class CameraView(context: Context) :
   var photoHdr = false
   var videoBitRateOverride: Double? = null
   var videoBitRateMultiplier: Double? = null
-
+  private var reactContext: ReactApplicationContext? = null
   // TODO: Use .BALANCED once CameraX fixes it https://issuetracker.google.com/issues/337214687
   var photoQualityBalance = QualityBalance.SPEED
   var lowLightBoost = false
@@ -125,6 +128,10 @@ class CameraView(context: Context) :
     updatePreview()
   }
 
+  fun setReactContext(reactContext: ReactApplicationContext) {
+    this.reactContext = reactContext
+  }
+
   override fun onAttachedToWindow() {
     Log.i(TAG, "CameraView attached to window!")
     super.onAttachedToWindow()
@@ -146,6 +153,10 @@ class CameraView(context: Context) :
 
   fun destroy() {
     cameraSession.close()
+  }
+
+  fun sendEvent(eventName: String, params: WritableMap?) {
+    reactContext?.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)?.emit(eventName, params)
   }
 
   fun update() {

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraViewManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraViewManager.kt
@@ -41,6 +41,7 @@ class CameraViewManager : ViewGroupManager<CameraView>() {
       .put(CameraOutputOrientationChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onOutputOrientationChanged"))
       .put(CameraPreviewOrientationChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onPreviewOrientationChanged"))
       .put(AverageFpsChangedEvent.EVENT_NAME, MapBuilder.of("registrationName", "onAverageFpsChanged"))
+      .put(BytesWrittenVideoEvent.EVENT_NAME, MapBuilder.of("registrationName", "onBytesWrittenVideo"))
       .build()
 
   override fun getName(): String = TAG

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraViewModule.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraViewModule.kt
@@ -54,7 +54,6 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
       }
     }
   }
-  private var listenersCount = 0
   private val backgroundCoroutineScope = CoroutineScope(CameraQueues.cameraExecutor.asCoroutineDispatcher())
 
   override fun invalidate() {
@@ -75,7 +74,6 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
       val uiManager = UIManagerHelper.getUIManager(context, uiManagerType) ?: throw Error("UIManager not found!")
 
       val view = uiManager.resolveView(viewId) as? CameraView ?: throw ViewNotFoundError(viewId)
-      view.setReactContext(reactApplicationContext)
       Log.d(TAG, "Found view $viewId!")
       return@runOnUiThreadAndWait view
     }
@@ -191,20 +189,6 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
     }
   }
 
-  // Required for rn built in EventEmitter Calls.
-  @ReactMethod
-  fun addListener(eventName: String?) {
-    this.listenersCount++
-  }
-
-  @ReactMethod
-  fun removeListeners(count: Int?) {
-    var finalCount = 0
-    if(count != null){
-      finalCount = count
-    }
-    this.listenersCount = max(0, this.listenersCount - finalCount);
-  }
   private fun canRequestPermission(permission: String): Boolean {
     val activity = currentActivity as? PermissionAwareActivity
     return activity?.shouldShowRequestPermissionRationale(permission) ?: false

--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraViewModule.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraViewModule.kt
@@ -33,8 +33,6 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlin.math.max
-
 
 @ReactModule(name = CameraViewModule.TAG)
 @Suppress("unused")
@@ -54,6 +52,7 @@ class CameraViewModule(reactContext: ReactApplicationContext) : ReactContextBase
       }
     }
   }
+
   private val backgroundCoroutineScope = CoroutineScope(CameraQueues.cameraExecutor.asCoroutineDispatcher())
 
   override fun invalidate() {

--- a/package/android/src/main/java/com/mrousavy/camera/react/Events.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/Events.kt
@@ -98,7 +98,6 @@ class CameraCodeScannedEvent(surfaceId: Int, viewId: Int, private val data: Writ
   Event<CameraCodeScannedEvent>(surfaceId, viewId) {
   override fun getEventName() = EVENT_NAME
   override fun getEventData() = data
-
   companion object {
     const val EVENT_NAME = "topCameraCodeScanned"
   }

--- a/package/android/src/main/java/com/mrousavy/camera/react/Events.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/Events.kt
@@ -102,11 +102,11 @@ class CameraCodeScannedEvent(surfaceId: Int, viewId: Int, private val data: Writ
     const val EVENT_NAME = "topCameraCodeScanned"
   }
 }
-  class BytesWrittenVideoEvent(surfaceId: Int, viewId: Int, private val data: WritableMap) :
-    Event<BytesWrittenVideoEvent>(surfaceId, viewId) {
-    override fun getEventName() = EVENT_NAME
-    override fun getEventData() = data
-    companion object {
-      const val EVENT_NAME = "bytesWrittenVideoEvent"
-    }
+class BytesWrittenVideoEvent(surfaceId: Int, viewId: Int, private val data: WritableMap) :
+  Event<BytesWrittenVideoEvent>(surfaceId, viewId) {
+  override fun getEventName() = EVENT_NAME
+  override fun getEventData() = data
+  companion object {
+    const val EVENT_NAME = "bytesWrittenVideoEvent"
+  }
 }

--- a/package/android/src/main/java/com/mrousavy/camera/react/Events.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/Events.kt
@@ -98,7 +98,16 @@ class CameraCodeScannedEvent(surfaceId: Int, viewId: Int, private val data: Writ
   Event<CameraCodeScannedEvent>(surfaceId, viewId) {
   override fun getEventName() = EVENT_NAME
   override fun getEventData() = data
+
   companion object {
     const val EVENT_NAME = "topCameraCodeScanned"
   }
+}
+  class BytesWrittenVideoEvent(surfaceId: Int, viewId: Int, private val data: WritableMap) :
+    Event<BytesWrittenVideoEvent>(surfaceId, viewId) {
+    override fun getEventName() = EVENT_NAME
+    override fun getEventData() = data
+    companion object {
+      const val EVENT_NAME = "bytesWrittenVideoEvent"
+    }
 }

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -153,7 +153,7 @@ final class CameraConfiguration {
     case disabled
     case enabled(config: T)
 
-    public static func == (lhs: OutputConfiguration, rhs: OutputConfiguration) -> Bool {
+    static func == (lhs: OutputConfiguration, rhs: OutputConfiguration) -> Bool {
       switch (lhs, rhs) {
       case (.disabled, .disabled):
         return true

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -143,10 +143,7 @@ extension CameraSession {
           let path = session.url.path
           if let size = try? FileManager.default.attributesOfItem(atPath: path)[.size] as? NSNumber {
             let bytes = size.doubleValue
-
-            DispatchQueue.main.async {
-              onBytesWritten(bytes)
-            }
+            onBytesWritten(bytes)
           }
         }
         self.recordingSizeTimer = timer

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -18,7 +18,8 @@ extension CameraSession {
    */
   func startRecording(options: RecordVideoOptions,
                       onVideoRecorded: @escaping (_ video: Video) -> Void,
-                      onError: @escaping (_ error: CameraError) -> Void) {
+                      onError: @escaping (_ error: CameraError) -> Void,
+                      onBytesWritten: @escaping (_ bytes: Double) -> Void) {
     // Run on Camera Queue
     CameraQueues.cameraQueue.async {
       let start = DispatchTime.now()
@@ -48,6 +49,8 @@ extension CameraSession {
         }
 
         self.recordingSession = nil
+        self.recordingSizeTimer?.cancel()
+        self.recordingSizeTimer = nil
 
         if self.didCancelRecording {
           VisionLogger.log(level: .info, message: "RecordingSession finished because the recording was canceled.")
@@ -128,6 +131,26 @@ extension CameraSession {
         self.didCancelRecording = false
         self.recordingSession = recordingSession
 
+        let timer = DispatchSource.makeTimerSource(queue: CameraQueues.cameraQueue)
+        timer.schedule(deadline: .now(), repeating: 0.4)
+
+        timer.setEventHandler {
+          guard let session = self.recordingSession else {
+            timer.cancel()
+            return
+          }
+
+          let path = session.url.path
+          if let size = try? FileManager.default.attributesOfItem(atPath: path)[.size] as? NSNumber {
+            let bytes = size.doubleValue
+
+            DispatchQueue.main.async {
+              onBytesWritten(bytes)
+            }
+          }
+        }
+        self.recordingSizeTimer = timer
+        self.recordingSizeTimer?.resume()
         let end = DispatchTime.now()
         VisionLogger.log(level: .info, message: "RecordingSesssion started in \(Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000)ms!")
       } catch let error as CameraError {

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -31,6 +31,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
   // State
   var metadataProvider = MetadataProvider()
   var recordingSession: RecordingSession?
+  var recordingSizeTimer: DispatchSourceTimer?
   var didCancelRecording = false
   var orientationManager = OrientationManager()
 

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -266,7 +266,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     }
   }
 
-  public final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+  final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
     switch captureOutput {
     case is AVCaptureVideoDataOutput:
       onVideoFrame(sampleBuffer: sampleBuffer, orientation: connection.orientation, isMirrored: connection.isVideoMirrored)

--- a/package/ios/Core/PreviewView.swift
+++ b/package/ios/Core/PreviewView.swift
@@ -48,7 +48,7 @@ final class PreviewView: UIView {
     }
   }
 
-  override public static var layerClass: AnyClass {
+  override static var layerClass: AnyClass {
     return AVCaptureVideoPreviewLayer.self
   }
 

--- a/package/ios/Core/Recording/Track.swift
+++ b/package/ios/Core/Recording/Track.swift
@@ -51,7 +51,7 @@ final class Track {
   /**
    Returns the last timestamp that was actually written to the track.
    */
-  public private(set) var lastTimestamp: CMTime?
+  private(set) var lastTimestamp: CMTime?
 
   /**
    Gets the natural size of the asset writer, or zero if it is not a visual track.

--- a/package/ios/Core/Recording/TrackTimeline.swift
+++ b/package/ios/Core/Recording/TrackTimeline.swift
@@ -25,22 +25,22 @@ final class TrackTimeline {
    Represents whether the timeline has been marked as finished or not.
    A timeline will automatically be marked as finished when a timestamp arrives that appears after a stop().
    */
-  public private(set) var isFinished = false
+  private(set) var isFinished = false
 
   /**
    Gets the latency of the buffers in this timeline.
    This is computed by (currentTime - mostRecentBuffer.timestamp)
    */
-  public private(set) var latency: CMTime = .zero
+  private(set) var latency: CMTime = .zero
 
   /**
    Get the first actually written timestamp of this timeline
    */
-  public private(set) var firstTimestamp: CMTime?
+  private(set) var firstTimestamp: CMTime?
   /**
    Get the last actually written timestamp of this timeline.
    */
-  public private(set) var lastTimestamp: CMTime?
+  private(set) var lastTimestamp: CMTime?
 
   init(ofTrackType type: TrackType, withClock clock: CMClock) {
     trackType = type

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -40,7 +40,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   return result;
 }
 
-#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value
+#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count)->jsi::Value
 
 jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
   auto name = propName.utf8(runtime);

--- a/package/ios/React/CameraView+RecordVideo.swift
+++ b/package/ios/React/CameraView+RecordVideo.swift
@@ -29,7 +29,7 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         onError: { error in
           callback.reject(error: error)
         },
-        onBytesWritten: self.onBytesWrittenVideo
+        onBytesWritten: onBytesWrittenVideo
       )
     } catch {
       // Some error occured while initializing VideoSettings

--- a/package/ios/React/CameraView+RecordVideo.swift
+++ b/package/ios/React/CameraView+RecordVideo.swift
@@ -28,7 +28,8 @@ extension CameraView: AVCaptureVideoDataOutputSampleBufferDelegate, AVCaptureAud
         },
         onError: { error in
           callback.reject(error: error)
-        }
+        },
+        onBytesWritten: self.onBytesWrittenVideo
       )
     } catch {
       // Some error occured while initializing VideoSettings

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -80,6 +80,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
   @objc var onOutputOrientationChangedEvent: RCTDirectEventBlock?
   @objc var onViewReadyEvent: RCTDirectEventBlock?
   @objc var onAverageFpsChangedEvent: RCTDirectEventBlock?
+  @objc var onBytesWrittenVideoEvent: RCTDirectEventBlock?
   @objc var onCodeScannedEvent: RCTDirectEventBlock?
 
   // zoom
@@ -390,6 +391,12 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
   func onAverageFpsChanged(averageFps: Double) {
     onAverageFpsChangedEvent?([
       "averageFps": averageFps,
+    ])
+  }
+
+  func onBytesWrittenVideo(bytes: Double) {
+    onBytesWrittenVideoEvent?([
+      "bytesWritten": bytes,
     ])
   }
 }

--- a/package/ios/React/CameraViewManager.m
+++ b/package/ios/React/CameraViewManager.m
@@ -68,6 +68,7 @@ RCT_REMAP_VIEW_PROPERTY(onOutputOrientationChanged, onOutputOrientationChangedEv
 RCT_REMAP_VIEW_PROPERTY(onPreviewOrientationChanged, onPreviewOrientationChangedEvent, RCTDirectEventBlock);
 RCT_REMAP_VIEW_PROPERTY(onViewReady, onViewReadyEvent, RCTDirectEventBlock);
 RCT_REMAP_VIEW_PROPERTY(onAverageFpsChanged, onAverageFpsChangedEvent, RCTDirectEventBlock);
+RCT_REMAP_VIEW_PROPERTY(onBytesWrittenVideo, onBytesWrittenVideoEvent, RCTDirectEventBlock);
 // Code Scanner
 RCT_EXPORT_VIEW_PROPERTY(codeScannerOptions, NSDictionary);
 RCT_REMAP_VIEW_PROPERTY(onCodeScanned, onCodeScannedEvent, RCTDirectEventBlock);

--- a/package/ios/React/Utils/Promise.swift
+++ b/package/ios/React/Utils/Promise.swift
@@ -14,7 +14,7 @@ import Foundation
  * Represents a JavaScript Promise instance. `reject()` and `resolve()` should only be called once.
  */
 class Promise {
-  public private(set) var didResolve = false
+  private(set) var didResolve = false
 
   init(resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) {
     self.resolver = resolver

--- a/package/src/Camera.tsx
+++ b/package/src/Camera.tsx
@@ -92,7 +92,6 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
     super(props)
     this.onViewReady = this.onViewReady.bind(this)
     this.onAverageFpsChanged = this.onAverageFpsChanged.bind(this)
-    this.onBytesWrittenVideo = this.onBytesWrittenVideo.bind(this)
     this.onInitialized = this.onInitialized.bind(this)
     this.onStarted = this.onStarted.bind(this)
     this.onStopped = this.onStopped.bind(this)
@@ -103,6 +102,7 @@ export class Camera extends React.PureComponent<CameraProps, CameraState> {
     this.onPreviewOrientationChanged = this.onPreviewOrientationChanged.bind(this)
     this.onError = this.onError.bind(this)
     this.onCodeScanned = this.onCodeScanned.bind(this)
+    this.onBytesWrittenVideo = this.onBytesWrittenVideo.bind(this)
     this.ref = React.createRef<RefType>()
     this.lastFrameProcessor = undefined
     this.state = {

--- a/package/src/NativeCameraView.ts
+++ b/package/src/NativeCameraView.ts
@@ -4,6 +4,7 @@ import type { ErrorWithCause } from './CameraError'
 import type { CameraProps, OnShutterEvent } from './types/CameraProps'
 import type { Code, CodeScanner, CodeScannerFrame } from './types/CodeScanner'
 import type { Orientation } from './types/Orientation'
+import type { OnBytesWrittenVideoEvent } from './types/VideoFile'
 
 export interface OnCodeScannedEvent {
   codes: Code[]
@@ -35,6 +36,7 @@ export type NativeCameraViewProps = Omit<
   | 'codeScanner'
   | 'fps'
   | 'videoBitRate'
+  | 'onBytesWrittenVideo'
 > & {
   // private intermediate props
   cameraId: string
@@ -58,6 +60,7 @@ export type NativeCameraViewProps = Omit<
   onShutter?: (event: NativeSyntheticEvent<OnShutterEvent>) => void
   onOutputOrientationChanged?: (event: NativeSyntheticEvent<OutputOrientationChangedEvent>) => void
   onPreviewOrientationChanged?: (event: NativeSyntheticEvent<PreviewOrientationChangedEvent>) => void
+  onBytesWrittenVideo?: (event: NativeSyntheticEvent<OnBytesWrittenVideoEvent>) => void
 }
 
 // requireNativeComponent automatically resolves 'CameraView' to 'CameraViewManager'

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -416,5 +416,9 @@ export interface CameraProps extends ViewProps {
    * ```
    */
   codeScanner?: CodeScanner
+  /**
+   * Called whenever the video is written to the file.
+   */
+  onBytesWrittenVideo?: (bytes: number) => void
   //#endregion
 }

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -417,7 +417,8 @@ export interface CameraProps extends ViewProps {
    */
   codeScanner?: CodeScanner
   /**
-   * Used to get the bytes written to the video file on real time while it is being recorded
+   * Fires every few hundred milliseconds to notify how many
+   * total bytes are currently written to the video file.
    * @example
    * ```tsx
    * const onBytesWrittenVideo = (bytes: number) => {

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -418,8 +418,6 @@ export interface CameraProps extends ViewProps {
   codeScanner?: CodeScanner
   /**
    * Used to get the bytes written to the video file on real time while it is being recorded
-   *
-   * @see See [the Code Scanner documentation](https://react-native-vision-camera.com/docs/guides/code-scanning) for more information
    * @example
    * ```tsx
    * const onBytesWrittenVideo = (bytes: number) => {

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -417,7 +417,17 @@ export interface CameraProps extends ViewProps {
    */
   codeScanner?: CodeScanner
   /**
-   * Called whenever the video is written to the file.
+   * Used to get the bytes written to the video file on real time while it is being recorded
+   *
+   * @see See [the Code Scanner documentation](https://react-native-vision-camera.com/docs/guides/code-scanning) for more information
+   * @example
+   * ```tsx
+   * const onBytesWrittenVideo = (bytes: number) => {
+   *   console.log(`Bytes written: ${bytes}`)
+   * }
+   *
+   * return <Camera {...props} onBytesWrittenVideo={onBytesWrittenVideo} />
+   * ```
    */
   onBytesWrittenVideo?: (bytes: number) => void
   //#endregion

--- a/package/src/types/VideoFile.ts
+++ b/package/src/types/VideoFile.ts
@@ -56,5 +56,8 @@ export interface VideoFile extends TemporaryFile {
 }
 
 export interface OnBytesWrittenVideoEvent {
+  /**
+   * Represents the amount of total bytes written to the video file.
+   */
   bytesWritten: number
 }

--- a/package/src/types/VideoFile.ts
+++ b/package/src/types/VideoFile.ts
@@ -22,7 +22,6 @@ export interface RecordVideoOptions {
   /**
    * Called when there was an unexpected runtime error while recording the video.
    */
-  onBytesWritten?: (bytes: number) => void
   onRecordingError: (error: CameraCaptureError) => void
   /**
    * Called when the recording has been successfully saved to file.
@@ -54,4 +53,8 @@ export interface VideoFile extends TemporaryFile {
    * The height of the video, in pixels.
    */
   height: number
+}
+
+export interface OnBytesWrittenVideoEvent {
+  bytesWritten: number
 }

--- a/package/src/types/VideoFile.ts
+++ b/package/src/types/VideoFile.ts
@@ -22,6 +22,7 @@ export interface RecordVideoOptions {
   /**
    * Called when there was an unexpected runtime error while recording the video.
    */
+  onBytesWritten?: (bytes: number) => void
   onRecordingError: (error: CameraCaptureError) => void
   /**
    * Called when the recording has been successfully saved to file.


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->
## What

This PR Adds the `onBytesWrittenVideo` callback in order to receive the bytes of the video while it is being recorded.

## Changes

### IOS

- Implementing `DispatchSourceTimer` on Ios in order to read the file size from the FileSystem every 400 ms, that will be executed after the video has started and when finished the timer is cleaned.
-  Adding `onBytesWrittenVideoEvent` as `RCTDirectEventBlock` in order to send events to JS in `RCTViewManager`

### Android

- Creating BytesWrittenVideoEvent class
- Adding `onBytesWrittenVideo` on the `getExportedCustomDirectEventTypeConstants` and all the logic to treat that as an Event and send data to JS
- Send the data directly from `VideoRecordEvent.Status` as it is available there

### TSX/TS

- Adding types and JS Docs
- Adding the onBytesWrittenVideo and destructuring the `NativeEvent` to just expose `(bytes: number) => void`

### Docs

- Add an example on video page
## Tested on

- iPhone 8
- Samsung Galaxy S24 FE

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
