### PR TITLE
docs: replace scanFaces with detectFaces in docs and comments

### DIFF
--- a/docs/docs/guides/FRAME_PROCESSORS_CREATE_OVERVIEW.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS_CREATE_OVERVIEW.mdx
@@ -101,7 +101,7 @@ Frame Processors can also accept parameters, following the same type convention 
 ```ts
 const frameProcessor = useFrameProcessor((frame) => {
   'worklet'
-  const faces = scanFaces(frame, { accuracy: 'fast' })
+  const faces = detectFaces(frame, { accuracy: 'fast' })
 }, [])
 ```
 

--- a/docs/docs/guides/FRAME_PROCESSORS_INTERACTING.mdx
+++ b/docs/docs/guides/FRAME_PROCESSORS_INTERACTING.mdx
@@ -72,7 +72,7 @@ const onFaceDetected = Worklets.createRunOnJS((face: Face) => {
 
 const frameProcessor = useFrameProcessor((frame) => {
   'worklet'
-  const faces = scanFaces(frame)
+  const faces = detectFaces(frame)
   if (faces.length > 0) {
     onFaceDetected(faces[0])
   }

--- a/docs/docs/guides/FRAME_PROCESSOR_CREATE_FINAL.mdx
+++ b/docs/docs/guides/FRAME_PROCESSOR_CREATE_FINAL.mdx
@@ -11,14 +11,14 @@ To make the Frame Processor Plugin available to the Frame Processor Worklet Runt
 ```ts
 import { VisionCameraProxy, Frame } from 'react-native-vision-camera'
 
-const plugin = VisionCameraProxy.initFrameProcessorPlugin('scanFaces')
+const plugin = VisionCameraProxy.initFrameProcessorPlugin('detectFaces')
 
 /**
  * Scans faces.
  */
-export function scanFaces(frame: Frame): object {
+export function detectFaces(frame: Frame): object {
   'worklet'
-  if (plugin == null) throw new Error('Failed to load Frame Processor Plugin "scanFaces"!')
+  if (plugin == null) throw new Error('Failed to load Frame Processor Plugin "detectFaces"!')
   return plugin.call(frame)
 }
 ```
@@ -32,7 +32,7 @@ function App() {
   const frameProcessor = useFrameProcessor((frame) => {
     'worklet'
     // highlight-next-line
-    const faces = scanFaces(frame)
+    const faces = detectFaces(frame)
     console.log(`Faces in Frame: ${faces}`)
   }, [])
 

--- a/package/src/frame-processors/VisionCameraProxy.ts
+++ b/package/src/frame-processors/VisionCameraProxy.ts
@@ -36,8 +36,8 @@ interface TVisionCameraProxy {
    * @param options (optional) Options, as a native dictionary, passed to the constructor/init-function of the native plugin.
    * @example
    * ```ts
-   * const plugin = VisionCameraProxy.initFrameProcessorPlugin('scanFaces', { model: 'fast' })
-   * if (plugin == null) throw new Error("Failed to load scanFaces plugin!")
+   * const plugin = VisionCameraProxy.initFrameProcessorPlugin('detectFaces', { model: 'fast' })
+   * if (plugin == null) throw new Error("Failed to load detectFaces plugin!")
    * ```
    */
   initFrameProcessorPlugin(name: string, options: Record<string, ParameterType>): FrameProcessorPlugin | undefined

--- a/package/src/hooks/useFrameProcessor.ts
+++ b/package/src/hooks/useFrameProcessor.ts
@@ -34,7 +34,7 @@ export function createFrameProcessor(frameProcessor: (frame: Frame) => void): Re
  * ```ts
  * const frameProcessor = useFrameProcessor((frame) => {
  *   'worklet'
- *   const faces = scanFaces(frame)
+ *   const faces = detectFaces(frame)
  *   console.log(`Faces: ${faces}`)
  * }, [])
  * ```

--- a/package/src/skia/useSkiaFrameProcessor.ts
+++ b/package/src/skia/useSkiaFrameProcessor.ts
@@ -156,7 +156,7 @@ function getSurfaceSize(frame: Frame): Size {
  * const offscreenTextures = Worklets.createSharedValue<SkImage[]>([])
  * const frameProcessor = createSkiaFrameProcessor((frame) => {
  *   'worklet'
- *   const faces = scanFaces(frame)
+ *   const faces = detectFaces(frame)
  *
  *   frame.render()
  *   for (const face of faces) {
@@ -317,7 +317,7 @@ export function createSkiaFrameProcessor(
  * ```ts
  * const frameProcessor = useSkiaFrameProcessor((frame) => {
  *   'worklet'
- *   const faces = scanFaces(frame)
+ *   const faces = detectFaces(frame)
  *
  *   frame.render()
  *   for (const face of faces) {

--- a/package/src/types/CameraProps.ts
+++ b/package/src/types/CameraProps.ts
@@ -391,7 +391,7 @@ export interface CameraProps extends ViewProps {
    * ```tsx
    * const frameProcessor = useFrameProcessor((frame) => {
    *   'worklet'
-   *   const faces = scanFaces(frame)
+   *   const faces = detectFaces(frame)
    *   console.log(`Faces: ${faces}`)
    * }, [])
    *


### PR DESCRIPTION
## What
This PR standardizes usage of example function scanFaces and detectFaces into detectFaces.

## Changes
* Changes all occurrences of scanFaces into detectFaces in docs, then comments.
* This prevents linkage errors for people who are copying docs.