### PR TITLE
fix(android): close ImageProxy in HybridPhoto.toImage() to prevent CameraX buffer pool exhaustion

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
@@ -67,9 +67,21 @@ class HybridPhoto(
   override val memorySize: Long
     get() = image.width * image.height * 4L
 
+  // Tracks whether the underlying ImageProxy has already been closed. toImage()
+  // now closes it eagerly to prevent CameraX buffer pool exhaustion; dispose()
+  // consults this flag so it does not double-close.
+  private var imageClosed: Boolean = false
+
+  private fun closeImageIfOpen() {
+    if (!imageClosed) {
+      image.close()
+      imageClosed = true
+    }
+  }
+
   override fun dispose() {
     super.dispose()
-    image.close()
+    closeImageIfOpen()
     cachedPixelBuffer?.dispose()
   }
 
@@ -163,15 +175,22 @@ class HybridPhoto(
           postRotate(orientationToApply.degrees.toFloat())
         }
       }
-    if (matrix.isIdentity) {
+    val result = if (matrix.isIdentity) {
       // No transforms needed! Just return
-      return HybridImage(bitmap)
+      HybridImage(bitmap)
     } else {
       // We need to transform the Bitmap
       val transformedBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, false)
       bitmap.recycle()
-      return HybridImage(transformedBitmap)
+      HybridImage(transformedBitmap)
     }
+    // Close the ImageProxy now that the pixel data has been copied into the Bitmap.
+    // Without this, the CameraX ImageCapture buffer pool fills up under rapid
+    // captures and the next capturePhoto() call hangs until the JVM GCs this
+    // HybridPhoto (at which point dispose() closes it). Since toBitmap() fully
+    // consumes the ImageProxy, it is safe to release the buffer here.
+    closeImageIfOpen()
+    return result
   }
 
   override fun toImageAsync(): Promise<HybridImageSpec> {


### PR DESCRIPTION
## Summary

On Android, `HybridPhoto.toImage()` copies pixels into a Bitmap via `image.toBitmap()` but never closes the underlying `ImageProxy`. CameraX's `ImageCapture` has a bounded buffer pool (4-5 slots depending on config); unreleased `ImageProxy` instances stay held until the `HybridPhoto` is garbage collected. Under rapid consecutive captures, JS GC does not run fast enough to release buffers before the next `capturePhoto()` call, the pool saturates, and `capturePhoto()` promises start hanging silently with no rejection or error.

## Reproduction

Android device, v5.x, rapid captures:

```ts
for (let i = 0; i < 10; i++) {
  const photo = await photoOutput.capturePhoto({ flashMode: 'off' }, {});
  const image = await photo.toImageAsync();
  // ... use image ...
  await new Promise((r) => setTimeout(r, 600));
}
```

Observed: iteration 5 (or thereabouts) hangs on \`capturePhoto()\`. No rejection, no error. Camera preview freezes. The only recovery is to unmount the camera session.

Same pattern runs to completion on iOS because \`AVCapturePhoto\` does not have an equivalent bounded buffer pool.

Workaround on the caller side: \`photo.dispose()\` after \`toImageAsync()\` releases the ImageProxy immediately via the existing \`HybridPhoto.dispose()\` override. A 50-capture stress run passes 50/50 with this workaround, fails at ~5/50 without it.

## Root cause

\`HybridPhoto.toImage()\` at \`packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt\`:

\`\`\`kotlin
override fun toImage(): HybridImageSpec {
  val bitmap = image.toBitmap()  // pixels extracted into Bitmap
  val matrix = Matrix().apply { /* ... */ }
  if (matrix.isIdentity) {
    return HybridImage(bitmap)
  } else {
    val transformedBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, false)
    bitmap.recycle()
    return HybridImage(transformedBitmap)
  }
  // image.close() is never called here. The ImageProxy is only released
  // when HybridPhoto.dispose() runs, which relies on JS GC.
}
\`\`\`

By the time \`image.toBitmap()\` returns, the pixel data lives in the new Bitmap. The \`ImageProxy\` is no longer needed by either branch.

## Fix (this PR)

Close the ImageProxy at the end of \`toImage()\` once the pixels have been copied into the Bitmap. \`dispose()\` is guarded with an \`imageClosed\` flag so it does not double-close if the user calls both.

\`\`\`kotlin
override fun toImage(): HybridImageSpec {
  val bitmap = image.toBitmap()
  val matrix = Matrix().apply { /* ... */ }
  val result = if (matrix.isIdentity) {
    HybridImage(bitmap)
  } else {
    val transformedBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, false)
    bitmap.recycle()
    HybridImage(transformedBitmap)
  }
  closeImageIfOpen()
  return result
}
\`\`\`

Behavior change: after \`toImage()\`, subsequent methods that read from \`image\` (\`saveToFile\`, \`getFileData\`, \`getPixelBuffer\`) will throw \`IllegalStateException\`. In practice \`toImage()\` and \`saveToFile()\` serve the same purpose (get the photo into a usable form) and are rarely combined on the same Photo, so most call sites are unaffected.

## Alternatives considered

- **HybridImage takes ownership of the ImageProxy.** Pass the proxy into \`HybridImage\` and close it in \`HybridImage.dispose()\`. Keeps the Photo usable after \`toImage()\` at the cost of extending the lifecycle across two hybrid objects. Happy to take this approach instead if preferred.
- **Document the close requirement.** Require callers to dispose the Photo after \`toImageAsync()\`. Places the burden on every user; does not fix the bug for the natural \"await toImage, drop Photo\" pattern.

## Tests / verification

Stress harness: 50 consecutive \`capturePhoto()\` + \`toImageAsync()\` iterations with 600ms between captures on a physical Android device.

- Without any fix: fails at ~5/50 (\`capturePhoto\` hangs indefinitely).
- With manual \`photo.dispose()\` after \`toImageAsync()\` in JS: 50/50 pass.
- With this PR (native fix, no JS workaround): 50/50 pass.

Happy to adjust approach if Option B (HybridImage ownership) is preferred.