### PR TITLE
fix: Better typed `CommonResolutions` + `CommonDynamicRanges`

### DIFF
--- a/packages/react-native-vision-camera/src/utils/CommonDynamicRanges.ts
+++ b/packages/react-native-vision-camera/src/utils/CommonDynamicRanges.ts
@@ -11,7 +11,7 @@ export const CommonDynamicRanges = {
     bitDepth: 'sdr-8-bit',
     colorSpace: 'srgb',
     colorRange: 'full',
-  } satisfies TargetDynamicRange,
+  },
   /**
    * Any HDR profile, preferrably 10-bit HLG_BT2020.
    */
@@ -19,5 +19,5 @@ export const CommonDynamicRanges = {
     bitDepth: 'hdr-10-bit',
     colorSpace: 'hlg-bt2020',
     colorRange: 'full',
-  } satisfies TargetDynamicRange,
-}
+  },
+} as const satisfies Record<string, TargetDynamicRange>

--- a/packages/react-native-vision-camera/src/utils/CommonResolutions.ts
+++ b/packages/react-native-vision-camera/src/utils/CommonResolutions.ts
@@ -1,3 +1,5 @@
+import type { Size } from '../specs/common-types/Size'
+
 /**
  * Common camera-centric resolution targets.
  *
@@ -76,4 +78,4 @@ export const CommonResolutions = {
    * Useful when you want the maximum available quality.
    */
   HIGHEST_4_3: { width: 30000, height: 40000 },
-} as const
+} as const satisfies Record<string, Size>


### PR DESCRIPTION
Avoids `as const` which looks weird in docs:

<img width="1659" height="1522" alt="Screenshot 2026-04-24 at 14 01 41" src="https://github.com/user-attachments/assets/4bee2bc3-7ae5-4421-8082-6da050599e46" />
