### PR TITLE
fix(ios): prevent crash when capturePhoto has no active video connection

### DIFF
--- a/package/ios/Core/CameraSession+Photo.swift
+++ b/package/ios/Core/CameraSession+Photo.swift
@@ -11,84 +11,170 @@ import Foundation
 
 extension CameraSession {
   /**
-   Takes a photo.
+   Captures a photo.
    `takePhoto` is only available if `photo={true}`.
    */
   func takePhoto(options: TakePhotoOptions, promise: Promise) {
-    // Run on Camera Queue
     CameraQueues.cameraQueue.async {
-      // Get Photo Output configuration
+      // Validate configuration
       guard let configuration = self.configuration else {
         promise.reject(error: .session(.cameraNotReady))
         return
       }
       guard configuration.photo != .disabled else {
-        // User needs to enable photo={true}
         promise.reject(error: .capture(.photoNotEnabled))
         return
       }
 
-      // Check if Photo Output is available
+      // Validate outputs and inputs
       guard let photoOutput = self.photoOutput,
             let videoDeviceInput = self.videoDeviceInput else {
-        // Camera is not yet ready
         promise.reject(error: .session(.cameraNotReady))
         return
       }
 
       VisionLogger.log(level: .info, message: "Capturing photo...")
 
-      // Create photo settings
-      let photoSettings = AVCapturePhotoSettings()
-
-      // set photo resolution
-      if #available(iOS 16.0, *) {
-        photoSettings.maxPhotoDimensions = photoOutput.maxPhotoDimensions
-      } else {
-        photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
-      }
-
-      // depth data
-      photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
-      if #available(iOS 12.0, *) {
-        photoSettings.isPortraitEffectsMatteDeliveryEnabled = photoOutput.isPortraitEffectsMatteDeliveryEnabled
-      }
-
-      // quality prioritization
-      if #available(iOS 13.0, *) {
-        photoSettings.photoQualityPrioritization = photoOutput.maxPhotoQualityPrioritization
-      }
-
-      // red-eye reduction
-      photoSettings.isAutoRedEyeReductionEnabled = options.enableAutoRedEyeReduction
-
-      // distortion correction
-      if #available(iOS 14.1, *) {
-        photoSettings.isAutoContentAwareDistortionCorrectionEnabled = options.enableAutoDistortionCorrection
-      }
-
-      // flash
-      if options.flash != .off {
-        guard videoDeviceInput.device.hasFlash else {
-          // If user enabled flash, but the device doesn't have a flash, throw an error.
-          promise.reject(error: .capture(.flashNotAvailable))
+      // Ensure session and video connection are ready
+      self.ensureReadyToCapture(repairIfNeeded: true) { ready in
+        guard ready else {
+          VisionLogger.log(level: .error, message: "Photo capture failed: session or connection not ready.")
+          promise.reject(error: .session(.cameraNotReady))
           return
         }
-      }
-      if videoDeviceInput.device.isFlashAvailable {
-        photoSettings.flashMode = options.flash.toFlashMode()
-      }
 
-      // Actually do the capture!
-      let photoCaptureDelegate = PhotoCaptureDelegate(promise: promise,
-                                                      enableShutterSound: options.enableShutterSound,
-                                                      metadataProvider: self.metadataProvider,
-                                                      path: options.path,
-                                                      cameraSessionDelegate: self.delegate)
-      photoOutput.capturePhoto(with: photoSettings, delegate: photoCaptureDelegate)
+        // Build photo settings
+        let photoSettings = AVCapturePhotoSettings()
 
-      // Assume that `takePhoto` is always called with the same parameters, so prepare the next call too.
-      photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)
+        if #available(iOS 16.0, *) {
+          photoSettings.maxPhotoDimensions = photoOutput.maxPhotoDimensions
+        } else {
+          photoSettings.isHighResolutionPhotoEnabled = photoOutput.isHighResolutionCaptureEnabled
+        }
+
+        // Depth / Portrait / Distortion
+        if photoOutput.isDepthDataDeliverySupported {
+          photoSettings.isDepthDataDeliveryEnabled = photoOutput.isDepthDataDeliveryEnabled
+        }
+        if #available(iOS 12.0, *) {
+          photoSettings.isPortraitEffectsMatteDeliveryEnabled = photoOutput.isPortraitEffectsMatteDeliveryEnabled
+        }
+        if #available(iOS 13.0, *) {
+          photoSettings.photoQualityPrioritization = photoOutput.maxPhotoQualityPrioritization
+        }
+        photoSettings.isAutoRedEyeReductionEnabled = options.enableAutoRedEyeReduction
+        if #available(iOS 14.1, *),
+           photoOutput.isContentAwareDistortionCorrectionSupported {
+          photoSettings.isAutoContentAwareDistortionCorrectionEnabled = options.enableAutoDistortionCorrection
+        }
+
+        // Flash
+        if options.flash != .off {
+          guard videoDeviceInput.device.hasFlash else {
+            promise.reject(error: .capture(.flashNotAvailable))
+            return
+          }
+        }
+        if videoDeviceInput.device.isFlashAvailable {
+          photoSettings.flashMode = options.flash.toFlashMode()
+        }
+
+        // Final connection guard
+        guard let videoConn = photoOutput.connection(with: .video),
+              videoConn.isEnabled, videoConn.isActive else {
+          VisionLogger.log(level: .error, message: "No active and enabled video connection for photo capture.")
+          promise.reject(error: .session(.cameraNotReady))
+          return
+        }
+
+        // Capture
+        let photoCaptureDelegate = PhotoCaptureDelegate(
+          promise: promise,
+          enableShutterSound: options.enableShutterSound,
+          metadataProvider: self.metadataProvider,
+          path: options.path,
+          cameraSessionDelegate: self.delegate
+        )
+        photoOutput.capturePhoto(with: photoSettings, delegate: photoCaptureDelegate)
+
+        // Prepare next settings
+        photoOutput.setPreparedPhotoSettingsArray([photoSettings], completionHandler: nil)
+      }
     }
