### PR TITLE
fix(ios): activate audio session synchronously before recording

### DIFF
--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -107,8 +107,8 @@ extension CameraSession {
            let audioOutput = self.audioOutput,
            let audioInput = self.audioDeviceInput {
           VisionLogger.log(level: .info, message: "Enabling Audio for Recording...")
-          // Activate Audio Session asynchronously
-          CameraQueues.audioQueue.async {
+          // Activate Audio Session synchronously to ensure mic is ready before recording starts
+          CameraQueues.audioQueue.sync {
             do {
               try self.activateAudioSession()
             } catch {


### PR DESCRIPTION
## Problem

The current code activates the audio session **asynchronously** on `audioQueue` before recording starts:

```swift
// Activate Audio Session asynchronously
CameraQueues.audioQueue.async {
  try self.activateAudioSession()
}
```

This creates a race condition: `recordingSession.start()` is called immediately after dispatching the async block, so AVAssetWriter can begin writing before the microphone is fully activated. The result is **missing or silent audio at the start of recordings**, particularly noticeable on the first recording after app launch or after the audio session has been deactivated.

## Fix

Change `audioQueue.async` → `audioQueue.sync` so the microphone is fully activated before `recordingSession.start()` proceeds.

```swift
// Activate Audio Session synchronously to ensure mic is ready before recording starts
CameraQueues.audioQueue.sync {
  try self.activateAudioSession()
}
```

**`ios/Core/CameraSession+Video.swift`** — one line change in `startRecording()`.

## Impact

- No behavioral change for normal recordings — the sync wait is brief (audio session activation is fast)
- Eliminates dropped audio frames at recording start
- Consistent with how the session is deactivated (already `async`, which is safe on teardown)