### PR TITLE
fix: Add 'worklet' directive to getCurrentThreadMarker

### DIFF
--- a/packages/react-native-vision-camera-worklets/src/getCurrentThreadMarker.ts
+++ b/packages/react-native-vision-camera-worklets/src/getCurrentThreadMarker.ts
@@ -1,5 +1,6 @@
 import { HybridWorkletQueueFactory } from './internal/HybridWorkletQueueFactory'
 
 export function getCurrentThreadMarker(): number {
+    "worklet";
   return HybridWorkletQueueFactory.getCurrentThreadMarker()
 }


### PR DESCRIPTION
fixes #3744 