### PR TITLE
feat: Add manual `iso`/`exposureDuration` props

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -113,6 +113,6 @@ jobs:
           -scheme VisionCameraExample \
           -sdk iphonesimulator \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 15' \
+          -destination 'platform=iOS Simulator,name=iPhone 17' \
           build \
           CODE_SIGNING_ALLOWED=NO | xcpretty"

--- a/.github/workflows/validate-cpp.yml
+++ b/.github/workflows/validate-cpp.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run clang-format style check
         uses: mrousavy/clang-format-action@v1
         with:
-          clang-format-version: '16'
+          clang-format-version: '21'
           check-path: ${{ matrix.path }}
           clang-format-style-path: package/.clang-format
 

--- a/package/android/src/main/cpp/frameprocessors/FrameHostObject.cpp
+++ b/package/android/src/main/cpp/frameprocessors/FrameHostObject.cpp
@@ -55,7 +55,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   return result;
 }
 
-#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value
+#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count)->jsi::Value
 
 jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
   auto name = propName.utf8(runtime);

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -54,7 +54,7 @@ final class CameraConfiguration {
 
   // Audio Session
   var audio: OutputConfiguration<Audio> = .disabled
-  
+
   var isManualExposure: Bool {
     return exposureDuration != nil || iso != nil
   }
@@ -136,7 +136,8 @@ final class CameraConfiguration {
       // format (depends on cameraId)
       formatChanged = inputChanged || left?.format != right.format
       // side-props (depends on format)
-      sidePropsChanged = formatChanged || left?.minFps != right.minFps || left?.maxFps != right.maxFps || left?.enableLowLightBoost != right.enableLowLightBoost || left?.exposureDuration != right.exposureDuration || left?.iso != right.iso
+      sidePropsChanged = formatChanged || left?.minFps != right.minFps || left?.maxFps != right.maxFps || left?.enableLowLightBoost != right.enableLowLightBoost
+        || left?.exposureDuration != right.exposureDuration || left?.iso != right.iso
       // torch (depends on isActive)
       let wasInactiveAndNeedsToEnableTorchAgain = left?.isActive == false && right.isActive == true && right.torch == .on
       torchChanged = inputChanged || wasInactiveAndNeedsToEnableTorchAgain || left?.torch != right.torch
@@ -157,7 +158,7 @@ final class CameraConfiguration {
     case disabled
     case enabled(config: T)
 
-    public static func == (lhs: OutputConfiguration, rhs: OutputConfiguration) -> Bool {
+    static func == (lhs: OutputConfiguration, rhs: OutputConfiguration) -> Bool {
       switch (lhs, rhs) {
       case (.disabled, .disabled):
         return true

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -46,12 +46,18 @@ final class CameraConfiguration {
 
   // Exposure
   var exposure: Float?
+  var exposureDuration: Double?
+  var iso: Float?
 
   // isActive (Start/Stop)
   var isActive = false
 
   // Audio Session
   var audio: OutputConfiguration<Audio> = .disabled
+  
+  var isManualExposure: Bool {
+    return exposureDuration != nil || iso != nil
+  }
 
   init(copyOf other: CameraConfiguration?) {
     if let other {
@@ -83,7 +89,6 @@ final class CameraConfiguration {
   /**
    Throw this to abort calls to configure { ... } and apply no changes.
    */
-  @frozen
   enum AbortThrow: Error {
     case abort
   }
@@ -131,7 +136,7 @@ final class CameraConfiguration {
       // format (depends on cameraId)
       formatChanged = inputChanged || left?.format != right.format
       // side-props (depends on format)
-      sidePropsChanged = formatChanged || left?.minFps != right.minFps || left?.maxFps != right.maxFps || left?.enableLowLightBoost != right.enableLowLightBoost
+      sidePropsChanged = formatChanged || left?.minFps != right.minFps || left?.maxFps != right.maxFps || left?.enableLowLightBoost != right.enableLowLightBoost || left?.exposureDuration != right.exposureDuration || left?.iso != right.iso
       // torch (depends on isActive)
       let wasInactiveAndNeedsToEnableTorchAgain = left?.isActive == false && right.isActive == true && right.torch == .on
       torchChanged = inputChanged || wasInactiveAndNeedsToEnableTorchAgain || left?.torch != right.torch
@@ -148,7 +153,6 @@ final class CameraConfiguration {
     }
   }
 
-  @frozen
   enum OutputConfiguration<T: Equatable>: Equatable {
     case disabled
     case enabled(config: T)

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -284,7 +284,8 @@ extension CameraSession {
 
     if configuration.isManualExposure {
       // Lock exposure to manual
-      let duration = CMTime(seconds: configuration.exposureDuration ?? AVCaptureDevice.currentExposureDuration.seconds, preferredTimescale: 1)
+      let durationSeconds = configuration.exposureDuration ?? AVCaptureDevice.currentExposureDuration.seconds
+      let duration = CMTime(seconds: durationSeconds, preferredTimescale: 1_000_000_000)
       let iso = configuration.iso ?? AVCaptureDevice.currentISO
       device.setExposureModeCustom(duration: duration, iso: iso)
     } else {

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -273,7 +273,7 @@ extension CameraSession {
       }
       device.automaticallyEnablesLowLightBoostWhenAvailable = configuration.enableLowLightBoost
     }
-
+    
     // Configure auto-focus
     if device.isFocusModeSupported(.continuousAutoFocus) {
       if device.isFocusPointOfInterestSupported {
@@ -281,11 +281,21 @@ extension CameraSession {
       }
       device.focusMode = .continuousAutoFocus
     }
-    if device.isExposureModeSupported(.continuousAutoExposure) {
-      if device.isExposurePointOfInterestSupported {
-        device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
+    
+    
+    if configuration.isManualExposure {
+      // Lock exposure to manual
+      let duration = CMTime(seconds: configuration.exposureDuration ?? AVCaptureDevice.currentExposureDuration.seconds, preferredTimescale: 1)
+      let iso = configuration.iso ?? AVCaptureDevice.currentISO
+      device.setExposureModeCustom(duration: duration, iso: iso)
+    } else {
+      // Configure auto-exposure
+      if device.isExposureModeSupported(.continuousAutoExposure) {
+        if device.isExposurePointOfInterestSupported {
+          device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
+        }
+        device.exposureMode = .continuousAutoExposure
       }
-      device.exposureMode = .continuousAutoExposure
     }
   }
 

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -273,7 +273,7 @@ extension CameraSession {
       }
       device.automaticallyEnablesLowLightBoostWhenAvailable = configuration.enableLowLightBoost
     }
-    
+
     // Configure auto-focus
     if device.isFocusModeSupported(.continuousAutoFocus) {
       if device.isFocusPointOfInterestSupported {
@@ -281,8 +281,7 @@ extension CameraSession {
       }
       device.focusMode = .continuousAutoFocus
     }
-    
-    
+
     if configuration.isManualExposure {
       // Lock exposure to manual
       let duration = CMTime(seconds: configuration.exposureDuration ?? AVCaptureDevice.currentExposureDuration.seconds, preferredTimescale: 1)

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -265,7 +265,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     }
   }
 
-  public final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+  final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
     switch captureOutput {
     case is AVCaptureVideoDataOutput:
       onVideoFrame(sampleBuffer: sampleBuffer, orientation: connection.orientation, isMirrored: connection.isVideoMirrored)

--- a/package/ios/Core/PreviewView.swift
+++ b/package/ios/Core/PreviewView.swift
@@ -48,7 +48,7 @@ final class PreviewView: UIView {
     }
   }
 
-  override public static var layerClass: AnyClass {
+  override static var layerClass: AnyClass {
     return AVCaptureVideoPreviewLayer.self
   }
 

--- a/package/ios/Core/Recording/Track.swift
+++ b/package/ios/Core/Recording/Track.swift
@@ -51,7 +51,7 @@ final class Track {
   /**
    Returns the last timestamp that was actually written to the track.
    */
-  public private(set) var lastTimestamp: CMTime?
+  private(set) var lastTimestamp: CMTime?
 
   /**
    Gets the natural size of the asset writer, or zero if it is not a visual track.

--- a/package/ios/Core/Recording/TrackTimeline.swift
+++ b/package/ios/Core/Recording/TrackTimeline.swift
@@ -25,22 +25,22 @@ final class TrackTimeline {
    Represents whether the timeline has been marked as finished or not.
    A timeline will automatically be marked as finished when a timestamp arrives that appears after a stop().
    */
-  public private(set) var isFinished = false
+  private(set) var isFinished = false
 
   /**
    Gets the latency of the buffers in this timeline.
    This is computed by (currentTime - mostRecentBuffer.timestamp)
    */
-  public private(set) var latency: CMTime = .zero
+  private(set) var latency: CMTime = .zero
 
   /**
    Get the first actually written timestamp of this timeline
    */
-  public private(set) var firstTimestamp: CMTime?
+  private(set) var firstTimestamp: CMTime?
   /**
    Get the last actually written timestamp of this timeline.
    */
-  public private(set) var lastTimestamp: CMTime?
+  private(set) var lastTimestamp: CMTime?
 
   init(ofTrackType type: TrackType, withClock clock: CMClock) {
     trackType = type

--- a/package/ios/Core/Types/CameraDeviceFormat.swift
+++ b/package/ios/Core/Types/CameraDeviceFormat.swift
@@ -68,7 +68,7 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
     minISO = jsValue["minISO"] as! Float
     maxISO = jsValue["maxISO"] as! Float
     minExposureDuration = jsValue["minExposureDuration"] as! Double
-    maxExposureDuration = jsValue["minExposureDuration"] as! Double
+    maxExposureDuration = jsValue["maxExposureDuration"] as! Double
     fieldOfView = jsValue["fieldOfView"] as! Float
     let jsVideoStabilizationModes = jsValue["videoStabilizationModes"] as! [String]
     videoStabilizationModes = try jsVideoStabilizationModes.map { try VideoStabilizationMode(jsValue: $0) }

--- a/package/ios/Core/Types/CameraDeviceFormat.swift
+++ b/package/ios/Core/Types/CameraDeviceFormat.swift
@@ -24,6 +24,9 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
 
   let minISO: Float
   let maxISO: Float
+  
+  let minExposureDuration: Double
+  let maxExposureDuration: Double
 
   let fieldOfView: Float
 
@@ -44,6 +47,8 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
     maxFps = format.maxFps
     minISO = format.minISO
     maxISO = format.maxISO
+    minExposureDuration = format.minExposureDuration.seconds
+    maxExposureDuration = format.maxExposureDuration.seconds
     fieldOfView = format.videoFieldOfView
     videoStabilizationModes = format.videoStabilizationModes.map { VideoStabilizationMode(from: $0) }
     autoFocusSystem = AutoFocusSystem(fromFocusSystem: format.autoFocusSystem)
@@ -62,6 +67,8 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
     maxFps = jsValue["maxFps"] as! Double
     minISO = jsValue["minISO"] as! Float
     maxISO = jsValue["maxISO"] as! Float
+    minExposureDuration = jsValue["minExposureDuration"] as! Double
+    maxExposureDuration = jsValue["minExposureDuration"] as! Double
     fieldOfView = jsValue["fieldOfView"] as! Float
     let jsVideoStabilizationModes = jsValue["videoStabilizationModes"] as! [String]
     videoStabilizationModes = try jsVideoStabilizationModes.map { try VideoStabilizationMode(jsValue: $0) }
@@ -88,6 +95,8 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
       "videoWidth": videoWidth,
       "minISO": minISO,
       "maxISO": maxISO,
+      "minExposureDuration": minExposureDuration,
+      "maxExposureDuration": maxExposureDuration,
       "fieldOfView": fieldOfView,
       "supportsVideoHdr": supportsVideoHdr,
       "supportsPhotoHdr": supportsPhotoHdr,

--- a/package/ios/Core/Types/CameraDeviceFormat.swift
+++ b/package/ios/Core/Types/CameraDeviceFormat.swift
@@ -24,7 +24,7 @@ struct CameraDeviceFormat: Equatable, CustomStringConvertible {
 
   let minISO: Float
   let maxISO: Float
-  
+
   let minExposureDuration: Double
   let maxExposureDuration: Double
 

--- a/package/ios/FrameProcessors/FrameHostObject.mm
+++ b/package/ios/FrameProcessors/FrameHostObject.mm
@@ -40,7 +40,7 @@ std::vector<jsi::PropNameID> FrameHostObject::getPropertyNames(jsi::Runtime& rt)
   return result;
 }
 
-#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count) -> jsi::Value
+#define JSI_FUNC [=](jsi::Runtime & runtime, const jsi::Value& thisValue, const jsi::Value* arguments, size_t count)->jsi::Value
 
 jsi::Value FrameHostObject::get(jsi::Runtime& runtime, const jsi::PropNameID& propName) {
   auto name = propName.utf8(runtime);

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -67,6 +67,8 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
       updatePreview()
     }
   }
+  @objc var iso: NSNumber?
+  @objc var exposureDuration: NSNumber?
 
   // events
   @objc var onInitializedEvent: RCTDirectEventBlock?
@@ -263,6 +265,8 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
       config.maxFps = maxFps?.int32Value
       config.enableLowLightBoost = lowLightBoost
       config.torch = try Torch(jsValue: torch)
+      config.exposureDuration = exposureDuration?.doubleValue ?? nil
+      config.iso = iso?.floatValue ?? nil
 
       // Zoom
       config.zoom = zoom.doubleValue

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -67,6 +67,7 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
       updatePreview()
     }
   }
+
   @objc var iso: NSNumber?
   @objc var exposureDuration: NSNumber?
 
@@ -265,8 +266,8 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
       config.maxFps = maxFps?.int32Value
       config.enableLowLightBoost = lowLightBoost
       config.torch = try Torch(jsValue: torch)
-      config.exposureDuration = exposureDuration?.doubleValue ?? nil
-      config.iso = iso?.floatValue ?? nil
+      config.exposureDuration = exposureDuration?.doubleValue
+      config.iso = iso?.floatValue
 
       // Zoom
       config.zoom = zoom.doubleValue

--- a/package/ios/React/CameraViewManager.m
+++ b/package/ios/React/CameraViewManager.m
@@ -53,6 +53,8 @@ RCT_EXPORT_VIEW_PROPERTY(videoBitRateMultiplier, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(torch, NSString);
 RCT_EXPORT_VIEW_PROPERTY(zoom, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(exposure, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(iso, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(exposureDuration, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(enableZoomGesture, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(outputOrientation, NSString);
 RCT_EXPORT_VIEW_PROPERTY(resizeMode, NSString);

--- a/package/ios/React/Utils/Promise.swift
+++ b/package/ios/React/Utils/Promise.swift
@@ -14,7 +14,7 @@ import Foundation
  * Represents a JavaScript Promise instance. `reject()` and `resolve()` should only be called once.
  */
 class Promise {
-  public private(set) var didResolve = false
+  private(set) var didResolve = false
 
   init(resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) {
     self.resolver = resolver

--- a/package/src/types/CameraDevice.ts
+++ b/package/src/types/CameraDevice.ts
@@ -79,6 +79,14 @@ export interface CameraDeviceFormat {
    */
   minISO: number
   /**
+   * Minimum supported exposure duration, in seconds
+   */
+  minExposureDuration: number
+  /**
+   * Maximum supported exposure duration, in seconds
+   */
+  maxExposureDuration: number
+  /**
    * The video field of view in degrees
    */
   fieldOfView: number

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -149,6 +149,23 @@ export interface CameraProps extends ViewProps {
    * The value between min- and max supported exposure is considered the default, neutral value.
    */
   exposure?: number
+
+  /**
+   * Manually configures the ISO value of the Camera.
+   *
+   * If either {@linkcode iso} or {@linkcode exposureDuration} is set, the Camera will be locked to manual exposure.
+   *
+   * @default undefined
+   */
+  iso?: number
+  /**
+   * Manually configures the exposure duration (in seconds) of the Camera.
+   *
+   * If either {@linkcode exposureDuration} or {@linkcode iso} is set, the Camera will be locked to manual exposure.
+   *
+   * @default undefined
+   */
+  exposureDuration?: number
   //#endregion
 
   //#region Format/Preset selection


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

Adds `iso` and `exposureDuration` props to `<Camera />`.

- `iso`: The range needs to be within `format.minISO` and `format.maxISO`
- `exposureDuration`: The range needs to be within `format.minExposureDuration` and `format.maxExposureDuration`

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
