### PR TITLE
fix: Android 16 KB page support

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -130,11 +130,13 @@ android {
 
     externalNativeBuild {
       cmake {
-        cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
+        cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all", "-Wl,-z,max-page-size=16384", "-Wl,-z,common-page-size=16384"
+        cFlags "-Wl,-z,max-page-size=16384", "-Wl,-z,common-page-size=16384"
         arguments "-DANDROID_STL=c++_shared",
                 "-DNODE_MODULES_DIR=${nodeModules}",
                 "-DENABLE_FRAME_PROCESSORS=${enableFrameProcessors ? "ON" : "OFF"}",
-                "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+                "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
+                "-DANDROID_MAX_PAGE_SIZE_SUPPORTED=16384"
         abiFilters (*reactNativeArchitectures())
       }
     }


### PR DESCRIPTION
## What

Fixes support for Android 16KB page size by configuring appropriate CMake linker flags to ensure compatibility with devices using larger memory page sizes.

## Changes

- Added linker flags -Wl,-z,max-page-size=16384 and -Wl,-z,common-page-size=16384 to both cppFlags and cFlags
- Added ANDROID_MAX_PAGE_SIZE_SUPPORTED=16384 CMake argument

## Tested on

* Redmi Note 7, Android 10