### PR TITLE
fix(ios): resolve Swift compiler warnings

### DIFF
--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -83,7 +83,6 @@ final class CameraConfiguration {
   /**
    Throw this to abort calls to configure { ... } and apply no changes.
    */
-  @frozen
   enum AbortThrow: Error {
     case abort
   }
@@ -148,7 +147,6 @@ final class CameraConfiguration {
     }
   }
 
-  @frozen
   enum OutputConfiguration<T: Equatable>: Equatable {
     case disabled
     case enabled(config: T)

--- a/package/ios/Core/Recording/Track.swift
+++ b/package/ios/Core/Recording/Track.swift
@@ -11,7 +11,6 @@ import Foundation
 
 // MARK: - TrackType
 
-@frozen
 enum TrackType {
   case audio
   case video

--- a/package/ios/Core/Types/AutoFocusSystem.swift
+++ b/package/ios/Core/Types/AutoFocusSystem.swift
@@ -9,7 +9,6 @@
 import AVFoundation
 import Foundation
 
-@frozen
 enum AutoFocusSystem: String, JSUnionValue {
   case contrastDetection = "contrast-detection"
   case phaseDetection = "phase-detection"

--- a/package/ios/Core/Types/Flash.swift
+++ b/package/ios/Core/Types/Flash.swift
@@ -11,7 +11,6 @@ import Foundation
 /**
  A Flash for Photo capture.
  */
-@frozen
 enum Flash: String, JSUnionValue {
   /**
    Flash never fires.

--- a/package/ios/Core/Types/HardwareLevel.swift
+++ b/package/ios/Core/Types/HardwareLevel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-@frozen
 enum HardwareLevel: String, JSUnionValue {
   case full
 

--- a/package/ios/Core/Types/OutputOrientation.swift
+++ b/package/ios/Core/Types/OutputOrientation.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-@frozen
 enum OutputOrientation: String, JSUnionValue {
   /**
    Automatically rotate outputs based on device physical rotation (even if screen-lock is on)

--- a/package/ios/Core/Types/PixelFormat.swift
+++ b/package/ios/Core/Types/PixelFormat.swift
@@ -9,7 +9,6 @@
 import AVFoundation
 import Foundation
 
-@frozen
 enum PixelFormat: String, JSUnionValue {
   case yuv
   case rgb

--- a/package/ios/Core/Types/QualityBalance.swift
+++ b/package/ios/Core/Types/QualityBalance.swift
@@ -9,7 +9,6 @@
 import AVFoundation
 import Foundation
 
-@frozen
 enum QualityBalance: String, JSUnionValue {
   case speed
   case balanced

--- a/package/ios/Core/Types/ResizeMode.swift
+++ b/package/ios/Core/Types/ResizeMode.swift
@@ -12,7 +12,6 @@ import Foundation
 /**
  A ResizeMode used for the PreviewView.
  */
-@frozen
 enum ResizeMode: String, JSUnionValue {
   /**
    Keep aspect ratio, but fill entire parent view (centered).

--- a/package/ios/Core/Types/ShutterType.swift
+++ b/package/ios/Core/Types/ShutterType.swift
@@ -11,7 +11,6 @@ import Foundation
 /**
  Represents the type of media that was captured in a `onShutter` event
  */
-@frozen
 enum ShutterType: String, JSUnionValue {
   /**
    A photo was captured on this `onShutter` event

--- a/package/ios/Core/Types/Torch.swift
+++ b/package/ios/Core/Types/Torch.swift
@@ -12,7 +12,6 @@ import Foundation
 /**
  A Torch used for permanent flash.
  */
-@frozen
 enum Torch: String, JSUnionValue {
   /**
    Torch (flash unit) is always off.

--- a/package/ios/Core/Types/VideoStabilizationMode.swift
+++ b/package/ios/Core/Types/VideoStabilizationMode.swift
@@ -9,7 +9,6 @@
 import AVFoundation
 import Foundation
 
-@frozen
 enum VideoStabilizationMode: String, JSUnionValue {
   case off
   case standard

--- a/package/ios/React/CameraViewManager.swift
+++ b/package/ios/React/CameraViewManager.swift
@@ -111,7 +111,7 @@ final class CameraViewManager: RCTViewManager {
   @objc
   final func getLocationPermissionStatus() -> String {
     #if VISION_CAMERA_ENABLE_LOCATION
-      let status = CLLocationManager.authorizationStatus()
+      let status = CLLocationManager().authorizationStatus
       return status.descriptor
     #else
       return CLAuthorizationStatus.restricted.descriptor


### PR DESCRIPTION
## Summary
- Remove `@frozen` attribute from 13 internal (non-public) enums that produce "@frozen has no effect on non-public enums" warnings on every build
- Replace deprecated `CLLocationManager.authorizationStatus()` class method with the instance property `.authorizationStatus` (deprecated since iOS 14.0)

## Test plan
- [ ] Build the iOS project and verify no more `@frozen` warnings
- [ ] Verify `getLocationPermissionStatus()` still returns correct values
- [ ] Run existing test suite