### PR TITLE
feat: Add `onSubjectAreaChanged` listener

### DIFF
--- a/apps/simple-camera/src/components/CameraView.tsx
+++ b/apps/simple-camera/src/components/CameraView.tsx
@@ -67,6 +67,10 @@ export function CameraView({ device, constraints, ...props }: Props) {
         style={styles.camera}
         device={device}
         constraints={constraints}
+        onSubjectAreaChanged={() => {
+          console.log(`Subject Area Changed! Resetting Focus...`)
+          camera.current?.resetFocus()
+        }}
         onSessionConfigSelected={(config) => {
           console.log(`Given Constraints:`, constraints)
           console.log(`Resolved SessionConfig:`, config.toString())

--- a/docs/content/docs/locking-ae-af-awb.mdx
+++ b/docs/content/docs/locking-ae-af-awb.mdx
@@ -63,12 +63,8 @@ if (controller.device.supportsWhiteBalanceLocking) {
 ### Getting current values
 
 At any point in time you can get the Camera's current Exposure, Focus or White-Balance values.
-For example, to figure out how far away the current focus point is, simply get the current [`lensPosition`](/api/react-native-vision-camera/hybrid-objects/CameraController#lensposition):
 
-```ts
-const controller = ...
-console.log(controller.lensPosition) // between 0...1
-```
+#### Getting current Exposure Duration/ISO
 
 To get the current exposure values (for example to use VisionCamera as a light meter) use [`exposureDuration`](/api/react-native-vision-camera/hybrid-objects/CameraController#exposureduration) or [`iso`](/api/react-native-vision-camera/hybrid-objects/CameraController#iso):
 
@@ -77,6 +73,17 @@ const controller = ...
 console.log(controller.exposureDuration)
 console.log(controller.iso)
 ```
+
+#### Getting current Focus Lens Position
+
+To figure out how far away the current focus point is, simply get the current [`lensPosition`](/api/react-native-vision-camera/hybrid-objects/CameraController#lensposition):
+
+```ts
+const controller = ...
+console.log(controller.lensPosition) // between 0...1
+```
+
+#### Getting current White Balance Gains
 
 Lastly, the [`CameraController`](/api/react-native-vision-camera/hybrid-objects/CameraController) also exposes its current White-Balance Gains via [`whiteBalanceGains`](/api/react-native-vision-camera/hybrid-objects/CameraController#whitebalancegains):
 
@@ -116,3 +123,56 @@ To reset Exposure/Focus/White-Balance back to auto, use [`resetFocus()`](/api/re
 const controller = ...
 await controller.resetFocus()
 ```
+
+### Reacting to subject area changes
+
+Once you lock AE/AF/AWB, the Camera keeps those values frozen no matter what the user points the device at. That's usually fine for a deliberate tap-to-focus, but if the user pans the Camera away from the subject, the scene becomes very under- or over-exposed and out-of-focus - the locked values no longer make sense.
+
+VisionCamera fires a [`onSubjectAreaChanged()`](/api/react-native-vision-camera/hybrid-objects/CameraController#addsubjectareachangedlistener) listener whenever the scene substantially changes - for example, when the focus point drifts off the previously-focused subject. You can listen for this event and automatically reset AE/AF/AWB back to continuously auto-adjusting.
+
+<Tabs items={["<Camera /> (view)", "useCamera(...) (hook)", "CameraSession (imperative)"]} groupId="api-style" persist>
+<Tab value="<Camera /> (view)">
+```tsx
+function App() {
+  const camera = useRef<Camera>(null)
+
+  return (
+    <Camera
+      style={StyleSheet.absoluteFill}
+      isActive={true}
+      device="back"
+      ref={camera}
+      // [!code ++:3]
+      onSubjectAreaChanged={() => {
+        camera.current?.resetFocus()
+      }}
+    />
+  )
+}
+```
+</Tab>
+<Tab value="useCamera(...) (hook)">
+```tsx
+function App() {
+  const camera = useCamera({
+    isActive: true,
+    device: 'back',
+    // [!code ++:3]
+    onSubjectAreaChanged: () => {
+      camera?.resetFocus()
+    }
+  })
+}
+```
+</Tab>
+<Tab value="CameraSession (imperative)">
+```tsx
+const session = ...
+const controller = await session.configure(...)
+// [!code ++:3]
+const listener = controller.addSubjectAreaChangedListener(() => {
+  controller.resetFocus()
+})
+```
+</Tab>
+</Tabs>

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -179,7 +179,7 @@ class HybridCameraController(
     }
   }
 
-  override fun setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Unit)?) {
+  override fun addSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Unit)?) {
     // TODO: CameraX does not yet support subject area changed listeners.
     //       Feature Request: https://issuetracker.google.com/issues/505643406
   }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -179,9 +179,12 @@ class HybridCameraController(
     }
   }
 
-  override fun addSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Unit)?) {
+  override fun addSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Unit)): ListenerSubscription {
     // TODO: CameraX does not yet support subject area changed listeners.
     //       Feature Request: https://issuetracker.google.com/issues/505643406
+    return ListenerSubscription {
+      // noop
+    }
   }
 
   override fun setExposureBias(exposure: Double): Promise<Unit> {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -179,6 +179,11 @@ class HybridCameraController(
     }
   }
 
+  override fun setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Unit)?) {
+    // TODO: CameraX does not yet support subject area changed listeners.
+    //       Feature Request: https://issuetracker.google.com/issues/505643406
+  }
+
   override fun setExposureBias(exposure: Double): Promise<Unit> {
     return Promise.async {
       camera.cameraControl

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -270,10 +270,8 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
   }
 
   func addSubjectAreaChangedListener(onSubjectAreaChanged: @escaping () -> Void) -> ListenerSubscription {
-    let remove = SubjectAreaMonitor.addObserver(device: captureDevice) {
-      onSubjectAreaChanged()
-    }
-    return ListenerSubscription(remove: remove)
+    return SubjectAreaMonitor.addObserver(device: captureDevice,
+                                          onSubjectAreaDidChange: onSubjectAreaChanged)
   }
 
   func setTorchMode(mode: TorchMode, strength: Double?) -> Promise<Void> {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -270,8 +270,9 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
   }
 
   func addSubjectAreaChangedListener(onSubjectAreaChanged: @escaping () -> Void) -> ListenerSubscription {
-    return SubjectAreaMonitor.addObserver(device: captureDevice,
-                                          onSubjectAreaDidChange: onSubjectAreaChanged)
+    return SubjectAreaMonitor.addObserver(
+      device: captureDevice,
+      onSubjectAreaDidChange: onSubjectAreaChanged)
   }
 
   func setTorchMode(mode: TorchMode, strength: Double?) -> Promise<Void> {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -269,20 +269,13 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
     }
   }
 
