### PR TITLE
fix(build): remove postinstall tsc hook (regression of #3275)

### DIFF
--- a/packages/react-native-vision-camera/package.json
+++ b/packages/react-native-vision-camera/package.json
@@ -30,7 +30,6 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "tsc || exit 0;",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf android/build node_modules/**/android/build lib",
     "build": "tsc",


### PR DESCRIPTION
## Summary

This re-applies the fix from #3275, which was lost in the 5.x rewrite.

The `postinstall: "tsc || exit 0;"` script in `packages/react-native-vision-camera/package.json` runs `tsc` on every consumer install. When `tsc` is on the consumer's `PATH` (commonly the case on Linux CI runners and Windows dev machines), the unprovisioned `tsc` walks up the consumer's tree to find a `tsconfig.json`, then emits compiled `.js` files next to every `.ts` source it can reach. The `|| exit 0` swallows the error so install "succeeds", leaving stray files behind in the consumer's project. On macOS dev machines `tsc` usually isn't on the postinstall `PATH`, so the bug is invisible there — which is why it slipped past the 5.x rewrite.

## History

- Issue #3274 (Nov 2024) reported the same symptom for v4.6.x.
- PR #3275 (Nov 2024) fixed it by removing the same `postinstall` line. Merged.
- The line came back in the 5.x rewrite (currently present in 5.0.4) and the bug returned.

## Real-world impact

In a downstream monorepo CI (`software-mansion/react-native-executorch`), bumping vision-camera from `5.0.0-beta.7` to `5.0.4` triggered Yarn's per-version build state cache to invalidate, which re-ran the `postinstall`, which then emitted compiled `.js` files across the whole monorepo. The lint step (which uses a `**/*.{js,ts,tsx}` glob) then tripped on the stray files. Diagnosis and reproduction in [software-mansion/react-native-executorch#1088](https://github.com/software-mansion/react-native-executorch/pull/1088).

## Why removing is correct

The package ships pre-built `lib/` (per the `files` field and `main: "lib/index"`), so consumers never need to compile anything on install. The existing `build: "tsc"` script remains for explicit invocation by maintainers and release tooling.

For maintainers who want compilation on git-URL installs (rare), `prepare: "tsc"` would be the right hook (runs in the package's own dev workflow and on git installs but NOT for npm-registry consumers). Happy to do that variant in a follow-up if preferred — but matching the original #3275 fix seems best.

## Test plan

- [x] `packages/react-native-vision-camera/package.json` no longer has the `postinstall` line.
- [x] `lib/` is unchanged in the published package — `npm i react-native-vision-camera` continues to give consumers a fully-built package.
- [ ] Reviewer to verify on Windows and Linux that `npm i react-native-vision-camera` no longer creates stray `.js` files in the consumer project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)