### PR TITLE
fix(android): avoid calling getJSModule in init

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt
@@ -71,7 +71,6 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
       } catch (error: Throwable) {
         Log.e(TAG, "Failed to initialize ProcessCameraProvider/ExtensionsManager! Error: ${error.message}", error)
       }
-      sendAvailableDevicesChangedEvent()
     }
   }
 
@@ -79,6 +78,7 @@ class CameraDevicesManager(private val reactContext: ReactApplicationContext) : 
   override fun initialize() {
     super.initialize()
     cameraManager.registerAvailabilityCallback(callback, null)
+    sendAvailableDevicesChangedEvent()
   }
 
   override fun invalidate() {


### PR DESCRIPTION
## What

`sendAvailableDevicesChangedEvent` is calling `getJSModule` from init (introduced in PR #3575), which could crash with
[`IllegalStateException: "getJSModule should only happen once initialize() has been called"`](https://github.com/facebook/react-native/blob/44b2da0df2b4121d4d160cb35d0b5d7b05704698/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java#L112).
https://github.com/mrousavy/react-native-vision-camera/blob/5206c7861eb25beff07d83367ff105de5da0b8b9/package/android/src/main/java/com/mrousavy/camera/react/CameraDevicesManager.kt#L62-L76

---
Now JS events are emitted safely from initialize() after React is ready.

## Changes

- Move `sendAvailableDevicesChangedEvent()` call from `init` to `initialize()`
- Ensure hot restart / app start no longer crashes

## Tested on

- Google Pixel 7, Android 16
- Samsung Galaxy S21, Android 15

## Related issues

- Fixes #3609
