### PR TITLE
docs: Add note about disposing `Photo` when no longer used

### DIFF
--- a/docs/content/docs/a-photo.mdx
+++ b/docs/content/docs/a-photo.mdx
@@ -16,6 +16,7 @@ A [`Photo`](/api/react-native-vision-camera/hybrid-objects/Photo) holds an in-me
 ```ts
 const photo = ...
 const image = await photo.toImageAsync()
+photo.dispose()
 ```
 
 The `image` can then be displayed in a [`<NitroImage />`](https://github.com/mrousavy/react-native-nitro-image) view:
@@ -32,6 +33,15 @@ function App() {
     />
   )
 }
+```
+
+### Dispose when no longer used
+
+As with all in-memory objects holding large native memory ([`Photo`](/api/react-native-vision-camera/hybrid-objects/Photo), [`Frame`](/api/react-native-vision-camera/hybrid-objects/Frame), [`Image`](https://github.com/mrousavy/react-native-nitro-image) or more) make sure to `dispose()` the [`Photo`](/api/react-native-vision-camera/hybrid-objects/Photo) once you are no longer using it, as otherwise the JS Runtime might not immediately delete it, possibly exhausting system resources or even stalling the Camera preventing further captures.
+
+```ts
+const photo = ...
+photo.dispose()
 ```
 
 ### Saving to a File

--- a/docs/content/docs/photo-output.mdx
+++ b/docs/content/docs/photo-output.mdx
@@ -80,7 +80,14 @@ const photo = await photoOutput.capturePhoto(
   { /*  options  */ },
   { /* callbacks */ }
 )
+// ...
+photo.dispose()
 ```
+
+> [!WARNING]
+> Make sure to [dispose the `Photo` when you no longer use it](a-photo#dispose-when-no-longer-used), as otherwise the JS Runtime might not immediately delete it, possibly exhausting system resources or stalling the Camera:
+
+See ["A Photo"](a-photo) to understand how the [`Photo`](/api/react-native-vision-camera/hybrid-objects/Photo) type works, and how to use it.
 
 #### Capturing Photos to a file
 
@@ -94,6 +101,3 @@ const { filePath } = await photoOutput.capturePhotoToFile(
 ```
 
 See [`CapturePhotoSettings`](/api/react-native-vision-camera/interfaces/CapturePhotoSettings) for a full list of configuration options, and [`CapturePhotoCallbacks`](/api/react-native-vision-camera/interfaces/CapturePhotoCallbacks) for a full list of callbacks for the capture method.
-
-> [!TIP]
-> See ["A Photo"](a-photo) to understand how the [`Photo`](/api/react-native-vision-camera/hybrid-objects/Photo) type works, and how to use it.

--- a/packages/react-native-vision-camera/src/specs/instances/Photo.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/instances/Photo.nitro.ts
@@ -21,6 +21,13 @@ import type { Depth } from './Depth.nitro'
  * display that using `react-native-nitro-image`'s
  * `<NitroImage />` component.
  *
+ * @note
+ * As with all in-memory objects holding large native memory
+ * such as Photos, Frames, Images or more, make sure to
+ * {@linkcode Photo.dispose | dispose()} the Photo once you
+ * are no longer using it, as otherwise the JS Runtime might
+ * not immediately delete it, possibly exhausting system resources.
+ *
  * @example
  * Display the Photo to the user using `react-native-nitro-image`:
  * ```tsx
@@ -31,6 +38,7 @@ import type { Depth } from './Depth.nitro'
  *   const photo = await photoOutput.capturePhoto({}, {})
  *   const img = await photo.toImageAsync()
  *   setImage(img)
+ *   photo.dispose()
  * }
  *
  * return <NitroImage style={{ flex: 1 }} image={image} />
@@ -43,6 +51,7 @@ import type { Depth } from './Depth.nitro'
  * const takePhoto = async () => {
  *   const photo = await photoOutput.capturePhoto({}, {})
  *   const image = await photo.toImageAsync()
+ *   photo.dispose()
  * }
  * ```
  * @example
@@ -54,6 +63,7 @@ import type { Depth } from './Depth.nitro'
  * const bytes = new Uint8Array(encodedData)
  * const data = Skia.Data.fromBytes(bytes)
  * const skiaImage = Skia.Image.MakeImageFromEncoded(data)
+ * photo.dispose()
  * ```
  */
 export interface Photo

--- a/packages/react-native-vision-camera/src/specs/outputs/CameraPhotoOutput.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/outputs/CameraPhotoOutput.nitro.ts
@@ -273,12 +273,19 @@ export interface CameraPhotoOutput extends CameraOutput {
    * as CameraX does not properly support in-memory Photos for formats like RAW yet.
    * See https://issuetracker.google.com/u/3/issues/482079661 for more information.
    *
+   * @note
+   * The {@linkcode Photo} has to be `dispose()`'d after it
+   * is no longer used, as otherwise the JS Runtime might not
+   * immediately delete it, possibly exhausting system resources.
+   *
    * @example
    * ```ts
    * const photo = await photoOutput.capturePhoto(
    *   { flashMode: 'on' },
    *   {}
    * )
+   * // ...
+   * photo.dispose()
    * ```
    */
   capturePhoto(


### PR DESCRIPTION
Clarifies the misunderstanding in https://github.com/mrousavy/react-native-vision-camera/pull/3750

Photos have to be disposed too, they hold 30+MB of native memory.

```ts
photo.dispose()
```