### PR TITLE
fix(ios): add @available(iOS 13.0, *) to UIApplication extension

### DIFF
--- a/package/ios/Core/Extensions/UIApplication+interfaceOrientation.swift
+++ b/package/ios/Core/Extensions/UIApplication+interfaceOrientation.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 
+@available(iOS 13.0, *)
 extension UIApplication {
   private var windowScene: UIWindowScene? {
     // Get all active scenes


### PR DESCRIPTION
UIWindowScene and connectedScenes APIs require iOS 13+, but the extension was missing the availability annotation, causing build errors when deployment target is below iOS 13.


## Summary

  Adds missing `@available(iOS 13.0, *)` annotation to `UIApplication+interfaceOrientation.swift`.

  ## Problem

  The extension uses `UIWindowScene` and `connectedScenes` APIs which require iOS 13+, but the extension is missing the availability annotation. This causes build errors:

  'UIWindowScene' is only available in iOS 13.0 or newer

  While the VisionCamera podspec declares iOS 12.4 as minimum, this file uses iOS 13+ APIs without proper guards. When CocoaPods compiles the pod, it uses the pod's declared minimum (12.4), not the app's deployment target, causing the build to fail.

  ## Why this matters

  Users may be running older Xcode versions (e.g., 16.x) because they're not yet ready to migrate to React Native's new architecture and need to stay on older RN versions. These setups are more likely to surface this build error.

  ## Alternative solution

  Instead of adding `@available`, the podspec minimum could be bumped to iOS 13.0. However, adding the annotation is more conservative and maintains backwards compatibility for any iOS
   12 users.

  ## Changes

  - `UIApplication+interfaceOrientation.swift`: Added `@available(iOS 13.0, *)` to the extension

## Related issues

#3648, #3404, #3040