### PR TITLE
fix: Throw error if output/preview is connected to a different Camera Session

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureSession+addOutputWithNoConnections.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureSession+addOutputWithNoConnections.swift
@@ -14,6 +14,9 @@ extension AVCaptureSession {
     case let hybridOutput as any NativeCameraOutput:
       // It's a normal AVCaptureOutput
       let output = hybridOutput.output
+      guard output.connections.isEmpty else {
+        throw RuntimeError.error(withMessage: "The given Output \"\(output)\" is already connected to a different Camera Session!")
+      }
       guard canAddOutput(output) else {
         throw RuntimeError.error(
           withMessage: "Output \"\(output)\" cannot be added to Camera Session!")
@@ -22,6 +25,9 @@ extension AVCaptureSession {
       addOutputWithNoConnections(output)
     case let hybridPreview as any NativePreviewViewOutput:
       // It's an AVVideoPreviewLayer - we need to set its .session
+      guard hybridPreview.previewLayer.session == nil else {
+        throw RuntimeError.error(withMessage: "The given Preview Output \"\(hybridPreview)\" is already connected to a different Camera Session!")
+      }
       logger.info("Adding Preview \(hybridPreview.previewLayer)...")
       hybridPreview.previewLayer.setSessionWithNoConnection(self)
     default:


### PR DESCRIPTION
If an output is already connected to a different Camera Session, we now detect this and throw before FigCaptureSession internally crashes.

This will be more useful to debug the issue in #3773, once we have a good repro for that

- Closes https://github.com/mrousavy/react-native-vision-camera/issues/3773