### PR TITLE
fix: implement more robust config and tear down bookkeeping

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -61,21 +61,6 @@ extension CameraSession {
 
     // Remove all outputs
     for output in captureSession.outputs {
-      // The following delegates are weak references
-      // so cleaning them up is not strictly necessary
-      // from a safety standpoint.
-      // It is good to mark that between this point
-      // and logic further down configureOutput()
-      // messages to delegate would be in an undefined
-      // state and with delegate == self the weak 
-      // references wouldn't be cleared during that 
-      // window.
-      if let metadataOutput = output as? AVCaptureMetadataOutput {
-        metadataOutput.setMetadataObjectsDelegate(nil, queue: nil)
-      }
-      if let videoOutput = output as? AVCaptureVideoDataOutput {
-        videoOutput.setSampleBufferDelegate(nil, queue: nil)
-      }
       captureSession.removeOutput(output)
     }
     photoOutput = nil

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -61,6 +61,12 @@ extension CameraSession {
 
     // Remove all outputs
     for output in captureSession.outputs {
+      if let metadataOutput = output as? AVCaptureMetadataOutput {
+        metadataOutput.setMetadataObjectsDelegate(nil, queue: nil)
+      }
+      if let videoOutput = output as? AVCaptureVideoDataOutput {
+        videoOutput.setSampleBufferDelegate(nil, queue: nil)
+      }
       captureSession.removeOutput(output)
     }
     photoOutput = nil

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -61,6 +61,15 @@ extension CameraSession {
 
     // Remove all outputs
     for output in captureSession.outputs {
+      // The following delegates are weak references
+      // so cleaning them up is not strictly necessary
+      // from a safety standpoint.
+      // It is good to mark that between this point
+      // and logic further down configureOutput()
+      // messages to delegate would be in an undefined
+      // state and with delegate == self the weak 
+      // references wouldn't be cleared during that 
+      // window.
       if let metadataOutput = output as? AVCaptureMetadataOutput {
         metadataOutput.setMetadataObjectsDelegate(nil, queue: nil)
       }

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -83,6 +83,18 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     NotificationCenter.default.removeObserver(self,
                                               name: AVAudioSession.interruptionNotification,
                                               object: AVAudioSession.sharedInstance)
+    let cameraCaptureSession = captureSession
+    CameraQueues.cameraQueue.async {
+      if cameraCaptureSession.isRunning {
+        cameraCaptureSession.stopRunning()
+      }
+    }
+    let cameraAudioSession = audioCaptureSession
+    CameraQueues.audioQueue.async {
+      if cameraAudioSession.isRunning {
+        cameraAudioSession.stopRunning()
+      }
+    }
   }
 
   /**
@@ -108,10 +120,13 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
    Any changes in here will be re-configured only if required, and under a lock (in this case, the serial cameraQueue DispatchQueue).
    The `configuration` object is a copy of the currently active configuration that can be modified by the caller in the lambda.
    */
-  func configure(_ lambda: @escaping (_ configuration: CameraConfiguration) throws -> Void) {
+  func configure(_ lambda: @escaping (_ configuration: CameraConfiguration) throws -> Void,
+                 completion: (() -> Void)? = nil) {
     initialize()
 
     VisionLogger.log(level: .info, message: "configure { ... }: Waiting for lock...")
+
+    let completionBlock = completion
 
     // Set up Camera (Video) Capture Session (on camera queue, acts like a lock)
     CameraQueues.cameraQueue.async {
@@ -121,10 +136,12 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
         try lambda(config)
       } catch CameraConfiguration.AbortThrow.abort {
         // call has been aborted and changes shall be discarded
+        completionBlock?()
         return
       } catch {
         // another error occured, possibly while trying to parse enums
         self.onConfigureError(error)
+        completionBlock?()
         return
       }
       let difference = CameraConfiguration.Difference(between: self.configuration, and: config)
@@ -244,7 +261,23 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
           }
         }
       }
+      completionBlock?()
     }
+  }
+
+  /**
+   Gracefully stop streaming and tear down any active outputs. Completion executes on the camera queue.
+   */
+  func shutdown(completion: (() -> Void)? = nil) {
+    configure({ config in
+      config.photo = .disabled
+      config.video = .disabled
+      config.audio = .disabled
+      config.codeScanner = .disabled
+      config.enableLocation = false
+      config.torch = .off
+      config.isActive = false
+    }, completion: completion)
   }
 
   /**
@@ -265,7 +298,7 @@ final class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     }
   }
 
-  public final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+  final func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
     switch captureOutput {
     case is AVCaptureVideoDataOutput:
       onVideoFrame(sampleBuffer: sampleBuffer, orientation: connection.orientation, isMirrored: connection.isVideoMirrored)

--- a/package/ios/React/CameraView.swift
+++ b/package/ios/React/CameraView.swift
@@ -141,7 +141,10 @@ public final class CameraView: UIView, CameraSessionDelegate, PreviewViewDelegat
   }
 
   deinit {
-    deactivateCameraSession()
+    // Allow phone to sleep
+    UIApplication.shared.isIdleTimerDisabled = false
+    // Bail on any in flight configure calls
+    currentConfigureCall.increment()
   }
 
   override public func layoutSubviews() {

--- a/package/ios/React/Utils/Counter.swift
+++ b/package/ios/React/Utils/Counter.swift
@@ -1,0 +1,34 @@
+import os.lock
+
+final class Counter {
+  /**
+    * https://forums.swift.org/t/atomic-property-wrapper-for-standard-library/30468/18
+  */
+  private var unfair_lock: os_unfair_lock_t
+  private var count = 1
+  init() {
+    unfair_lock = .allocate(capacity: 1)
+    unfair_lock.initialize(to: os_unfair_lock())
+  }
+  deinit {
+    unfair_lock.deinitialize(count: 1)
+    unfair_lock.deallocate()
+  }
+  private func lock() {
+    os_unfair_lock_lock(unfair_lock)
+  }
+  private func unlock() {
+    os_unfair_lock_unlock(unfair_lock)
+  }
+  func increment() -> Int {
+    lock()
+    defer { unlock() }
+    count &+= 1
+    return count
+  }
+  func check(_ count: Int) -> Bool {
+    lock()
+    defer { unlock() }
+    return self.count == count
+  }
+}


### PR DESCRIPTION
## What

This is a revision pass on the work done in https://github.com/mrousavy/react-native-vision-camera/pull/3650

Fix the navigation freeze on React Navigation/Fabric by shutting the camera session down deterministically when the view unmounts.

## Changes

Instead of introducing a new shutdown method revise use of configure

* Cleaning up capture sessions in deinit likely indicates some bookkeeping isn't completing and is likely to obscure rather than fix bugs
* Adding a completion handler to config adds a lot of complexity we can avoid and replace with a more correct DispatchGroup (the group doesn't notify until any async audio and location work complete)
* Switch existing DispatchTime usage for dropping redundant config calls to a simple monotonic counter that uses an unfair lock
* remove didScheduleShutdown as deactivateCameraSession() is safe to call repeatedly

## Tested on

iPhone 12 mini running 18.7.1

## Related issues

