### PR TITLE
feat(ios): add external microphone support and input routing

### DIFF
--- a/package/ios/Core/CameraSession+Audio.swift
+++ b/package/ios/Core/CameraSession+Audio.swift
@@ -25,9 +25,25 @@ extension CameraSession {
       try audioSession.updateCategory(AVAudioSession.Category.playAndRecord,
                                       mode: .videoRecording,
                                       options: [.mixWithOthers,
+                                                .allowBluetooth,
                                                 .allowBluetoothA2DP,
                                                 .defaultToSpeaker,
                                                 .allowAirPlay])
+
+      try audioSession.setPreferredSampleRate(48000)
+
+      // Prefer external microphone if available (USB/Lightning > Bluetooth > built-in)
+      if let availableInputs = audioSession.availableInputs {
+        let preferredInput = availableInputs.first(where: { input in
+          [.usbAudio, .externalLine, .thunderbolt].contains(input.portType)
+        }) ?? availableInputs.first(where: { input in
+          [.bluetoothHFP, .bluetoothLE].contains(input.portType)
+        })
+        if let preferredInput = preferredInput {
+          VisionLogger.log(level: .info, message: "Preferring external audio input: \(preferredInput.portName) (\(preferredInput.portType.rawValue))")
+          try audioSession.setPreferredInput(preferredInput)
+        }
+      }
 
       if #available(iOS 14.5, *) {
         // prevents the audio session from being interrupted by a phone call


### PR DESCRIPTION
## Problem

When a user plugs in an external microphone (USB, Lightning, Thunderbolt) or pairs a Bluetooth headset, VisionCamera currently ignores it and records from the built-in mic instead.

Two root causes:
1. **`.allowBluetooth` is missing** from the audio session options. `.allowBluetoothA2DP` only routes Bluetooth output (speakers/headphones) — Bluetooth HFP input (microphone on a headset) requires `.allowBluetooth`.
2. **No input routing logic** — even with the right options set, iOS does not automatically prefer an external mic. `setPreferredInput()` must be called explicitly.

## Changes

**`ios/Core/CameraSession+Audio.swift`** — `activateAudioSession()`

- Add `.allowBluetooth` to audio session options to enable Bluetooth HFP input
- Call `setPreferredSampleRate(48000)` for professional audio quality
- After configuring the session, scan `availableInputs` and call `setPreferredInput()` to route to the best available source:
  - **Priority 1:** USB / Lightning / Thunderbolt
  - **Priority 2:** Bluetooth HFP / LE
  - **Fallback:** built-in mic (iOS default, no action needed)

## Testing

- Record a video with no external mic → built-in mic is used (unchanged behavior)
- Plug in a USB-C/Lightning mic → external mic is used automatically
- Pair a Bluetooth headset → Bluetooth HFP mic is used
- Unplug/disconnect external mic mid-session → iOS falls back to built-in (existing system behavior)