### PR TITLE
fix: Fix crash in BarcodeScanner on `deliversPreviewSizedOutputBuffers`

### DIFF
--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
@@ -66,6 +66,7 @@ class HybridBarcodeScannerOutput: HybridCameraOutputSpec, NativeCameraOutput {
     self.output.setSampleBufferDelegate(delegate, queue: queue)
     self.output.alwaysDiscardsLateVideoFrames = true
     if #available(iOS 17.0, *), options.outputResolution != .full {
+      self.output.automaticallyConfiguresOutputBufferDimensions = false
       self.output.deliversPreviewSizedOutputBuffers = true
     }
   }


### PR DESCRIPTION
As per docs:

```swift
/**
 @property deliversPreviewSizedOutputBuffers
 @abstract
    Indicates whether the receiver is currently configured to deliver preview sized buffers.
 
 @discussion
    If you wish to manually set deliversPreviewSizedOutputBuffers, you must first set automaticallyConfiguresOutputBufferDimensions to NO. When deliversPreviewSizedOutputBuffers is set to YES, auto focus, exposure, and white balance changes are quicker. AVCaptureVideoDataOutput assumes that the buffers are being used for on-screen preview rather than recording.

    When AVCaptureDevice.activeFormat supports ProRes Raw video, setting deliversPreviewSizedOutputBuffers gives out buffers with 422 format that can be used for proxy video recording.
 */
@available(iOS 13.0, *)
open var deliversPreviewSizedOutputBuffers: Bool
```

We need to set `automaticallyConfiguresOutputBufferDimensions` to false first.

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3752

