### PR TITLE
Migrate StyleSheet.absoluteFillObject

### DIFF
--- a/package/src/FpsGraph.tsx
+++ b/package/src/FpsGraph.tsx
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgb(243, 74, 77)',
   },
   centerContainer: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     justifyContent: 'center',
     alignItems: 'center',
   },


### PR DESCRIPTION
## What
Migrate StyleSheet.absoluteFillObject which has been removed in react-native 0.85: https://github.com/facebook/react-native/releases/tag/v0.85.0-rc.0

## Changes
Replace removed StyleSheet.absoluteFillObject with StyleSheet.absoluteFill which under the hood exports the exact same object.

## Tested on
Not tested