### PR TITLE
fix(ios): make @frozen enums public to resolve Swift compilation warnings

### DIFF
--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -84,7 +84,7 @@ final class CameraConfiguration {
    Throw this to abort calls to configure { ... } and apply no changes.
    */
   @frozen
-  enum AbortThrow: Error {
+  public enum AbortThrow: Error {
     case abort
   }
 
@@ -149,7 +149,7 @@ final class CameraConfiguration {
   }
 
   @frozen
-  enum OutputConfiguration<T: Equatable>: Equatable {
+  public enum OutputConfiguration<T: Equatable>: Equatable {
     case disabled
     case enabled(config: T)
 

--- a/package/ios/Core/Recording/Track.swift
+++ b/package/ios/Core/Recording/Track.swift
@@ -12,7 +12,7 @@ import Foundation
 // MARK: - TrackType
 
 @frozen
-enum TrackType {
+public enum TrackType {
   case audio
   case video
 }

--- a/package/ios/Core/Types/AutoFocusSystem.swift
+++ b/package/ios/Core/Types/AutoFocusSystem.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Foundation
 
 @frozen
-enum AutoFocusSystem: String, JSUnionValue {
+public enum AutoFocusSystem: String, JSUnionValue {
   case contrastDetection = "contrast-detection"
   case phaseDetection = "phase-detection"
   case none

--- a/package/ios/Core/Types/Flash.swift
+++ b/package/ios/Core/Types/Flash.swift
@@ -12,7 +12,7 @@ import Foundation
  A Flash for Photo capture.
  */
 @frozen
-enum Flash: String, JSUnionValue {
+public enum Flash: String, JSUnionValue {
   /**
    Flash never fires.
    */

--- a/package/ios/Core/Types/HardwareLevel.swift
+++ b/package/ios/Core/Types/HardwareLevel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @frozen
-enum HardwareLevel: String, JSUnionValue {
+public enum HardwareLevel: String, JSUnionValue {
   case full
 
   init(jsValue: String) throws {

--- a/package/ios/Core/Types/OutputOrientation.swift
+++ b/package/ios/Core/Types/OutputOrientation.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @frozen
-enum OutputOrientation: String, JSUnionValue {
+public enum OutputOrientation: String, JSUnionValue {
   /**
    Automatically rotate outputs based on device physical rotation (even if screen-lock is on)
    */

--- a/package/ios/Core/Types/PixelFormat.swift
+++ b/package/ios/Core/Types/PixelFormat.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Foundation
 
 @frozen
-enum PixelFormat: String, JSUnionValue {
+public enum PixelFormat: String, JSUnionValue {
   case yuv
   case rgb
   case unknown

--- a/package/ios/Core/Types/QualityBalance.swift
+++ b/package/ios/Core/Types/QualityBalance.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Foundation
 
 @frozen
-enum QualityBalance: String, JSUnionValue {
+public enum QualityBalance: String, JSUnionValue {
   case speed
   case balanced
   case quality

--- a/package/ios/Core/Types/ResizeMode.swift
+++ b/package/ios/Core/Types/ResizeMode.swift
@@ -13,7 +13,7 @@ import Foundation
  A ResizeMode used for the PreviewView.
  */
 @frozen
-enum ResizeMode: String, JSUnionValue {
+public enum ResizeMode: String, JSUnionValue {
   /**
    Keep aspect ratio, but fill entire parent view (centered).
    */

--- a/package/ios/Core/Types/ShutterType.swift
+++ b/package/ios/Core/Types/ShutterType.swift
@@ -12,7 +12,7 @@ import Foundation
  Represents the type of media that was captured in a `onShutter` event
  */
 @frozen
-enum ShutterType: String, JSUnionValue {
+public enum ShutterType: String, JSUnionValue {
   /**
    A photo was captured on this `onShutter` event
    */

--- a/package/ios/Core/Types/Torch.swift
+++ b/package/ios/Core/Types/Torch.swift
@@ -13,7 +13,7 @@ import Foundation
  A Torch used for permanent flash.
  */
 @frozen
-enum Torch: String, JSUnionValue {
+public enum Torch: String, JSUnionValue {
   /**
    Torch (flash unit) is always off.
    */

--- a/package/ios/Core/Types/VideoStabilizationMode.swift
+++ b/package/ios/Core/Types/VideoStabilizationMode.swift
@@ -10,7 +10,7 @@ import AVFoundation
 import Foundation
 
 @frozen
-enum VideoStabilizationMode: String, JSUnionValue {
+public enum VideoStabilizationMode: String, JSUnionValue {
   case off
   case standard
   case cinematic


### PR DESCRIPTION
## Summary

This PR fixes Swift compilation warnings related to the  attribute on non-public enums.

## Problem

Swift compiler emits warnings:  for several enum definitions in the iOS Core module.

The  attribute can only be applied to  enums, not internal ones. Without the  modifier, the  attribute has no effect and generates compiler warnings.

## Solution

- Added  modifier to all  enums in the iOS Core module
- This allows the  attribute to work correctly and provide compiler optimizations
- No functional changes, only access level modifications

## Files Changed

-  - 2 enums (AbortThrow, OutputConfiguration)
-  - 1 enum (TrackType)  
- Types directory - 10 enum files:
  - AutoFocusSystem.swift
  - Flash.swift
  - HardwareLevel.swift
  - OutputOrientation.swift
  - PixelFormat.swift
  - QualityBalance.swift
  - ResizeMode.swift
  - ShutterType.swift
  - Torch.swift
  - VideoStabilizationMode.swift

## Testing

- Swift compilation warnings are resolved
- No breaking changes to public API (these enums are now properly public)
- All existing functionality remains unchanged