+  }
+
+  // MARK: - Readiness / Repair
+
+  /// Ensures the session is running and the video connection is enabled + active.
+  /// Optionally tries to repair the output and waits shortly to handle race conditions.
+  private func ensureReadyToCapture(repairIfNeeded: Bool,
+                                    timeout: TimeInterval = 0.5,
+                                    poll: TimeInterval = 0.05,
+                                    completion: @escaping (Bool) -> Void) {
+    if isReadyNowActive() {
+      completion(true)
+      return
+    }
+
+    var repairedOnce = false
+    let deadline = DispatchTime.now() + timeout
+
+    func tick() {
+      if isReadyNowActive() {
+        completion(true)
+        return
+      }
+      if repairIfNeeded && !repairedOnce {
+        repairedOnce = repairPhotoConnectionIfNeeded()
+      }
+      if DispatchTime.now() < deadline {
+        CameraQueues.cameraQueue.asyncAfter(deadline: .now() + poll) { tick() }
+      } else {
+        completion(false)
+      }
+    }
+
+    tick()
+  }
+
+  /// Checks if session is running and the video connection is enabled and active.
+  private func isReadyNowActive() -> Bool {
+    guard let photoOutput = self.photoOutput else { return false }
+    let running = self.captureSession.isRunning
+    guard running, let conn = photoOutput.connection(with: .video) else { return false }
+    return conn.isEnabled && conn.isActive
+  }
+
+  /// Repairs the photo output connection by re-adding it to the session.
+  @discardableResult
+  private func repairPhotoConnectionIfNeeded() -> Bool {
+    guard let photoOutput = self.photoOutput else { return false }
+    let session = self.captureSession
+
+    let conn = photoOutput.connection(with: .video)
+    if conn?.isEnabled == true && conn?.isActive == true { return false }
+
+    VisionLogger.log(level: .info, message: "Repairing photo connection...")
+
+    session.beginConfiguration()
+
+    if session.canSetSessionPreset(.photo) {
+      session.sessionPreset = .photo
+    }
+
+    if session.outputs.contains(photoOutput) {
+      session.removeOutput(photoOutput)
+    }
+    if session.canAddOutput(photoOutput) {
+      session.addOutput(photoOutput)
+    }
+
+    session.commitConfiguration()
+
+    if !session.isRunning {
+      session.startRunning()
+    }
+
+    return true
   }
 }


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This PR fixes a crash on iOS devices where calling
AVCapturePhotoOutput.capturePhoto(with:delegate:) could throw:
```
*** -[AVCapturePhotoOutput capturePhotoWithSettings:delegate:] No active and enabled video connection
```

The crash was caused by attempting to capture a photo when the AVCaptureSession was running but the video connection was not yet active (e.g., right after camera switch, format change, or session interruption).

## Changes

* Added a readiness check before capture:
  * Ensure AVCaptureSession.isRunning == true
  * Ensure video connection is both enabled and active
* Added an auto-repair path:
  * Re-add AVCapturePhotoOutput inside beginConfiguration/commitConfiguration
  * Reset session preset to .photo if available
  * Restart the session if necessary
* Added a short polling window (default 0.5s, every 50ms) to handle timing races after reconfiguration
* Preserved existing logging (VisionLogger.log) and behavior for resolution, flash, red-eye reduction, depth data, portrait effects matte, and distortion correction.

## Tested on

* iPhone 17 Pro (iOS 18 beta) – verified crash no longer occurs when switching cameras rapidly and capturing immediately.
* iPhone 16 Pro (iOS 26.0) - regression check, normal behavior.
* iPhone 16 Pro (iOS 18.6) - regression check, normal behavior.
* iPhone 16 (iOS 26.0) - regression check, normal behavior.
* iPhone 12 Pro (iOS 16.x) – regression check, normal behavior.

## Related issues

* Closes #3633 
* Related discussions:
  * https://stackoverflow.com/questions/78212727
  * https://stackoverflow.com/questions/67804126