### PR TITLE
docs: fix typo in take photos & recording videos description

### DIFF
--- a/docs/docs/guides/RECORDING_VIDEOS.mdx
+++ b/docs/docs/guides/RECORDING_VIDEOS.mdx
@@ -174,7 +174,7 @@ See [FPS](formats#fps) for more information.
 
 ## Saving the Video to the Camera Roll
 
-Since the Video is stored as a temporary file, you need save it to the Camera Roll to permanentely store it. You can use [react-native-cameraroll](https://github.com/react-native-cameraroll/react-native-cameraroll) for this:
+Since the Video is stored as a temporary file, you need save it to the Camera Roll to permanently store it. You can use [react-native-cameraroll](https://github.com/react-native-cameraroll/react-native-cameraroll) for this:
 
 ```ts
 camera.current.startRecording({

--- a/docs/docs/guides/TAKING_PHOTOS.mdx
+++ b/docs/docs/guides/TAKING_PHOTOS.mdx
@@ -109,7 +109,7 @@ On iOS, snapshot capture requires [`video`](/docs/api/interfaces/CameraProps#vid
 
 ## Saving the Photo to the Camera Roll
 
-Since the Photo is stored as a temporary file, you need to save it to the Camera Roll to permanentely store it. You can use [react-native-cameraroll](https://github.com/react-native-cameraroll/react-native-cameraroll) for this:
+Since the Photo is stored as a temporary file, you need to save it to the Camera Roll to permanently store it. You can use [react-native-cameraroll](https://github.com/react-native-cameraroll/react-native-cameraroll) for this:
 
 ```ts
 const file = await camera.current.takePhoto()


### PR DESCRIPTION
## What
This PR fixes a typo in the "Take Photos" & "Recording Videos" pages.

## Changes
- Fix typo in two sections

## Tested on
No tests needed.

## Related issues
No related issues.