-  func setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Void)?) throws {
-    // TODO: Properly implement this so that this supports multiple listeners and can be removed in JS? `observer`?
-    try captureDevice.lockForConfiguration()
-    captureDevice.isSubjectAreaChangeMonitoringEnabled = true
-    captureDevice.unlockForConfiguration()
-    
-    let observer = NotificationCenter.default.addObserver(
-      forName: AVCaptureDevice.subjectAreaDidChangeNotification,
-      object: captureDevice,
-      queue: .current) { [weak self] notification in
-        onSubjectAreaChanged?.()
-      }
+  func addSubjectAreaChangedListener(onSubjectAreaChanged: @escaping () -> Void) -> ListenerSubscription {
+    let remove = SubjectAreaMonitor.addObserver(device: captureDevice) {
+      onSubjectAreaChanged()
+    }
+    return ListenerSubscription(remove: remove)
   }
-  
+
   func setTorchMode(mode: TorchMode, strength: Double?) -> Promise<Void> {
     return captureDevice.withLock(queue) {
       // 1. Ensure we have a torch

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import Foundation
 import NitroModules
 
-class HybridCameraController: HybridCameraControllerSpec, NativeCameraController {
+final class HybridCameraController: HybridCameraControllerSpec, NativeCameraController {
   let device: any HybridCameraDeviceSpec
   let queue: DispatchQueue
   let captureDevice: AVCaptureDevice
@@ -269,6 +269,20 @@ class HybridCameraController: HybridCameraControllerSpec, NativeCameraController
     }
   }
 
+  func setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Void)?) throws {
+    // TODO: Properly implement this so that this supports multiple listeners and can be removed in JS? `observer`?
+    try captureDevice.lockForConfiguration()
+    captureDevice.isSubjectAreaChangeMonitoringEnabled = true
+    captureDevice.unlockForConfiguration()
+    
+    let observer = NotificationCenter.default.addObserver(
+      forName: AVCaptureDevice.subjectAreaDidChangeNotification,
+      object: captureDevice,
+      queue: .current) { [weak self] notification in
+        onSubjectAreaChanged?.()
+      }
+  }
+  
   func setTorchMode(mode: TorchMode, strength: Double?) -> Promise<Void> {
     return captureDevice.withLock(queue) {
       // 1. Ensure we have a torch

--- a/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
+++ b/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
@@ -38,12 +38,10 @@ enum SubjectAreaMonitor {
     let id = UUID()
 
     lock.lock()
-    let entry = entries[key] ?? Entry(device: device)
-    let wasEmpty = entry.tokens.isEmpty
-    entries[key] = entry
-    lock.unlock()
+    defer { lock.unlock() }
 
-    if wasEmpty {
+    let entry = entries[key] ?? Entry(device: device)
+    if entry.tokens.isEmpty {
       setMonitoringEnabled(on: device, enabled: true)
     }
 
@@ -54,10 +52,8 @@ enum SubjectAreaMonitor {
     ) { _ in
       handler()
     }
-
-    lock.lock()
     entry.tokens[id] = token
-    lock.unlock()
+    entries[key] = entry
 
     return {
       removeObserver(deviceKey: key, id: id)
@@ -66,22 +62,19 @@ enum SubjectAreaMonitor {
 
   private static func removeObserver(deviceKey: String, id: UUID) {
     lock.lock()
+    defer { lock.unlock() }
+
     guard let entry = entries[deviceKey],
           let token = entry.tokens.removeValue(forKey: id)
     else {
-      lock.unlock()
       return
     }
-    let shouldDisable = entry.tokens.isEmpty
-    let device = entry.device
-    if shouldDisable {
-      entries.removeValue(forKey: deviceKey)
-    }
-    lock.unlock()
 
     NotificationCenter.default.removeObserver(token)
-    if shouldDisable {
-      setMonitoringEnabled(on: device, enabled: false)
+
+    if entry.tokens.isEmpty {
+      setMonitoringEnabled(on: entry.device, enabled: false)
+      entries.removeValue(forKey: deviceKey)
     }
   }
 

--- a/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
+++ b/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
@@ -1,0 +1,97 @@
+//
+//  SubjectAreaMonitor.swift
+//  VisionCamera
+//
+//  Created by Marc Rousavy on 23.04.26.
+//
+
+import AVFoundation
+
+/// Coordinates `AVCaptureDevice.isSubjectAreaChangeMonitoringEnabled` across
+/// multiple observers and multiple `HybridCameraController` instances per device.
+///
+/// The underlying AVFoundation flag is a single-writer state on the device —
+/// enabling it for one observer and disabling it for another would clobber
+/// whichever ran last. This type refcounts observers per device so that
+/// monitoring is only enabled while at least one observer is registered,
+/// and only disabled when the final observer is removed.
+enum SubjectAreaMonitor {
+  private final class Entry {
+    let device: AVCaptureDevice
+    var tokens: [UUID: NSObjectProtocol] = [:]
+    init(device: AVCaptureDevice) { self.device = device }
+  }
+
+  private static var entries: [String: Entry] = [:]
+  private static let lock = NSLock()
+
+  /// Registers an observer for `subjectAreaDidChangeNotification` on the given device.
+  ///
+  /// Enables `isSubjectAreaChangeMonitoringEnabled` on the device if this is the
+  /// first observer. Returns a closure that, when invoked, removes this observer
+  /// and disables monitoring iff it was the last one across all callers.
+  static func addObserver(
+    device: AVCaptureDevice,
+    handler: @escaping @Sendable () -> Void
+  ) -> () -> Void {
+    let key = device.uniqueID
+    let id = UUID()
+
+    lock.lock()
+    let entry = entries[key] ?? Entry(device: device)
+    let wasEmpty = entry.tokens.isEmpty
+    entries[key] = entry
+    lock.unlock()
+
+    if wasEmpty {
+      setMonitoringEnabled(on: device, enabled: true)
+    }
+
+    let token = NotificationCenter.default.addObserver(
+      forName: AVCaptureDevice.subjectAreaDidChangeNotification,
+      object: device,
+      queue: nil
+    ) { _ in
+      handler()
+    }
+
+    lock.lock()
+    entry.tokens[id] = token
+    lock.unlock()
+
+    return {
+      removeObserver(deviceKey: key, id: id)
+    }
+  }
+
+  private static func removeObserver(deviceKey: String, id: UUID) {
+    lock.lock()
+    guard let entry = entries[deviceKey],
+          let token = entry.tokens.removeValue(forKey: id)
+    else {
+      lock.unlock()
+      return
+    }
+    let shouldDisable = entry.tokens.isEmpty
+    let device = entry.device
+    if shouldDisable {
+      entries.removeValue(forKey: deviceKey)
+    }
+    lock.unlock()
+
+    NotificationCenter.default.removeObserver(token)
+    if shouldDisable {
+      setMonitoringEnabled(on: device, enabled: false)
+    }
+  }
+
+  private static func setMonitoringEnabled(on device: AVCaptureDevice, enabled: Bool) {
+    do {
+      try device.lockForConfiguration()
+      device.isSubjectAreaChangeMonitoringEnabled = enabled
+      device.unlockForConfiguration()
+    } catch {
+      logger.error("Failed to set subject area monitoring to \(enabled): \(error)")
+    }
+  }
+}

--- a/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
+++ b/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
@@ -83,6 +83,7 @@ enum SubjectAreaMonitor {
       try device.lockForConfiguration()
       device.isSubjectAreaChangeMonitoringEnabled = enabled
       device.unlockForConfiguration()
+      logger.info("\(enabled ? "Enabled" : "Disabled") subject area change monitoring.")
     } catch {
       logger.error("Failed to set subject area monitoring to \(enabled): \(error)")
     }

--- a/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
+++ b/packages/react-native-vision-camera/ios/Utils/SubjectAreaMonitor.swift
@@ -28,19 +28,19 @@ enum SubjectAreaMonitor {
   /// Registers an observer for `subjectAreaDidChangeNotification` on the given device.
   ///
   /// Enables `isSubjectAreaChangeMonitoringEnabled` on the device if this is the
-  /// first observer. Returns a closure that, when invoked, removes this observer
-  /// and disables monitoring iff it was the last one across all callers.
+  /// first observer. Returns a `ListenerSubscription`, which removes this observer
+  /// and disables monitoring if it was the last one across all callers.
   static func addObserver(
     device: AVCaptureDevice,
-    handler: @escaping @Sendable () -> Void
-  ) -> () -> Void {
-    let key = device.uniqueID
-    let id = UUID()
+    onSubjectAreaDidChange: @escaping () -> Void
+  ) -> ListenerSubscription {
+    let deviceKey = device.uniqueID
+    let listenerID = UUID()
 
     lock.lock()
     defer { lock.unlock() }
 
-    let entry = entries[key] ?? Entry(device: device)
+    let entry = entries[deviceKey] ?? Entry(device: device)
     if entry.tokens.isEmpty {
       setMonitoringEnabled(on: device, enabled: true)
     }
@@ -50,22 +50,22 @@ enum SubjectAreaMonitor {
       object: device,
       queue: nil
     ) { _ in
-      handler()
+      onSubjectAreaDidChange()
     }
-    entry.tokens[id] = token
-    entries[key] = entry
+    entry.tokens[listenerID] = token
+    entries[deviceKey] = entry
 
-    return {
-      removeObserver(deviceKey: key, id: id)
+    return ListenerSubscription {
+      removeObserver(deviceKey: deviceKey, listenerID: listenerID)
     }
   }
 
-  private static func removeObserver(deviceKey: String, id: UUID) {
+  private static func removeObserver(deviceKey: String, listenerID: UUID) {
     lock.lock()
     defer { lock.unlock() }
 
     guard let entry = entries[deviceKey],
-          let token = entry.tokens.removeValue(forKey: id)
+      let token = entry.tokens.removeValue(forKey: listenerID)
     else {
       return
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/VisionCameraOnLoad.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/VisionCameraOnLoad.cpp
@@ -16,10 +16,10 @@
 #include <NitroModules/HybridObjectRegistry.hpp>
 
 #include "JHybridCameraControllerSpec.hpp"
+#include "JFunc_void.hpp"
 #include "JHybridCameraFactorySpec.hpp"
 #include "JHybridFrameRendererSpec.hpp"
 #include "JHybridNativeThreadSpec.hpp"
-#include "JFunc_void.hpp"
 #include "JHybridNativeThreadFactorySpec.hpp"
 #include "JHybridGestureControllerSpec.hpp"
 #include "JHybridTapToFocusGestureControllerSpec.hpp"
@@ -124,10 +124,10 @@ void registerAllNatives() {
 
   // Register native JNI methods
   margelo::nitro::camera::JHybridCameraControllerSpec::CxxPart::registerNatives();
+  margelo::nitro::camera::JFunc_void_cxx::registerNatives();
   margelo::nitro::camera::JHybridCameraFactorySpec::CxxPart::registerNatives();
   margelo::nitro::camera::JHybridFrameRendererSpec::CxxPart::registerNatives();
   margelo::nitro::camera::JHybridNativeThreadSpec::CxxPart::registerNatives();
-  margelo::nitro::camera::JFunc_void_cxx::registerNatives();
   margelo::nitro::camera::JHybridNativeThreadFactorySpec::CxxPart::registerNatives();
   margelo::nitro::camera::JHybridGestureControllerSpec::CxxPart::registerNatives();
   margelo::nitro::camera::JHybridTapToFocusGestureControllerSpec::CxxPart::registerNatives();

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.cpp
@@ -68,6 +68,9 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include <variant>
 #include "JVariant_NullType_Double.hpp"
 #include <NitroModules/JNull.hpp>
+#include <functional>
+#include "JFunc_void.hpp"
+#include <NitroModules/JNICallable.hpp>
 #include "WhiteBalanceTemperatureAndTint.hpp"
 #include "JWhiteBalanceTemperatureAndTint.hpp"
 
@@ -272,6 +275,10 @@ namespace margelo::nitro::camera {
       });
       return __promise;
     }();
+  }
+  void JHybridCameraControllerSpec::setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* onSubjectAreaChanged */)>("setSubjectAreaChangedListener_cxx");
+    method(_javaPart, onSubjectAreaChanged.has_value() ? JFunc_void_cxx::fromCpp(onSubjectAreaChanged.value()) : nullptr);
   }
   std::shared_ptr<Promise<void>> JHybridCameraControllerSpec::setZoom(double zoom) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(double /* zoom */)>("setZoom");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.cpp
@@ -19,6 +19,8 @@ namespace margelo::nitro::camera { enum class ExposureMode; }
 namespace margelo::nitro::camera { enum class WhiteBalanceMode; }
 // Forward declaration of `WhiteBalanceGains` to properly resolve imports.
 namespace margelo::nitro::camera { struct WhiteBalanceGains; }
+// Forward declaration of `ListenerSubscription` to properly resolve imports.
+namespace margelo::nitro::camera { struct ListenerSubscription; }
 // Forward declaration of `CameraControllerConfiguration` to properly resolve imports.
 namespace margelo::nitro::camera { struct CameraControllerConfiguration; }
 // Forward declaration of `HybridMeteringPointSpec` to properly resolve imports.
@@ -50,6 +52,11 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
 #include <NitroModules/JUnit.hpp>
+#include "ListenerSubscription.hpp"
+#include "JListenerSubscription.hpp"
+#include <functional>
+#include "JFunc_void.hpp"
+#include <NitroModules/JNICallable.hpp>
 #include "CameraControllerConfiguration.hpp"
 #include "JCameraControllerConfiguration.hpp"
 #include <optional>
@@ -68,9 +75,6 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include <variant>
 #include "JVariant_NullType_Double.hpp"
 #include <NitroModules/JNull.hpp>
-#include <functional>
-#include "JFunc_void.hpp"
-#include <NitroModules/JNICallable.hpp>
 #include "WhiteBalanceTemperatureAndTint.hpp"
 #include "JWhiteBalanceTemperatureAndTint.hpp"
 
@@ -276,9 +280,10 @@ namespace margelo::nitro::camera {
       return __promise;
     }();
   }
-  void JHybridCameraControllerSpec::setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) {
-    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void::javaobject> /* onSubjectAreaChanged */)>("setSubjectAreaChangedListener_cxx");
-    method(_javaPart, onSubjectAreaChanged.has_value() ? JFunc_void_cxx::fromCpp(onSubjectAreaChanged.value()) : nullptr);
+  ListenerSubscription JHybridCameraControllerSpec::addSubjectAreaChangedListener(const std::function<void()>& onSubjectAreaChanged) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JListenerSubscription>(jni::alias_ref<JFunc_void::javaobject> /* onSubjectAreaChanged */)>("addSubjectAreaChangedListener_cxx");
+    auto __result = method(_javaPart, JFunc_void_cxx::fromCpp(onSubjectAreaChanged));
+    return __result->toCpp();
   }
   std::shared_ptr<Promise<void>> JHybridCameraControllerSpec::setZoom(double zoom) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(double /* zoom */)>("setZoom");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.hpp
@@ -81,7 +81,7 @@ namespace margelo::nitro::camera {
     std::shared_ptr<Promise<void>> configure(const CameraControllerConfiguration& config) override;
     std::shared_ptr<Promise<void>> focusTo(const std::shared_ptr<HybridMeteringPointSpec>& point, const FocusOptions& options) override;
     std::shared_ptr<Promise<void>> resetFocus() override;
-    void setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) override;
+    ListenerSubscription addSubjectAreaChangedListener(const std::function<void()>& onSubjectAreaChanged) override;
     std::shared_ptr<Promise<void>> setZoom(double zoom) override;
     std::shared_ptr<Promise<void>> startZoomAnimation(double zoom, double rate) override;
     std::shared_ptr<Promise<void>> cancelZoomAnimation() override;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.hpp
@@ -81,6 +81,7 @@ namespace margelo::nitro::camera {
     std::shared_ptr<Promise<void>> configure(const CameraControllerConfiguration& config) override;
     std::shared_ptr<Promise<void>> focusTo(const std::shared_ptr<HybridMeteringPointSpec>& point, const FocusOptions& options) override;
     std::shared_ptr<Promise<void>> resetFocus() override;
+    void setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) override;
     std::shared_ptr<Promise<void>> setZoom(double zoom) override;
     std::shared_ptr<Promise<void>> startZoomAnimation(double zoom, double rate) override;
     std::shared_ptr<Promise<void>> cancelZoomAnimation() override;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraControllerSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraControllerSpec.kt
@@ -139,12 +139,12 @@ abstract class HybridCameraControllerSpec: HybridObject() {
   @Keep
   abstract fun resetFocus(): Promise<Unit>
   
-  abstract fun setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Unit)?): Unit
+  abstract fun addSubjectAreaChangedListener(onSubjectAreaChanged: () -> Unit): ListenerSubscription
   
   @DoNotStrip
   @Keep
-  private fun setSubjectAreaChangedListener_cxx(onSubjectAreaChanged: Func_void?): Unit {
-    val __result = setSubjectAreaChangedListener(onSubjectAreaChanged?.let { it })
+  private fun addSubjectAreaChangedListener_cxx(onSubjectAreaChanged: Func_void): ListenerSubscription {
+    val __result = addSubjectAreaChangedListener(onSubjectAreaChanged)
     return __result
   }
   

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraControllerSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraControllerSpec.kt
@@ -139,6 +139,15 @@ abstract class HybridCameraControllerSpec: HybridObject() {
   @Keep
   abstract fun resetFocus(): Promise<Unit>
   
+  abstract fun setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Unit)?): Unit
+  
+  @DoNotStrip
+  @Keep
+  private fun setSubjectAreaChangedListener_cxx(onSubjectAreaChanged: Func_void?): Unit {
+    val __result = setSubjectAreaChangedListener(onSubjectAreaChanged?.let { it })
+    return __result
+  }
+  
   @DoNotStrip
   @Keep
   abstract fun setZoom(zoom: Double): Promise<Unit>

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
@@ -543,6 +543,21 @@ namespace margelo::nitro::camera::bridge::swift {
     return optional.value();
   }
   
+  // pragma MARK: std::optional<std::function<void()>>
+  /**
+   * Specialized version of `std::optional<std::function<void()>>`.
+   */
+  using std__optional_std__function_void____ = std::optional<std::function<void()>>;
+  inline std::optional<std::function<void()>> create_std__optional_std__function_void____(const std::function<void()>& value) noexcept {
+    return std::optional<std::function<void()>>(value);
+  }
+  inline bool has_value_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::function<void()> get_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
+    return optional.value();
+  }
+  
   // pragma MARK: std::optional<double>
   /**
    * Specialized version of `std::optional<double>`.
@@ -577,6 +592,15 @@ namespace margelo::nitro::camera::bridge::swift {
   }
   inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
+  }
+  
+  // pragma MARK: Result<void>
+  using Result_void_ = Result<void>;
+  inline Result_void_ create_Result_void_() noexcept {
+    return Result<void>::withValue();
+  }
+  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
+    return Result<void>::withError(error);
   }
   
   // pragma MARK: Result<WhiteBalanceGains>
@@ -1246,15 +1270,6 @@ namespace margelo::nitro::camera::bridge::swift {
   // pragma MARK: std::weak_ptr<HybridFrameSpec>
   using std__weak_ptr_HybridFrameSpec_ = std::weak_ptr<HybridFrameSpec>;
   inline std__weak_ptr_HybridFrameSpec_ weakify_std__shared_ptr_HybridFrameSpec_(const std::shared_ptr<HybridFrameSpec>& strong) noexcept { return strong; }
-  
-  // pragma MARK: Result<void>
-  using Result_void_ = Result<void>;
-  inline Result_void_ create_Result_void_() noexcept {
-    return Result<void>::withValue();
-  }
-  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
-    return Result<void>::withError(error);
-  }
   
   // pragma MARK: std::shared_ptr<HybridNativeThreadSpec>
   /**
@@ -2379,21 +2394,6 @@ namespace margelo::nitro::camera::bridge::swift {
     return optional.has_value();
   }
   inline std::shared_ptr<HybridLocationSpec> get_std__optional_std__shared_ptr_HybridLocationSpec__(const std::optional<std::shared_ptr<HybridLocationSpec>>& optional) noexcept {
-    return optional.value();
-  }
-  
-  // pragma MARK: std::optional<std::function<void()>>
-  /**
-   * Specialized version of `std::optional<std::function<void()>>`.
-   */
-  using std__optional_std__function_void____ = std::optional<std::function<void()>>;
-  inline std::optional<std::function<void()>> create_std__optional_std__function_void____(const std::function<void()>& value) noexcept {
-    return std::optional<std::function<void()>>(value);
-  }
-  inline bool has_value_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline std::function<void()> get_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
     return optional.value();
   }
   

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
@@ -543,21 +543,6 @@ namespace margelo::nitro::camera::bridge::swift {
     return optional.value();
   }
   
-  // pragma MARK: std::optional<std::function<void()>>
-  /**
-   * Specialized version of `std::optional<std::function<void()>>`.
-   */
-  using std__optional_std__function_void____ = std::optional<std::function<void()>>;
-  inline std::optional<std::function<void()>> create_std__optional_std__function_void____(const std::function<void()>& value) noexcept {
-    return std::optional<std::function<void()>>(value);
-  }
-  inline bool has_value_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline std::function<void()> get_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
-    return optional.value();
-  }
-  
   // pragma MARK: std::optional<double>
   /**
    * Specialized version of `std::optional<double>`.
@@ -594,13 +579,13 @@ namespace margelo::nitro::camera::bridge::swift {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
   }
   
-  // pragma MARK: Result<void>
-  using Result_void_ = Result<void>;
-  inline Result_void_ create_Result_void_() noexcept {
-    return Result<void>::withValue();
+  // pragma MARK: Result<ListenerSubscription>
+  using Result_ListenerSubscription_ = Result<ListenerSubscription>;
+  inline Result_ListenerSubscription_ create_Result_ListenerSubscription_(const ListenerSubscription& value) noexcept {
+    return Result<ListenerSubscription>::withValue(value);
   }
-  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
-    return Result<void>::withError(error);
+  inline Result_ListenerSubscription_ create_Result_ListenerSubscription_(const std::exception_ptr& error) noexcept {
+    return Result<ListenerSubscription>::withError(error);
   }
   
   // pragma MARK: Result<WhiteBalanceGains>
@@ -1271,6 +1256,15 @@ namespace margelo::nitro::camera::bridge::swift {
   using std__weak_ptr_HybridFrameSpec_ = std::weak_ptr<HybridFrameSpec>;
   inline std__weak_ptr_HybridFrameSpec_ weakify_std__shared_ptr_HybridFrameSpec_(const std::shared_ptr<HybridFrameSpec>& strong) noexcept { return strong; }
   
+  // pragma MARK: Result<void>
+  using Result_void_ = Result<void>;
+  inline Result_void_ create_Result_void_() noexcept {
+    return Result<void>::withValue();
+  }
+  inline Result_void_ create_Result_void_(const std::exception_ptr& error) noexcept {
+    return Result<void>::withError(error);
+  }
+  
   // pragma MARK: std::shared_ptr<HybridNativeThreadSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridNativeThreadSpec>`.
@@ -1506,15 +1500,6 @@ namespace margelo::nitro::camera::bridge::swift {
   Func_void_std__vector_std__shared_ptr_HybridCameraExtensionSpec__ create_Func_void_std__vector_std__shared_ptr_HybridCameraExtensionSpec__(void* NON_NULL swiftClosureWrapper) noexcept;
   inline Func_void_std__vector_std__shared_ptr_HybridCameraExtensionSpec___Wrapper wrap_Func_void_std__vector_std__shared_ptr_HybridCameraExtensionSpec__(Func_void_std__vector_std__shared_ptr_HybridCameraExtensionSpec__ value) noexcept {
     return Func_void_std__vector_std__shared_ptr_HybridCameraExtensionSpec___Wrapper(std::move(value));
-  }
-  
-  // pragma MARK: Result<ListenerSubscription>
-  using Result_ListenerSubscription_ = Result<ListenerSubscription>;
-  inline Result_ListenerSubscription_ create_Result_ListenerSubscription_(const ListenerSubscription& value) noexcept {
-    return Result<ListenerSubscription>::withValue(value);
-  }
-  inline Result_ListenerSubscription_ create_Result_ListenerSubscription_(const std::exception_ptr& error) noexcept {
-    return Result<ListenerSubscription>::withError(error);
   }
   
   // pragma MARK: Result<std::optional<std::shared_ptr<HybridCameraDeviceSpec>>>
@@ -2394,6 +2379,21 @@ namespace margelo::nitro::camera::bridge::swift {
     return optional.has_value();
   }
   inline std::shared_ptr<HybridLocationSpec> get_std__optional_std__shared_ptr_HybridLocationSpec__(const std::optional<std::shared_ptr<HybridLocationSpec>>& optional) noexcept {
+    return optional.value();
+  }
+  
+  // pragma MARK: std::optional<std::function<void()>>
+  /**
+   * Specialized version of `std::optional<std::function<void()>>`.
+   */
+  using std__optional_std__function_void____ = std::optional<std::function<void()>>;
+  inline std::optional<std::function<void()>> create_std__optional_std__function_void____(const std::function<void()>& value) noexcept {
+    return std::optional<std::function<void()>>(value);
+  }
+  inline bool has_value_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::function<void()> get_std__optional_std__function_void____(const std::optional<std::function<void()>>& optional) noexcept {
     return optional.value();
   }
   

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraControllerSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraControllerSpecSwift.hpp
@@ -36,6 +36,8 @@ namespace margelo::nitro::camera { enum class FocusResponsiveness; }
 namespace margelo::nitro::camera { enum class SceneAdaptiveness; }
 // Forward declaration of `MeteringMode` to properly resolve imports.
 namespace margelo::nitro::camera { enum class MeteringMode; }
+// Forward declaration of `ListenerSubscription` to properly resolve imports.
+namespace margelo::nitro::camera { struct ListenerSubscription; }
 // Forward declaration of `WhiteBalanceTemperatureAndTint` to properly resolve imports.
 namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 
@@ -57,6 +59,7 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include <vector>
 #include <NitroModules/Null.hpp>
 #include <variant>
+#include "ListenerSubscription.hpp"
 #include <functional>
 #include "WhiteBalanceTemperatureAndTint.hpp"
 
@@ -213,11 +216,13 @@ namespace margelo::nitro::camera {
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline void setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) override {
-      auto __result = _swiftPart.setSubjectAreaChangedListener(onSubjectAreaChanged);
+    inline ListenerSubscription addSubjectAreaChangedListener(const std::function<void()>& onSubjectAreaChanged) override {
+      auto __result = _swiftPart.addSubjectAreaChangedListener(onSubjectAreaChanged);
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }
+      auto __value = std::move(__result.value());
+      return __value;
     }
     inline std::shared_ptr<Promise<void>> setZoom(double zoom) override {
       auto __result = _swiftPart.setZoom(std::forward<decltype(zoom)>(zoom));

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraControllerSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraControllerSpecSwift.hpp
@@ -57,6 +57,7 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include <vector>
 #include <NitroModules/Null.hpp>
 #include <variant>
+#include <functional>
 #include "WhiteBalanceTemperatureAndTint.hpp"
 
 #include "VisionCamera-Swift-Cxx-Umbrella.hpp"
@@ -211,6 +212,12 @@ namespace margelo::nitro::camera {
       }
       auto __value = std::move(__result.value());
       return __value;
+    }
+    inline void setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) override {
+      auto __result = _swiftPart.setSubjectAreaChangedListener(onSubjectAreaChanged);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
     }
     inline std::shared_ptr<Promise<void>> setZoom(double zoom) override {
       auto __result = _swiftPart.setZoom(std::forward<decltype(zoom)>(zoom));

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec.swift
@@ -40,7 +40,7 @@ public protocol HybridCameraControllerSpec_protocol: HybridObject {
   func configure(config: CameraControllerConfiguration) throws -> Promise<Void>
   func focusTo(point: (any HybridMeteringPointSpec), options: FocusOptions) throws -> Promise<Void>
   func resetFocus() throws -> Promise<Void>
-  func setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Void)?) throws -> Void
+  func addSubjectAreaChangedListener(onSubjectAreaChanged: @escaping () -> Void) throws -> ListenerSubscription
   func setZoom(zoom: Double) throws -> Promise<Void>
   func startZoomAnimation(zoom: Double, rate: Double) throws -> Promise<Void>
   func cancelZoomAnimation() throws -> Promise<Void>

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec.swift
@@ -40,6 +40,7 @@ public protocol HybridCameraControllerSpec_protocol: HybridObject {
   func configure(config: CameraControllerConfiguration) throws -> Promise<Void>
   func focusTo(point: (any HybridMeteringPointSpec), options: FocusOptions) throws -> Promise<Void>
   func resetFocus() throws -> Promise<Void>
+  func setSubjectAreaChangedListener(onSubjectAreaChanged: (() -> Void)?) throws -> Void
   func setZoom(zoom: Double) throws -> Promise<Void>
   func startZoomAnimation(zoom: Double, rate: Double) throws -> Promise<Void>
   func cancelZoomAnimation() throws -> Promise<Void>

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec_cxx.swift
@@ -362,25 +362,19 @@ open class HybridCameraControllerSpec_cxx {
   }
   
   @inline(__always)
-  public final func setSubjectAreaChangedListener(onSubjectAreaChanged: bridge.std__optional_std__function_void____) -> bridge.Result_void_ {
+  public final func addSubjectAreaChangedListener(onSubjectAreaChanged: bridge.Func_void) -> bridge.Result_ListenerSubscription_ {
     do {
-      try self.__implementation.setSubjectAreaChangedListener(onSubjectAreaChanged: { () -> (() -> Void)? in
-        if bridge.has_value_std__optional_std__function_void____(onSubjectAreaChanged) {
-          let __unwrapped = bridge.get_std__optional_std__function_void____(onSubjectAreaChanged)
-          return { () -> () -> Void in
-            let __wrappedFunction = bridge.wrap_Func_void(__unwrapped)
-            return { () -> Void in
-              __wrappedFunction.call()
-            }
-          }()
-        } else {
-          return nil
+      let __result = try self.__implementation.addSubjectAreaChangedListener(onSubjectAreaChanged: { () -> () -> Void in
+        let __wrappedFunction = bridge.wrap_Func_void(onSubjectAreaChanged)
+        return { () -> Void in
+          __wrappedFunction.call()
         }
       }())
-      return bridge.create_Result_void_()
+      let __resultCpp = __result
+      return bridge.create_Result_ListenerSubscription_(__resultCpp)
     } catch (let __error) {
       let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
+      return bridge.create_Result_ListenerSubscription_(__exceptionPtr)
     }
   }
   

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec_cxx.swift
@@ -362,6 +362,29 @@ open class HybridCameraControllerSpec_cxx {
   }
   
   @inline(__always)
+  public final func setSubjectAreaChangedListener(onSubjectAreaChanged: bridge.std__optional_std__function_void____) -> bridge.Result_void_ {
+    do {
+      try self.__implementation.setSubjectAreaChangedListener(onSubjectAreaChanged: { () -> (() -> Void)? in
+        if bridge.has_value_std__optional_std__function_void____(onSubjectAreaChanged) {
+          let __unwrapped = bridge.get_std__optional_std__function_void____(onSubjectAreaChanged)
+          return { () -> () -> Void in
+            let __wrappedFunction = bridge.wrap_Func_void(__unwrapped)
+            return { () -> Void in
+              __wrappedFunction.call()
+            }
+          }()
+        } else {
+          return nil
+        }
+      }())
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func setZoom(zoom: Double) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
       let __result = try self.__implementation.setZoom(zoom: zoom)

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.cpp
@@ -42,6 +42,7 @@ namespace margelo::nitro::camera {
       prototype.registerHybridMethod("configure", &HybridCameraControllerSpec::configure);
       prototype.registerHybridMethod("focusTo", &HybridCameraControllerSpec::focusTo);
       prototype.registerHybridMethod("resetFocus", &HybridCameraControllerSpec::resetFocus);
+      prototype.registerHybridMethod("setSubjectAreaChangedListener", &HybridCameraControllerSpec::setSubjectAreaChangedListener);
       prototype.registerHybridMethod("setZoom", &HybridCameraControllerSpec::setZoom);
       prototype.registerHybridMethod("startZoomAnimation", &HybridCameraControllerSpec::startZoomAnimation);
       prototype.registerHybridMethod("cancelZoomAnimation", &HybridCameraControllerSpec::cancelZoomAnimation);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.cpp
@@ -42,7 +42,7 @@ namespace margelo::nitro::camera {
       prototype.registerHybridMethod("configure", &HybridCameraControllerSpec::configure);
       prototype.registerHybridMethod("focusTo", &HybridCameraControllerSpec::focusTo);
       prototype.registerHybridMethod("resetFocus", &HybridCameraControllerSpec::resetFocus);
-      prototype.registerHybridMethod("setSubjectAreaChangedListener", &HybridCameraControllerSpec::setSubjectAreaChangedListener);
+      prototype.registerHybridMethod("addSubjectAreaChangedListener", &HybridCameraControllerSpec::addSubjectAreaChangedListener);
       prototype.registerHybridMethod("setZoom", &HybridCameraControllerSpec::setZoom);
       prototype.registerHybridMethod("startZoomAnimation", &HybridCameraControllerSpec::startZoomAnimation);
       prototype.registerHybridMethod("cancelZoomAnimation", &HybridCameraControllerSpec::cancelZoomAnimation);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.hpp
@@ -45,6 +45,7 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include "CameraControllerConfiguration.hpp"
 #include "HybridMeteringPointSpec.hpp"
 #include "FocusOptions.hpp"
+#include <functional>
 #include <optional>
 #include "WhiteBalanceTemperatureAndTint.hpp"
 
@@ -106,6 +107,7 @@ namespace margelo::nitro::camera {
       virtual std::shared_ptr<Promise<void>> configure(const CameraControllerConfiguration& config) = 0;
       virtual std::shared_ptr<Promise<void>> focusTo(const std::shared_ptr<HybridMeteringPointSpec>& point, const FocusOptions& options) = 0;
       virtual std::shared_ptr<Promise<void>> resetFocus() = 0;
+      virtual void setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) = 0;
       virtual std::shared_ptr<Promise<void>> setZoom(double zoom) = 0;
       virtual std::shared_ptr<Promise<void>> startZoomAnimation(double zoom, double rate) = 0;
       virtual std::shared_ptr<Promise<void>> cancelZoomAnimation() = 0;

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.hpp
@@ -31,6 +31,8 @@ namespace margelo::nitro::camera { struct CameraControllerConfiguration; }
 namespace margelo::nitro::camera { class HybridMeteringPointSpec; }
 // Forward declaration of `FocusOptions` to properly resolve imports.
 namespace margelo::nitro::camera { struct FocusOptions; }
+// Forward declaration of `ListenerSubscription` to properly resolve imports.
+namespace margelo::nitro::camera { struct ListenerSubscription; }
 // Forward declaration of `WhiteBalanceTemperatureAndTint` to properly resolve imports.
 namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 
@@ -45,6 +47,7 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include "CameraControllerConfiguration.hpp"
 #include "HybridMeteringPointSpec.hpp"
 #include "FocusOptions.hpp"
+#include "ListenerSubscription.hpp"
 #include <functional>
 #include <optional>
 #include "WhiteBalanceTemperatureAndTint.hpp"
@@ -107,7 +110,7 @@ namespace margelo::nitro::camera {
       virtual std::shared_ptr<Promise<void>> configure(const CameraControllerConfiguration& config) = 0;
       virtual std::shared_ptr<Promise<void>> focusTo(const std::shared_ptr<HybridMeteringPointSpec>& point, const FocusOptions& options) = 0;
       virtual std::shared_ptr<Promise<void>> resetFocus() = 0;
-      virtual void setSubjectAreaChangedListener(const std::optional<std::function<void()>>& onSubjectAreaChanged) = 0;
+      virtual ListenerSubscription addSubjectAreaChangedListener(const std::function<void()>& onSubjectAreaChanged) = 0;
       virtual std::shared_ptr<Promise<void>> setZoom(double zoom) = 0;
       virtual std::shared_ptr<Promise<void>> startZoomAnimation(double zoom, double rate) = 0;
       virtual std::shared_ptr<Promise<void>> cancelZoomAnimation() = 0;

--- a/packages/react-native-vision-camera/src/hooks/internal/useListenerSubscription.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useListenerSubscription.ts
@@ -1,5 +1,6 @@
 import { useLayoutEffect } from 'react'
 import type { ListenerSubscription } from '../../specs/common-types/ListenerSubscription'
+import { useStableCallback } from './useStableCallback'
 
 type ListenerMethodName<T> = {
   [K in keyof T]: T[K] extends (
@@ -22,13 +23,15 @@ export function useListenerSubscription<T, K extends ListenerMethodName<T>>(
     ? L | undefined
     : never,
 ): void {
+  const stableCallback = useStableCallback(callback)
+
   // Subscribe during layout so passive effects (e.g. start/stop) cannot emit before listeners are attached.
   useLayoutEffect(() => {
     if (object == null) return
-    if (callback == null) return
+    if (stableCallback == null) return
 
-    type Func = (_: typeof callback) => ListenerSubscription
-    const listener = (object[subscriberFuncName] as Func)(callback)
+    type Func = (_: typeof stableCallback) => ListenerSubscription
+    const listener = (object[subscriberFuncName] as Func)(stableCallback)
     return () => listener.remove()
-  }, [callback, object, subscriberFuncName])
+  }, [stableCallback, object, subscriberFuncName])
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useStableCallback.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useStableCallback.ts
@@ -1,14 +1,32 @@
 import { useCallback, useRef } from 'react'
 
-// biome-ignore lint/suspicious/noExplicitAny: This is the only way to model functions
-export function useStableCallback<T extends (...args: any[]) => any>(
-  callback: T,
-): (...args: Parameters<T>) => ReturnType<T> {
-  // Wrap callback in useRef
+/**
+ * Returns a wrapper with a stable identity that always calls the latest
+ * {@linkcode callback}. Re-renders that change only the {@linkcode callback}
+ * reference do not change the returned identity.
+ *
+ * When {@linkcode callback} is `undefined` or `null`, the hook returns
+ * that same nullish value. The returned identity therefore only changes
+ * when {@linkcode callback} flips between "defined" and "nullish" — not
+ * when the function itself changes — which makes it safe as a
+ * `useEffect`/`useLayoutEffect` dependency.
+ */
+export function useStableCallback<T>(callback: T): T {
   const callbackRef = useRef(callback)
   callbackRef.current = callback
-  // Call the ref's current value in useCallback
-  return useCallback((...params: Parameters<T>): ReturnType<T> => {
-    return callbackRef.current(...params)
-  }, [])
+
+  const stable = useCallback((...args: unknown[]): unknown => {
+    const fn = callbackRef.current
+    if (typeof fn !== 'function') {
+      throw new Error(
+        'useStableCallback: wrapped callback was invoked but the underlying callback is not a function. ' +
+          'The hook returns the nullish value directly when the input is null/undefined, so callers ' +
+          'should not hold a reference to the wrapper in that state.',
+      )
+    }
+    return fn(...args)
+  }, []) as T
+
+  if (callback == null) return callback
+  return stable
 }

--- a/packages/react-native-vision-camera/src/hooks/useCamera.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCamera.ts
@@ -98,6 +98,8 @@ export interface CameraProps {
    *
    * This is a good point to reset any locked AE/AF/AWB
    * focus states back to continuously auto-focus.
+   *
+   * @platform iOS
    */
   onSubjectAreaChanged?: () => void
 }

--- a/packages/react-native-vision-camera/src/hooks/useCamera.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCamera.ts
@@ -91,6 +91,15 @@ export interface CameraProps {
    * is running uninterrupted again.
    */
   onInterruptionEnded?: () => void
+  /**
+   * Called when the subject area substantially changes,
+   * e.g. when the user pans away from a scene that was
+   * previously in focus.
+   *
+   * This is a good point to reset any locked AE/AF/AWB
+   * focus states back to continuously auto-focus.
+   */
+  onSubjectAreaChanged?: () => void
 }
 
 function defaultOnErrorHandler(error: Error) {
@@ -112,6 +121,7 @@ export function useCamera({
   onError = defaultOnErrorHandler,
   onInterruptionStarted,
   onInterruptionEnded,
+  onSubjectAreaChanged,
   enableDistortionCorrection,
   enableLowLightBoost,
   enableSmoothAutoFocus,
@@ -185,6 +195,11 @@ export function useCamera({
     session,
     'addOnInterruptionEndedListener',
     onInterruptionEnded,
+  )
+  useListenerSubscription(
+    controller,
+    'addSubjectAreaChangedListener',
+    onSubjectAreaChanged,
   )
 
   // 8. On unmount, dispose the controller & session.

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -295,6 +295,7 @@ export interface CameraController
    * it is useful to listen for subject area changes, to reset focus
    * again via {@linkcode resetFocus | resetFocus()}.
    *
+   * @platform iOS
    * @example
    * ```ts
    * const controller = ...

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -7,6 +7,7 @@ import type {
   MeteringMode,
   SceneAdaptiveness,
 } from './common-types/FocusOptions'
+import type { ListenerSubscription } from './common-types/ListenerSubscription'
 import type { TorchMode } from './common-types/TorchMode'
 import type { WhiteBalanceGains } from './common-types/WhiteBalanceGains'
 import type { WhiteBalanceMode } from './common-types/WhiteBalanceMode'
@@ -279,9 +280,12 @@ export interface CameraController
    * substantially changes - e.g. when the user pans away
    * from a scene previously in focus.
    *
-   * When {@linkcode onSubjectAreaChanged} is set to
-   * `undefined`, the device stops monitoring subject
-   * area change events.
+   * Returns a {@linkcode ListenerSubscription} - call
+   * {@linkcode ListenerSubscription.remove | remove()} on it
+   * to stop receiving subject-area-change events. Multiple
+   * subscriptions can coexist; the device stops monitoring
+   * subject-area changes only once the last subscription is
+   * removed.
    *
    * @discussion
    * When manually locking focus (e.g. via
@@ -300,15 +304,17 @@ export interface CameraController
    *   controller.lockCurrentFocus(),
    *   controller.lockCurrentWhiteBalance(),
    * ])
-   * const listener = controller.setSubjectAreaChangedListener(() => {
+   * const subscription = controller.addSubjectAreaChangedListener(() => {
    *   // When user moves Camera away, reset AE/AF/AWB again
    *   controller.resetFocus()
    * })
+   * // Later, to stop listening:
+   * subscription.remove()
    * ```
    */
-  setSubjectAreaChangedListener(
-    onSubjectAreaChanged: (() => void) | undefined,
-  ): void
+  addSubjectAreaChangedListener(
+    onSubjectAreaChanged: () => void,
+  ): ListenerSubscription
 
   // pragma MARK: Zoom
   /**

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -263,7 +263,9 @@ export interface CameraController
   focusTo(point: MeteringPoint, options: FocusOptions): Promise<void>
   /**
    * Cancels any current focus operations from {@linkcode focusTo | focusTo(...)},
-   * resets back all 3A focus modes to continuously auto-focus, and
+   * resets back all 3A focus modes to continuously auto-focus if they
+   * have been previously locked (e.g. via {@linkcode setFocusLocked | setFocusLocked(...)} or
+   * {@linkcode lockCurrentFocus | lockCurrentFocus()}, and similar), and
    * resets the focus point of interest to be in the center.
    *
    * @example
@@ -272,6 +274,41 @@ export interface CameraController
    * ```
    */
   resetFocus(): Promise<void>
+  /**
+   * Adds a listener to be fired everytime the subject area
+   * substantially changes - e.g. when the user pans away
+   * from a scene previously in focus.
+   *
+   * When {@linkcode onSubjectAreaChanged} is set to
+   * `undefined`, the device stops monitoring subject
+   * area change events.
+   *
+   * @discussion
+   * When manually locking focus (e.g. via
+   * {@linkcode focusTo | focusTo(...)} with {@linkcode FocusOptions.adaptiveness adaptiveness} set to {@linkcode SceneAdaptiveness | 'locked'},
+   * {@linkcode setFocusLocked | setFocusLocked(...)} (or similar), or
+   * {@linkcode lockCurrentFocus | lockCurrentFocus()} (or similar)),
+   * it is useful to listen for subject area changes, to reset focus
+   * again via {@linkcode resetFocus | resetFocus()}.
+   *
+   * @example
+   * ```ts
+   * const controller = ...
+   * // Lock AE/AF/AWB
+   * await Promise.all([
+   *   controller.lockCurrentExposure(),
+   *   controller.lockCurrentFocus(),
+   *   controller.lockCurrentWhiteBalance(),
+   * ])
+   * const listener = controller.setSubjectAreaChangedListener(() => {
+   *   // When user moves Camera away, reset AE/AF/AWB again
+   *   controller.resetFocus()
+   * })
+   * ```
+   */
+  setSubjectAreaChangedListener(
+    onSubjectAreaChanged: (() => void) | undefined,
+  ): void
 
   // pragma MARK: Zoom
   /**


### PR DESCRIPTION
```ts
/**
 * Adds a listener to be fired everytime the subject area
 * substantially changes - e.g. when the user pans away
 * from a scene previously in focus.
 *
 * When {@linkcode onSubjectAreaChanged} is set to
 * `undefined`, the device stops monitoring subject
 * area change events.
 *
 * @discussion
 * When manually locking focus (e.g. via
 * {@linkcode focusTo | focusTo(...)} with {@linkcode FocusOptions.adaptiveness adaptiveness} set to {@linkcode SceneAdaptiveness | 'locked'},
 * {@linkcode setFocusLocked | setFocusLocked(...)} (or similar), or
 * {@linkcode lockCurrentFocus | lockCurrentFocus()} (or similar)),
 * it is useful to listen for subject area changes, to reset focus
 * again via {@linkcode resetFocus | resetFocus()}.
 *
 * @example
 * ```ts
 * const controller = ...
 * // Lock AE/AF/AWB
 * await Promise.all([
 *   controller.lockCurrentExposure(),
 *   controller.lockCurrentFocus(),
 *   controller.lockCurrentWhiteBalance(),
 * ])
 * const listener = controller.setSubjectAreaChangedListener(() => {
 *   // When user moves Camera away, reset AE/AF/AWB again
 *   controller.resetFocus()
 * })
 * ```
 */
setSubjectAreaChangedListener(
  onSubjectAreaChanged: (() => void) | undefined,
): void
```

- Closes #3758 