### PR TITLE
fix: Handle Bayer/ProRes RAW formats on iPhone 16/17 for video recording

### DIFF
--- a/package/ios/Core/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
+++ b/package/ios/Core/Extensions/AVCaptureVideoDataOutput+recommendedVideoSettings.swift
@@ -8,6 +8,7 @@
 
 import AVFoundation
 import Foundation
+import VideoToolbox
 
 extension AVCaptureVideoDataOutput {
   private func supportsCodec(_ videoCodec: AVVideoCodecType, writingTo fileType: AVFileType) -> Bool {
@@ -15,29 +16,136 @@ extension AVCaptureVideoDataOutput {
     return availableCodecs.contains(videoCodec)
   }
 
+  /// Returns true if the given settings dictionary uses a non-standard codec
+  /// (anything other than H.264 or HEVC, e.g. ProRes, ProRes RAW).
+  private func isNonStandardCodec(in settings: [String: Any]?) -> Bool {
+    guard let codecValue = settings?[AVVideoCodecKey] as? String else { return false }
+    return codecValue != AVVideoCodecType.h264.rawValue && codecValue != AVVideoCodecType.hevc.rawValue
+  }
+
+  /// Returns true if the pixel format is a known 8-bit format (safe for HEVC Main profile)
+  private func isConfirmed8BitPixelFormat(_ pixelFormat: OSType?) -> Bool {
+    guard let pf = pixelFormat else { return false }
+    return [
+      kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, // 420v
+      kCVPixelFormatType_420YpCbCr8BiPlanarFullRange, // 420f
+      kCVPixelFormatType_32BGRA, // BGRA
+      kCVPixelFormatType_32ARGB, // ARGB
+      kCVPixelFormatType_32RGBA, // RGBA
+    ].contains(pf)
+  }
+
   /**
    Get the recommended options for an [AVAssetWriter] with the desired [RecordVideoOptions].
+
+   - Parameter options: The recording options (codec, file type, bitrate, etc.)
+   - Parameter devicePixelFormat: The actual pixel format from the device's active format.
+     This is critical for correct HEVC profile selection on devices with 10-bit sensors (iPhone 14 Pro+).
+   - Parameter forceH264: If true, force H.264 codec regardless of other settings.
    */
-  func recommendedVideoSettings(forOptions options: RecordVideoOptions) throws -> [String: Any] {
-    let settings: [String: Any]?
-    VisionLogger.log(level: .info, message: "Getting recommended video settings for \(options.fileType) file...")
-    if let videoCodec = options.codec {
-      // User passed a custom codec
-      if supportsCodec(videoCodec, writingTo: options.fileType) {
-        // The codec is supported, use it
-        VisionLogger.log(level: .info, message: "Using codec \(videoCodec)...")
-        settings = recommendedVideoSettings(forVideoCodecType: videoCodec, assetWriterOutputFileType: options.fileType)
-      } else {
-        // The codec is not supported, fall-back to default
-        VisionLogger.log(level: .info, message: "Codec \(videoCodec) is not supported, falling back to default...")
+  func recommendedVideoSettings(forOptions options: RecordVideoOptions,
+                                devicePixelFormat: OSType? = nil,
+                                forceH264: Bool = false) throws -> [String: Any] {
+    var settings: [String: Any]?
+    let isConfirmed8Bit = isConfirmed8BitPixelFormat(devicePixelFormat)
+
+    VisionLogger.log(level: .info,
+                     message: "Getting recommended video settings for \(options.fileType) file " +
+                       "(codec: \(options.codec?.rawValue ?? "default"), forceH264: \(forceH264))...")
+    VisionLogger.log(level: .info,
+                     message: "Device pixel format: \(devicePixelFormat.map { String(format: "0x%08X", $0) } ?? "nil"), " +
+                       "isConfirmed8Bit: \(isConfirmed8Bit)")
+
+    // If forceH264 is set, skip all other codecs and go straight to H.264
+    if forceH264 {
+      VisionLogger.log(level: .warning, message: "Forcing H.264 codec for maximum compatibility...")
+      if supportsCodec(.h264, writingTo: options.fileType) {
+        settings = recommendedVideoSettings(forVideoCodecType: .h264, assetWriterOutputFileType: options.fileType)
+        if let codecValue = settings?[AVVideoCodecKey] as? String, codecValue != AVVideoCodecType.h264.rawValue {
+          VisionLogger.log(level: .warning,
+                           message: "recommendedVideoSettings returned \(codecValue) instead of H.264, overriding...")
+          settings?[AVVideoCodecKey] = AVVideoCodecType.h264.rawValue
+        }
+      }
+    }
+
+    // If not forcing H.264 or H.264 isn't available, try normal codec selection
+    if settings == nil {
+      let preferredCodec: AVVideoCodecType = options.codec ?? .hevc
+
+      // Strategy 1: Try the preferred codec
+      if supportsCodec(preferredCodec, writingTo: options.fileType) {
+        VisionLogger.log(level: .info, message: "Using preferred codec \(preferredCodec.rawValue)...")
+        settings = recommendedVideoSettings(forVideoCodecType: preferredCodec, assetWriterOutputFileType: options.fileType)
+      }
+
+      // Strategy 2: If preferred codec returned ProRes settings or wasn't supported, try HEVC
+      if settings == nil || isNonStandardCodec(in: settings) {
+        if preferredCodec != .hevc && supportsCodec(.hevc, writingTo: options.fileType) {
+          VisionLogger.log(level: .warning, message: "Preferred codec returned non-standard settings. Trying HEVC...")
+          settings = recommendedVideoSettings(forVideoCodecType: .hevc, assetWriterOutputFileType: options.fileType)
+        }
+      }
+
+      // Strategy 3: Try H.264
+      if settings == nil || isNonStandardCodec(in: settings) {
+        if supportsCodec(.h264, writingTo: options.fileType) {
+          VisionLogger.log(level: .warning, message: "HEVC returned non-standard settings. Trying H.264...")
+          settings = recommendedVideoSettings(forVideoCodecType: .h264, assetWriterOutputFileType: options.fileType)
+        }
+      }
+
+      // Strategy 4: Default recommended settings
+      if settings == nil {
+        VisionLogger.log(level: .warning, message: "No codec-specific settings available. Using default...")
         settings = recommendedVideoSettingsForAssetWriter(writingTo: options.fileType)
       }
-    } else {
-      // User didn't pass a custom codec, just use default
-      settings = recommendedVideoSettingsForAssetWriter(writingTo: options.fileType)
     }
+
     guard var settings else {
       throw CameraError.capture(.createRecorderError(message: "Failed to get video settings!"))
+    }
+
+    // Safety check: On devices like iPhone 14 Pro+ and iPhone 16/17, even codec-specific
+    // recommended settings may return ProRes/ProRes RAW codec settings that require
+    // SMPTE RDD18 metadata (ISO sensitivity, white balance, etc.) which this library
+    // does not provide. Force-override any non-standard codec to a compatible one.
+    if isNonStandardCodec(in: settings) {
+      let originalCodec = settings[AVVideoCodecKey] as? String ?? "nil"
+      let fallbackCodec: AVVideoCodecType = (forceH264 || isConfirmed8Bit) ? .h264 : .hevc
+      VisionLogger.log(level: .warning,
+                       message: "Overriding non-standard codec \(originalCodec) → \(fallbackCodec.rawValue)")
+      settings[AVVideoCodecKey] = fallbackCodec.rawValue
+
+      // Strip any ProRes-specific compression properties that may be incompatible
+      if var compressionProps = settings[AVVideoCompressionPropertiesKey] as? [String: Any] {
+        let standardKeys: Set<String> = [
+          AVVideoAverageBitRateKey,
+          AVVideoExpectedSourceFrameRateKey,
+          AVVideoMaxKeyFrameIntervalKey,
+          AVVideoMaxKeyFrameIntervalDurationKey,
+          AVVideoProfileLevelKey,
+          AVVideoQualityKey,
+        ]
+        compressionProps = compressionProps.filter { standardKeys.contains($0.key) }
+        settings[AVVideoCompressionPropertiesKey] = compressionProps
+      }
+    }
+
+    // Set correct profile based on codec
+    let codecKey = settings[AVVideoCodecKey] as? String
+    if codecKey == AVVideoCodecType.hevc.rawValue {
+      var compressionProps = settings[AVVideoCompressionPropertiesKey] as? [String: Any] ?? [:]
+      // Use Main10 profile for HEVC - it can encode both 8-bit and 10-bit content
+      // with no quality loss. This eliminates -12905 errors entirely.
+      VisionLogger.log(level: .info, message: "Setting HEVC Main10 profile for universal compatibility")
+      compressionProps[AVVideoProfileLevelKey] = kVTProfileLevel_HEVC_Main10_AutoLevel as String
+      settings[AVVideoCompressionPropertiesKey] = compressionProps
+    } else if codecKey == AVVideoCodecType.h264.rawValue {
+      var compressionProps = settings[AVVideoCompressionPropertiesKey] as? [String: Any] ?? [:]
+      VisionLogger.log(level: .info, message: "Setting H.264 High profile for best compatibility")
+      compressionProps[AVVideoProfileLevelKey] = AVVideoProfileLevelH264HighAutoLevel
+      settings[AVVideoCompressionPropertiesKey] = compressionProps
     }
 
     if let bitRateOverride = options.bitRateOverride {
@@ -48,7 +156,9 @@ extension AVCaptureVideoDataOutput {
       }
       var compressionSettings = settings[AVVideoCompressionPropertiesKey] as? [String: Any] ?? [:]
       let currentBitRate = compressionSettings[AVVideoAverageBitRateKey] as? NSNumber
-      VisionLogger.log(level: .info, message: "Setting Video Bit-Rate from \(currentBitRate?.doubleValue.description ?? "nil") bps to \(bitsPerSecond) bps...")
+      VisionLogger.log(level: .info,
+                       message: "Setting Video Bit-Rate from \(currentBitRate?.doubleValue.description ?? "nil") bps " +
+                         "to \(bitsPerSecond) bps...")
 
       compressionSettings[AVVideoAverageBitRateKey] = NSNumber(value: bitsPerSecond)
       settings[AVVideoCompressionPropertiesKey] = compressionSettings

--- a/package/ios/Core/Extensions/FourCharCode+toString.swift
+++ b/package/ios/Core/Extensions/FourCharCode+toString.swift
@@ -14,4 +14,19 @@ extension FourCharCode {
     s.append(String(UnicodeScalar(self & 255)!))
     return s
   }
+
+  /// Convenience property for FourCC string representation
+  var fourCCString: String {
+    let bytes = [
+      UInt8((self >> 24) & 0xFF),
+      UInt8((self >> 16) & 0xFF),
+      UInt8((self >> 8) & 0xFF),
+      UInt8(self & 0xFF),
+    ]
+    let isPrintable = bytes.allSatisfy { $0 >= 32 && $0 < 127 }
+    if isPrintable, let str = String(bytes: bytes, encoding: .ascii) {
+      return str
+    }
+    return String(format: "0x%08X", self)
+  }
 }

--- a/package/ios/Core/Recording/Track.swift
+++ b/package/ios/Core/Recording/Track.swift
@@ -84,6 +84,18 @@ final class Track {
     timeline.resume()
   }
 
+  /**
+   Force-marks the track input as finished if it hasn't already been naturally finished
+   through the timeline. This is needed on devices (e.g. iPhone 14 Pro+, iPhone 16/17) where
+   the camera hardware stops delivering frames immediately after stop(), so no "late" frame
+   arrives to trigger the natural finish flow via TrackTimeline.
+   */
+  func ensureFinished() {
+    guard !timeline.isFinished else { return }
+    VisionLogger.log(level: .info, message: "Force-finishing \(type) track input (no late frames arrived after stop).")
+    assetWriterInput.markAsFinished()
+  }
+
   func append(buffer originalBuffer: CMSampleBuffer) throws {
     // 1. If the track is already finished (from a previous call), don't write anything.
     if timeline.isFinished {


### PR DESCRIPTION
On newer iPhones (14 Pro+, 16, 17), certain camera modes use Bayer/ProRes RAW pixel formats that cannot be encoded with standard HEVC/H.264 codecs without special SMPTE RDD18 metadata (ISO sensitivity, white balance, etc.).

This fix:
- Filters out Bayer formats when selecting camera formats
- Forces compatible output pixel formats (420f/420v/BGRA) during recording
- Falls back to H.264 when BGRA is the only available format
- Uses HEVC Main10 profile for universal compatibility with both 8-bit and 10-bit content
- Ensures track inputs are properly finished on devices that stop delivering frames immediately
- Handles stopRecording() gracefully when no recording is in progress

Fixes video recording errors -11875 (missing SMPTE RDD18 metadata) and -12905 (HEVC profile mismatch) on affected devices.

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
