### PR TITLE
fix(ios): restore UIImage.Orientation references after rename

### DIFF
--- a/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/UI+CameraOrientation.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/UI+CameraOrientation.swift
@@ -8,7 +8,7 @@ import UIKit
 import VisionCamera
 
 extension CameraOrientation {
-  func toUIImageOrientation(isMirrored: Bool = false) -> UIImage.CameraOrientation {
+  func toUIImageOrientation(isMirrored: Bool = false) -> UIImage.Orientation {
     switch self {
     case .up:
       return isMirrored ? .upMirrored : .up

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCapturePhoto+getMediaSampleMetadata.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCapturePhoto+getMediaSampleMetadata.swift
@@ -16,7 +16,7 @@ extension AVCapturePhoto {
       throw RuntimeError.error(
         withMessage: "Photo did not contain a `kCGImagePropertyOrientation` metadata key!")
     }
-    let uiOrientation = try UIImage.CameraOrientation(fromExif: exifOrientation)
+    let uiOrientation = try UIImage.Orientation(fromExif: exifOrientation)
     let orientation = CameraOrientation(uiOrientation: uiOrientation)
     let isMirrored = uiOrientation.isMirrored
     let timestamp = self.timestamp

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVDepthData+toUIImage.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVDepthData+toUIImage.swift
@@ -10,7 +10,7 @@ import Foundation
 import NitroModules
 
 extension AVDepthData {
-  func toUIImage(orientation: UIImage.CameraOrientation) throws -> UIImage {
+  func toUIImage(orientation: UIImage.Orientation) throws -> UIImage {
     // No-copy create CIImage from AVDepthData
     guard let ciImage = CIImage(depthData: self) else {
       throw RuntimeError.error(withMessage: "Failed to convert Depth to Image!")

--- a/packages/react-native-vision-camera/ios/Extensions/CIImage+toUIImage.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/CIImage+toUIImage.swift
@@ -12,7 +12,7 @@ import NitroModules
 extension CIImage {
   private static let context = CIContext(options: [.useSoftwareRenderer: false])
 
-  func toUIImage(orientation: UIImage.CameraOrientation) throws -> UIImage {
+  func toUIImage(orientation: UIImage.Orientation) throws -> UIImage {
     // Copy the CIImage into a CGImage (render)
     guard
       let cgImage = Self.context.createCGImage(

--- a/packages/react-native-vision-camera/ios/Extensions/Converters/UI+CameraOrientation.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/Converters/UI+CameraOrientation.swift
@@ -9,7 +9,7 @@ import Foundation
 import NitroModules
 
 extension CameraOrientation {
-  init(uiOrientation: UIImage.CameraOrientation) {
+  init(uiOrientation: UIImage.Orientation) {
     switch uiOrientation {
     case .up, .upMirrored:
       self = .up
@@ -20,7 +20,7 @@ extension CameraOrientation {
     case .right, .rightMirrored:
       self = .right
     @unknown default:
-      fatalError("UIImage.CameraOrientation has unknown value: \(uiOrientation)")
+      fatalError("UIImage.Orientation has unknown value: \(uiOrientation)")
     }
   }
   init(interfaceOrientation: UIInterfaceOrientation) {
@@ -40,7 +40,7 @@ extension CameraOrientation {
     }
   }
 
-  func toUIImageOrientation(isMirrored: Bool) -> UIImage.CameraOrientation {
+  func toUIImageOrientation(isMirrored: Bool) -> UIImage.Orientation {
     switch self {
     case .up:
       return isMirrored ? .upMirrored : .up

--- a/packages/react-native-vision-camera/ios/Extensions/CoreMedia/CMSampleBuffer+toUIImage.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/CoreMedia/CMSampleBuffer+toUIImage.swift
@@ -10,7 +10,7 @@ import Foundation
 import NitroModules
 
 extension CMSampleBuffer {
-  func toUIImage(orientation: UIImage.CameraOrientation) throws -> UIImage {
+  func toUIImage(orientation: UIImage.Orientation) throws -> UIImage {
     guard let imageBuffer else {
       throw RuntimeError.error(withMessage: "This Frame does not have a PixelBuffer!")
     }

--- a/packages/react-native-vision-camera/ios/Public/MediaSampleMetadata.swift
+++ b/packages/react-native-vision-camera/ios/Public/MediaSampleMetadata.swift
@@ -32,7 +32,7 @@ public struct MediaSampleMetadata {
     self.isMirrored = isMirrored
   }
 
-  var uiImageOrientation: UIImage.CameraOrientation {
+  var uiImageOrientation: UIImage.Orientation {
     return orientation.toUIImageOrientation(isMirrored: isMirrored)
   }
 }


### PR DESCRIPTION
## Summary

The rename in #3754 (`Orientation` to `CameraOrientation`) also replaced references to UIKit's nested `UIImage.Orientation` enum, which caused iOS builds to fail with:

```
'CameraOrientation' is not a member type of class 'UIKit.UIImage'
```

`UIImage` is an Apple UIKit class and its nested enum is literally named `Orientation`, so those references must remain `UIImage.Orientation`. `ios/Extensions/UIImageOrientation+exif.swift` already kept the correct name, which is how the partial rename was spotted.

## Repro

Any iOS build against v5.0.3:

```bash
pod install && xcodebuild
```

Xcode stops at the first file it hits (`UI+CameraOrientation.swift:12`) but 8 occurrences across 7 files are affected.

## Change

Mechanical replacement of `UIImage.CameraOrientation` with `UIImage.Orientation` in:

- `packages/react-native-vision-camera/ios/Extensions/Converters/UI+CameraOrientation.swift` (3 occurrences, incl. the `fatalError` message string)
- `packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCapturePhoto+getMediaSampleMetadata.swift`
- `packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVDepthData+toUIImage.swift`
- `packages/react-native-vision-camera/ios/Extensions/CoreMedia/CMSampleBuffer+toUIImage.swift`
- `packages/react-native-vision-camera/ios/Extensions/CIImage+toUIImage.swift`
- `packages/react-native-vision-camera/ios/Public/MediaSampleMetadata.swift`
- `packages/react-native-vision-camera-barcode-scanner/ios/Extensions/UI+CameraOrientation.swift`

Total: 7 files changed, 9 insertions(+), 9 deletions(-).

The vision-camera-owned `extension CameraOrientation` blocks and return/argument types that use the renamed VC type are unchanged. Only the references to Apple's `UIImage.Orientation` are restored.