### PR TITLE
feat(ios): remove simulator camera restriction

### DIFF
--- a/package/ios/Core/CameraError.swift
+++ b/package/ios/Core/CameraError.swift
@@ -76,7 +76,6 @@ enum DeviceError {
   case microphoneUnavailable
   case lowLightBoostNotSupported
   case focusNotSupported
-  case notAvailableOnSimulator
   case pixelFormatNotSupported(targetFormats: [FourCharCode], availableFormats: [FourCharCode])
 
   var code: String {
@@ -95,8 +94,6 @@ enum DeviceError {
       return "low-light-boost-not-supported"
     case .focusNotSupported:
       return "focus-not-supported"
-    case .notAvailableOnSimulator:
-      return "camera-not-available-on-simulator"
     case .pixelFormatNotSupported:
       return "pixel-format-not-supported"
     }
@@ -118,8 +115,6 @@ enum DeviceError {
       return "The currently selected camera device does not support focusing!"
     case .microphoneUnavailable:
       return "The microphone was unavailable."
-    case .notAvailableOnSimulator:
-      return "The Camera is not available on the iOS Simulator!"
     case let .pixelFormatNotSupported(targetFormats: targetFormats, availableFormats: availableFormats):
       let tried = targetFormats.map { $0.toString() }
       let found = availableFormats.map { $0.toString() }

--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -24,11 +24,6 @@ extension CameraSession {
     }
     videoDeviceInput = nil
 
-    #if targetEnvironment(simulator)
-      // iOS Simulators don't have Cameras
-      throw CameraError.device(.notAvailableOnSimulator)
-    #endif
-
     guard let cameraId = configuration.cameraId else {
       throw CameraError.device(.noDevice)
     }


### PR DESCRIPTION
## Summary
- Removes the compile-time `#if targetEnvironment(simulator)` check that throws `CameraError.device(.notAvailableOnSimulator)`
- Removes the now-unused `DeviceError.notAvailableOnSimulator` error case
- Enables camera functionality with tools like [RocketSim](https://www.rocketsim.app/) that provide virtual camera support in the iOS Simulator

## Motivation
Tools like RocketSim now support virtual cameras in the iOS Simulator, making it possible to test camera functionality without a physical device. The current restriction prevents this useful development workflow.

## Test plan
- [x] Build and run on iOS Simulator with RocketSim virtual camera enabled
- [x] Verify camera functionality works as expected