### PR TITLE
[ios] Use runtime camera checks on simulator for camera availability

### DIFF
--- a/package/ios/Core/CameraSession+Configuration.swift
+++ b/package/ios/Core/CameraSession+Configuration.swift
@@ -25,8 +25,10 @@ extension CameraSession {
     videoDeviceInput = nil
 
     #if targetEnvironment(simulator)
-      // iOS Simulators don't have Cameras
-      throw CameraError.device(.notAvailableOnSimulator)
+      // On Simulator, only throw if no runtime video source is available.
+      if AVCaptureDevice.default(for: .video) == nil {
+        throw CameraError.device(.notAvailableOnSimulator)
+      }
     #endif
 
     guard let cameraId = configuration.cameraId else {


### PR DESCRIPTION
## What
Replace the unconditional simulator camera block with a runtime `AVCaptureDevice` availability check so simulator fallbacks only apply when no runtime video device exists.

## Changes
- Replace the unconditional `#if targetEnvironment(simulator)` throw in `configureDevice(...)` with a simulator-only runtime check.
- Keep throwing `device/camera-not-available-on-simulator` when `AVCaptureDevice.default(for: .video)` is unavailable.
- Allow the normal camera configuration path when a runtime video device is present.
- Clarify the inline simulator comment to describe the runtime source-availability behavior.

## Tested on
- Run example app on Simulator and iPhone, verified the error is thrown on Simulator and the normal code path works as expected on the device.

## Related issues
- Inspired by [https://github.com/expo/expo/pull/44159](https://github.com/expo/expo/pull/44159).