### PR TITLE
fix: Use `Map` instead of `MutableMap`

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
@@ -104,11 +104,11 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
     eventEmitter.emit("CameraDevicesChanged", devices)
   }
 
-  override fun getConstants(): MutableMap<String, Any?> {
+  override fun getConstants(): Map<String, Any?> {
     val devices = getDevicesJson()
     val preferredDevice = if (devices.size() > 0) devices.getMap(0) else null
 
-    return mutableMapOf(
+    return mapOf(
       "availableCameraDevices" to devices,
       "userPreferredCameraDevice" to preferredDevice?.toHashMap()
     )


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues
- fixes https://github.com/mrousavy/react-native-vision-camera/issues/3602#issuecomment-3199604497
<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
