### PR TITLE
fix: Remove `createNormalizedMeteringPoint(...)` 1:1 export- prefer `VisionCamera.createNormalizedMeteringPoint(...)`

### DIFF
--- a/docs/content/docs/tap-to-focus.mdx
+++ b/docs/content/docs/tap-to-focus.mdx
@@ -60,7 +60,7 @@ const meteringPoint = preview.createMeteringPoint(viewX, viewY)
 
 ..or from normalized Camera Coordinates (`0.0` to `1.0`) via [`createNormalizedMeteringPoint(...)`](/api/react-native-vision-camera/hybrid-objects/CameraFactory#createnormalizedmeteringpoint):
 ```ts
-const meteringPoint = VisionCamera.createMeteringPoint(0.5, 0.5)
+const meteringPoint = VisionCamera.createNormalizedMeteringPoint(0.5, 0.5)
 ```
 
 Then, start a Focus Metering Action to the specific [`MeteringPoint`](/api/react-native-vision-camera/hybrid-objects/MeteringPoint) via [`CameraController.focusTo(...)`](/api/react-native-vision-camera/hybrid-objects/CameraController#focusto)):

--- a/packages/react-native-vision-camera-skia/src/views/SkiaCamera.tsx
+++ b/packages/react-native-vision-camera-skia/src/views/SkiaCamera.tsx
@@ -20,7 +20,6 @@ import {
   type CameraSession,
   type CameraSessionConfig,
   type CameraVideoOutput,
-  createNormalizedMeteringPoint,
   type FocusOptions,
   type Frame,
   type MeteringMode,
@@ -34,6 +33,7 @@ import {
   useFrameOutput,
   useOrientation,
   type VideoPixelFormat,
+  VisionCamera,
 } from 'react-native-vision-camera'
 import { createSynchronizable, scheduleOnRN } from 'react-native-worklets'
 import { renderToTexture, type SkiaOnFrameState } from '../render'
@@ -355,7 +355,7 @@ function SkiaCameraImpl({
         throw new Error(`Cannot focus - Camera is null!`)
       }
       const transformedPoint = this.convertViewPointToNormalizedPoint(viewPoint)
-      const meteringPoint = createNormalizedMeteringPoint(
+      const meteringPoint = VisionCamera.createNormalizedMeteringPoint(
         transformedPoint.x,
         transformedPoint.y,
       )

--- a/packages/react-native-vision-camera/src/VisionCamera.ts
+++ b/packages/react-native-vision-camera/src/VisionCamera.ts
@@ -3,6 +3,8 @@ import type { CameraFactory } from './specs/CameraFactory.nitro'
 
 /**
  * The native VisionCamera module.
+ *
+ * This is the entry point for the entire VisionCamera imperative API.
  */
 export const VisionCamera =
   NitroModules.createHybridObject<CameraFactory>('CameraFactory')

--- a/packages/react-native-vision-camera/src/createNormalizedMeteringPoint.ts
+++ b/packages/react-native-vision-camera/src/createNormalizedMeteringPoint.ts
@@ -1,6 +1,0 @@
-import { VisionCamera } from './VisionCamera'
-
-// TODO: We need to expose more from VisionCamera and also copy over the docs, but `VisionCamera` sounds super internal...
-
-export const createNormalizedMeteringPoint: (typeof VisionCamera)['createNormalizedMeteringPoint'] =
-  VisionCamera.createNormalizedMeteringPoint.bind(VisionCamera)

--- a/packages/react-native-vision-camera/src/index.ts
+++ b/packages/react-native-vision-camera/src/index.ts
@@ -1,6 +1,5 @@
 // Devices API
 export * from './CameraDevices'
-export * from './createNormalizedMeteringPoint'
 export * from './devices/getCameraDevice'
 // Hooks
 export * from './hooks/useAsyncRunner'


### PR DESCRIPTION
unnecessary re-export.