### PR TITLE
docs: add expo-modules guide for creating Frame Processor Plugins

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSORS_CREATE_OVERVIEW.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS_CREATE_OVERVIEW.mdx
@@ -200,7 +200,7 @@ Your Frame Processor Plugins have to be fast. Use the FPS Graph (`enableFpsGraph
 
 <br />
 
-#### 🚀 Create your first Frame Processor Plugin for [iOS](frame-processors-plugins-ios) or [Android](frame-processors-plugins-android)!
+#### 🚀 Create your first Frame Processor Plugin for [iOS](frame-processors-plugins-ios), [Android](frame-processors-plugins-android), or [Expo Modules](frame-processors-plugins-expo)!
 
 [1]: https://github.com/mrousavy/react-native-vision-camera/blob/main/package/src/types/Frame.ts
 [2]: https://github.com/mrousavy/react-native-vision-camera/blob/main/package/ios/FrameProcessors/Frame.h

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_ANDROID.mdx
@@ -203,4 +203,4 @@ The Frame Processor Plugin can be initialized from JavaScript using `VisionCamer
 
 <br />
 
-#### 🚀 Next section: [Finish creating your Frame Processor Plugin](frame-processors-plugins-final) (or [add iOS support to your Frame Processor Plugin](frame-processors-plugins-ios))
+#### 🚀 Next section: [Finish creating your Frame Processor Plugin](frame-processors-plugins-final) (or [add iOS support](frame-processors-plugins-ios), or [use Expo Modules](frame-processors-plugins-expo))

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_EXPO.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_EXPO.mdx
@@ -1,0 +1,194 @@
+---
+id: frame-processors-plugins-expo
+title: Creating Frame Processor Plugins
+sidebar_label: Creating Frame Processor Plugins (Expo)
+---
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+## Creating a Frame Processor Plugin with Expo Modules
+
+The Frame Processor Plugin API is built to be as extensible as possible, allowing you to create custom Frame Processor Plugins.
+In this guide, we will create a custom Face Detector Plugin that can be used from JavaScript, packaged as a local Expo Module.
+
+:::info
+This guide is specifically for projects using **Expo** with **Continuous Native Generation (CNG)**. If you're using a bare React Native project, refer to the [iOS](frame-processors-plugins-ios) or [Android](frame-processors-plugins-android) guides instead.
+:::
+
+## Step 1: Create the Expo Module
+
+Create a local Expo Module using the official CLI:
+
+```bash
+npx create-expo-module@latest --local face-detector-frame-processor
+```
+
+## Step 2: iOS Implementation
+
+### Configure the Podspec
+
+First, add VisionCamera as a dependency to link the required headers.
+
+Edit `ios/FaceDetectorFrameProcessor.podspec`:
+
+```ruby
+Pod::Spec.new do |s|
+  # ... standard setup ...
+  s.dependency "ExpoModulesCore"
+  # highlight-next-line
+  s.dependency "VisionCamera"  # Required for Frame Processor headers
+end
+```
+
+### Implement the Frame Processor
+
+Create `ios/FaceDetectorFrameProcessor.m`:
+
+```objc
+#import <VisionCamera/FrameProcessorPlugin.h>
+#import <VisionCamera/FrameProcessorPluginRegistry.h>
+#import <VisionCamera/VisionCameraProxyHolder.h>
+#import <VisionCamera/Frame.h>
+
+@interface FaceDetectorFrameProcessorPlugin : FrameProcessorPlugin
+
+@end
+
+@implementation FaceDetectorFrameProcessorPlugin
+
+- (instancetype _Nonnull)initWithProxy:(VisionCameraProxyHolder*)proxy
+                           withOptions:(NSDictionary* _Nullable)options {
+  self = [super initWithProxy:proxy withOptions:options];
+  return self;
+}
+
+- (id _Nullable)callback:(Frame* _Nonnull)frame
+           withArguments:(NSDictionary* _Nullable)arguments {
+  // code goes here
+  return nil;
+}
+
+// highlight-start
+VISION_EXPORT_FRAME_PROCESSOR(FaceDetectorFrameProcessorPlugin, detectFaces)
+// highlight-end
+
+@end
+```
+
+:::note
+The above example uses **Objective-C**. If you prefer to write your Frame Processor Plugin in **Swift**, follow the Swift implementation guide in the [iOS Frame Processor Plugin documentation](frame-processors-plugins-ios#manual-setup), and adapt it for use within your Expo Module.
+:::
+
+## Step 3: Android Implementation
+
+### Configure Gradle Dependencies
+
+Android requires explicit dependencies for VisionCamera.
+
+Edit `android/build.gradle`:
+
+```groovy
+// ... standard setup ...
+
+dependencies {
+  // highlight-start
+  implementation project(':react-native-vision-camera')
+  // highlight-end
+}
+```
+
+### Implement the Frame Processor Plugin
+
+Create `android/src/main/java/expo/modules/facedetectorframeprocessor/FaceDetectorFrameProcessorPlugin.java`:
+
+```java
+package expo.modules.facedetectorframeprocessor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.mrousavy.camera.frameprocessors.Frame;
+import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin;
+import com.mrousavy.camera.frameprocessors.VisionCameraProxy;
+
+import java.util.Map;
+
+public class FaceDetectorFrameProcessorPlugin extends FrameProcessorPlugin {
+    public FaceDetectorFrameProcessorPlugin(VisionCameraProxy proxy, @Nullable Map<String, Object> options) {
+        super();
+    }
+
+    @Nullable
+    @Override
+    public Object callback(@NonNull Frame frame, @Nullable Map<String, Object> arguments) {
+       // code goes here
+       return null;
+    }
+}
+```
+
+### Register frame processor plugin with Expo Module
+
+The Expo Module acts as a "loader" that registers the Frame Processor Plugin at startup.
+
+Create `android/src/main/java/expo/modules/facedetectorframeprocessor/FaceDetectorFrameProcessorModule.kt`:
+
+```kotlin
+package expo.modules.facedetectorframeprocessor
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import com.mrousavy.camera.frameprocessors.FrameProcessorPluginRegistry
+import com.mrousavy.camera.frameprocessors.VisionCameraProxy
+
+class FaceDetectorFrameProcessorModule : Module() {
+  // highlight-start
+  init {
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin(
+      "detectFaces"
+    ) { proxy: VisionCameraProxy?, options: Map<String?, Any?>? ->
+      FaceDetectorFrameProcessorPlugin(
+        proxy,
+        options
+      )
+    }
+  }
+  // highlight-end
+
+  override fun definition() = ModuleDefinition {
+    Name("FaceDetectorFrameProcessor")
+  }
+}
+```
+
+:::info
+The Expo Module uses the `init` block to register the Frame Processor Plugin. This ensures the plugin is available before any JavaScript code tries to use it.
+:::
+
+## Step 4: Configure Autolinking
+
+Update `expo-module.config.json` to register the native modules for both platforms:
+
+```json
+{
+  "platforms": [
+    "apple",
+    "android"
+  ],
+  "apple": {
+    "modules": [
+      "FaceDetectorFrameProcessorModule"
+    ]
+  },
+  "android": {
+    "modules": [
+      "expo.modules.facedetectorframeprocessor.FaceDetectorFrameProcessorModule"
+    ]
+  }
+}
+```
+
+<br />
+
+#### 🚀 Next section: [Finish creating your Frame Processor Plugin](frame-processors-plugins-final)

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_PLUGIN_IOS.mdx
@@ -126,4 +126,4 @@ VISION_EXPORT_SWIFT_FRAME_PROCESSOR(FaceDetectorFrameProcessorPlugin, detectFace
 
 <br />
 
-#### 🚀 Next section: [Finish creating your Frame Processor Plugin](frame-processors-plugins-final) (or [add Android support to your Frame Processor Plugin](frame-processors-plugins-android))
+#### 🚀 Next section: [Finish creating your Frame Processor Plugin](frame-processors-plugins-final) (or [add Android support](frame-processors-plugins-android), or [use Expo Modules](frame-processors-plugins-expo))

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -26,6 +26,7 @@ module.exports = {
               'guides/frame-processors-plugins-overview',
               'guides/frame-processors-plugins-ios',
               'guides/frame-processors-plugins-android',
+              'guides/frame-processors-plugins-expo',
               'guides/frame-processors-plugins-cpp',
               'guides/frame-processors-plugins-final',
             ]


### PR DESCRIPTION
## What

This PR adds a new documentation guide for creating Frame Processor Plugins using Expo Modules.

## Changes

- Added `FRAME_PROCESSOR_CREATE_PLUGIN_EXPO.mdx` guide
- Covers both iOS (Objective-C) and Android (Kotlin/Java) implementations

## Related issues

- #3504 