### PR TITLE
Revert "fix(android): bump androidX to beta01 (which fixes several edge cases)"

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -185,7 +185,7 @@ dependencies {
   implementation "com.facebook.react:react-android:+"
 
   // CameraX dependency
-  def camerax_version = "1.5.0-beta01"
+  def camerax_version = "1.5.0-alpha03"
   implementation "androidx.camera:camera-core:${camerax_version}"
   implementation "androidx.camera:camera-camera2:${camerax_version}"
   implementation "androidx.camera:camera-lifecycle:${camerax_version}"


### PR DESCRIPTION
Reverts mrousavy/react-native-vision-camera#3576

This requires compile SDK v 35 and Android Gradle Plugin v 8.5.0, the example app isn't updated yet and we don't want to break backwards compatibility too much 