### PR TITLE
fix: improve SkiaCameraCanvas layout handling

### DIFF
--- a/package/src/skia/SkiaCameraCanvas.tsx
+++ b/package/src/skia/SkiaCameraCanvas.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import { View } from 'react-native'
 import type { LayoutChangeEvent, ViewProps } from 'react-native'
 import type { CameraProps } from '../types/CameraProps'
 import type { ISharedValue } from 'react-native-worklets-core'
@@ -47,10 +48,12 @@ function SkiaCameraCanvasImpl({ offscreenTextures, resizeMode = 'cover', childre
   }, [])
 
   return (
-    <SkiaProxy.Canvas {...props} onLayout={onLayout} pointerEvents="none">
-      {children}
-      <SkiaProxy.Image x={0} y={0} width={width} height={height} fit={resizeMode} image={texture} />
-    </SkiaProxy.Canvas>
+    <View {...props} onLayout={onLayout} style={[props.style, { flex: 1 }]}>
+      <SkiaProxy.Canvas style={{ width, height }} pointerEvents="none">
+        {children}
+        <SkiaProxy.Image x={0} y={0} width={width} height={height} fit={resizeMode} image={texture} />
+      </SkiaProxy.Canvas>
+    </View>
   )
 }
 


### PR DESCRIPTION
## What

Wraps the Skia Canvas with a View component to provide better layout control and flexibility. The View handles layout events and styles, while the Canvas receives explicit width/height dimensions.

This fix is a backwards compatible patch for the post Skia 2.20 removal of `canvas.onLayout`.

## Changes

* Added `View` import from `react-native` to wrap the Skia Canvas component
* Moved `onLayout` and style props to the outer `View` wrapper
* Applied explicit `width` and `height` styles to the `SkiaProxy.Canvas` based on layout measurements
* Merged user-provided styles with `{ flex: 1 }` to maintain backwards compatibility
* Canvas now receives dimensions from parent View instead of handling layout directly

## Tested on

* Expo 53 + React 19 + Skia 2.3.10 (with no memory leak on iOS!)

## Related issues

* Fixes #3598

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->
