### PR TITLE
feat(shutdown): implement graceful shutdown for camera session

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -61,6 +61,12 @@ extension CameraSession {
 
     // Remove all outputs
     for output in captureSession.outputs {
+      if let metadataOutput = output as? AVCaptureMetadataOutput {
+        metadataOutput.setMetadataObjectsDelegate(nil, queue: nil)
+      }
+      if let videoOutput = output as? AVCaptureVideoDataOutput {
+        videoOutput.setSampleBufferDelegate(nil, queue: nil)
+      }
       captureSession.removeOutput(output)
     }
     photoOutput = nil

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -61,12 +61,6 @@ extension CameraSession {
 
     // Remove all outputs
     for output in captureSession.outputs {
-      if let metadataOutput = output as? AVCaptureMetadataOutput {
-        metadataOutput.setMetadataObjectsDelegate(nil, queue: nil)
-      }
-      if let videoOutput = output as? AVCaptureVideoDataOutput {
-        videoOutput.setSampleBufferDelegate(nil, queue: nil)
-      }
       captureSession.removeOutput(output)
     }
     photoOutput = nil

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -130,18 +130,20 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
 
     // Set up Camera (Video) Capture Session (on camera queue, acts like a lock)
     CameraQueues.cameraQueue.async {
+      defer {
+        completionBlock?()
+      }
+
       // Let caller configure a new configuration for the Camera.
       let config = CameraConfiguration(copyOf: self.configuration)
       do {
         try lambda(config)
       } catch CameraConfiguration.AbortThrow.abort {
         // call has been aborted and changes shall be discarded
-        completionBlock?()
         return
       } catch {
         // another error occured, possibly while trying to parse enums
         self.onConfigureError(error)
-        completionBlock?()
         return
       }
       let difference = CameraConfiguration.Difference(between: self.configuration, and: config)
@@ -261,7 +263,6 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
           }
         }
       }
-      completionBlock?()
     }
   }
 

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -83,6 +83,18 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     NotificationCenter.default.removeObserver(self,
                                               name: AVAudioSession.interruptionNotification,
                                               object: AVAudioSession.sharedInstance)
+    let cameraCaptureSession = captureSession
+    CameraQueues.cameraQueue.async {
+      if cameraCaptureSession.isRunning {
+        cameraCaptureSession.stopRunning()
+      }
+    }
+    let cameraAudioSession = audioCaptureSession
+    CameraQueues.audioQueue.async {
+      if cameraAudioSession.isRunning {
+        cameraAudioSession.stopRunning()
+      }
+    }
   }
 
   /**
@@ -108,10 +120,13 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
    Any changes in here will be re-configured only if required, and under a lock (in this case, the serial cameraQueue DispatchQueue).
    The `configuration` object is a copy of the currently active configuration that can be modified by the caller in the lambda.
    */
-  func configure(_ lambda: @escaping (_ configuration: CameraConfiguration) throws -> Void) {
+  func configure(_ lambda: @escaping (_ configuration: CameraConfiguration) throws -> Void,
+                 completion: (() -> Void)? = nil) {
     initialize()
 
     VisionLogger.log(level: .info, message: "configure { ... }: Waiting for lock...")
+
+    let completionBlock = completion
 
     // Set up Camera (Video) Capture Session (on camera queue, acts like a lock)
     CameraQueues.cameraQueue.async {
@@ -121,10 +136,12 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
         try lambda(config)
       } catch CameraConfiguration.AbortThrow.abort {
         // call has been aborted and changes shall be discarded
+        completionBlock?()
         return
       } catch {
         // another error occured, possibly while trying to parse enums
         self.onConfigureError(error)
+        completionBlock?()
         return
       }
       let difference = CameraConfiguration.Difference(between: self.configuration, and: config)
@@ -244,7 +261,23 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
           }
         }
       }
+      completionBlock?()
     }
+  }
+
+  /**
+   Gracefully stop streaming and tear down any active outputs. Completion executes on the camera queue.
+   */
+  func shutdown(completion: (() -> Void)? = nil) {
+    configure({ config in
+      config.photo = .disabled
+      config.video = .disabled
+      config.audio = .disabled
+      config.codeScanner = .disabled
+      config.enableLocation = false
+      config.torch = .off
+      config.isActive = false
+    }, completion: completion)
   }
 
   /**
@@ -265,7 +298,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     }
   }
 
-  public final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+  final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
     switch captureOutput {
     case is AVCaptureVideoDataOutput:
       onVideoFrame(sampleBuffer: sampleBuffer, orientation: connection.orientation, isMirrored: connection.isVideoMirrored)

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -302,13 +302,13 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
       frameProcessor = nil
     #endif
 
-    let slowShutdownWarning = DispatchWorkItem {
+    let logSlowShutdownWarning = DispatchWorkItem {
       VisionLogger.log(level: .warning, message: "CameraSession shutdown is still running after 2 seconds.")
     }
-    CameraQueues.cameraQueue.asyncAfter(deadline: .now() + .seconds(2), execute: slowShutdownWarning)
+    CameraQueues.cameraQueue.asyncAfter(deadline: .now() + .seconds(2), execute: logSlowShutdownWarning)
 
     cameraSession.shutdown { [weak self] in
-      slowShutdownWarning.cancel()
+      logSlowShutdownWarning.cancel()
       DispatchQueue.main.async {
         self?.didScheduleShutdown = false
       }

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -142,10 +142,6 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
     }
   }
 
-  deinit {
-    shutdownCameraSession()
-  }
-
   override public func layoutSubviews() {
     if let previewView {
       previewView.frame = frame


### PR DESCRIPTION
## What
Fix the navigation freeze on React Navigation/Fabric by shutting the camera session down deterministically when the view unmounts.

## Changes
- Add CameraSession.shutdown, which disables photo/video/audio/code-scanner/location/torch before flipping isActive = false, and clears delegates while removing outputs.  
- Stop both capture sessions asynchronously during CameraSession.deinit as a backstop.  
- Have CameraView call the shutdown helper on unmount/deinit, log if teardown exceeds 2 s, and guard against concurrent shutdowns.

## Tested on
- iPhone 14 Pro (iOS 26.0.1) with code scanner enabled, navigating away from the camera screen (no freeze).

## Related issues
- Fixes #3636