### PR TITLE
feat(ios): add iPad multitasking camera support

### DIFF
--- a/package/ios/Core/CameraError.swift
+++ b/package/ios/Core/CameraError.swift
@@ -172,6 +172,7 @@ enum SessionError {
   case audioSessionFailedToActivate
   case audioInUseByOtherApp
   case hardwareCostTooHigh(cost: Float)
+  case multitaskingCameraNotSupported
 
   var code: String {
     switch self {
@@ -183,6 +184,8 @@ enum SessionError {
       return "audio-session-failed-to-activate"
     case .hardwareCostTooHigh:
       return "hardware-cost-too-high"
+    case .multitaskingCameraNotSupported:
+      return "multitasking-camera-not-supported"
     }
   }
 
@@ -198,6 +201,10 @@ enum SessionError {
       return "The session's hardware-cost is too high! (Expected: <=1.0, Received: \(cost)) " +
         "See https://developer.apple.com/documentation/avfoundation/avcapturesession/3950869-hardwarecost " +
         "for more information."
+    case .multitaskingCameraNotSupported:
+      return "The camera cannot be used while multitasking with other apps. " +
+        "This device does not support `isMultitaskingCameraAccessSupported`. " +
+        "Close other apps or use the app in full-screen mode."
     }
   }
 }


### PR DESCRIPTION
## Summary

  Adds support for iPad Split View / Slide Over multitasking:

  - Enable `isMultitaskingCameraAccessEnabled` on iOS 16+ devices that support it
  - Add session interruption observers for `AVCaptureSessionWasInterrupted`
  - Report `session/multitasking-camera-not-supported` error to JS when camera is interrupted due to `videoDeviceNotAvailableWithMultipleForegroundApps`
  - Auto-restart camera when interruption ends (user closes other apps)

  ## Problem

  On iPad, when the app is in Split View or Slide Over with another app, the camera shows a black screen. There's no feedback to the user about why the camera isn't working.

  ## Solution

  1. **For M-series iPads (M1, M2, M3, etc.):** Enable `isMultitaskingCameraAccessEnabled` so the camera works in split view
  2. **For older iPads:** Send a proper error (`session/multitasking-camera-not-supported`) to the JS side so apps can show a user-friendly message explaining the limitation

  ## Changes

  - `CameraSession.swift`: Added interruption observers and multitasking enable logic
  - `CameraError.swift`: Added new `SessionError.multitaskingCameraNotSupported` case

  ## Usage

  Apps can handle the error in `onError`:

  ```jsx
  <Camera
    onError={(error) => {
      if (error.code === 'session/multitasking-camera-not-supported') {
        // Show message: "Camera cannot run in split view on this iPad"
      }
    }}
  />
```

  ## Testing

  Tested on:
  - iPad Air 7th gen with M3 chip (iOS 18.6.2) - camera works in Split View
  - iPad Air 7th gen with M3 chip (iOS 26.2) - camera works in Split View and Slide Over view
  - iPad Pro 3rd gen with A12X chip (iOS 26.2) - receives `session/multitasking-camera-not-supported` error in Split View, camera auto-restarts when returning to full screen