### PR TITLE
feat: Add `CameraDevice.maxTorchStrength` prop

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -133,11 +133,48 @@ describe('VisionCamera - Controller', () => {
     await session.start()
 
     try {
-      // TODO: Add setTorchMode('on', STRENGTH) test when we expose something like
-      //       CameraDevice.supportsTorchStrength - currently this might throw on
-      //       some phones without a way to check upfront if it supports setting strength!
       await controller.setTorchMode('on')
       expect(controller.torchMode).toBe('on')
+
+      await controller.setTorchMode('off')
+      expect(controller.torchMode).toBe('off')
+    } finally {
+      await session.stop()
+    }
+  })
+
+  it('sets torchMode with a specific strength when the device supports it', async () => {
+    if (backDevice.maxTorchStrength === 0) {
+      console.log(
+        '[SKIP] torchStrength: device only supports binary torch (maxTorchStrength === 0)',
+      )
+      return
+    }
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const [controller] = await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    if (controller == null) throw new Error('no controller')
+    await session.start()
+
+    try {
+      const target = backDevice.maxTorchStrength / 2
+      await controller.setTorchMode('on', target)
+      expect(controller.torchMode).toBe('on')
+      expect(controller.torchStrength).toBeGreaterThan(0)
+      expect(controller.torchStrength).toBeLessThanOrEqual(
+        backDevice.maxTorchStrength,
+      )
 
       await controller.setTorchMode('off')
       expect(controller.torchMode).toBe('off')

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
@@ -168,6 +168,14 @@ class HybridCameraDevice(
 
   override val hasTorch: Boolean
     get() = cameraInfo.hasFlashUnit()
+  override val maxTorchStrength: Double
+    // CameraX reports `maxTorchStrengthLevel == 1` for devices that only
+    // support binary torch (on/off) and `> 1` for devices that accept a
+    // strength level. Our public `setTorchMode(mode, strength?)` API
+    // normalizes the incoming strength to 0..1 before multiplying by
+    // `maxTorchStrengthLevel`, so the public maximum is always `1.0`
+    // when strength is configurable, and `0.0` otherwise.
+    get() = if (cameraInfo.maxTorchStrengthLevel > 1) 1.0 else 0.0
 
   override val supportsLowLightBoost: Boolean
     get() = cameraInfo.isLowLightBoostSupported

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridPhysicalCameraDevice.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridPhysicalCameraDevice.kt
@@ -90,6 +90,7 @@ class HybridPhysicalCameraDevice(
   override val maxWhiteBalanceGain: Double = 0.0
   override val hasFlash: Boolean = false
   override val hasTorch: Boolean = false
+  override val maxTorchStrength: Double = 0.0
   override val supportsLowLightBoost: Boolean = false
   override val minZoom: Double = 0.0
   override val maxZoom: Double = 0.0

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
@@ -195,6 +195,13 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
     return device.hasTorch
   }
 
+  var maxTorchStrength: Double {
+    // AVCaptureDevice.maxAvailableTorchLevel is a platform constant (1.0).
+    // When the device has a torch, torch strength is always configurable via
+    // setTorchModeOn(level:) in the 0...1 range.
+    return device.hasTorch ? Double(AVCaptureDevice.maxAvailableTorchLevel) : 0.0
+  }
+
   var supportsLowLightBoost: Bool {
     return device.isLowLightBoostSupported
   }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
@@ -308,6 +308,11 @@ namespace margelo::nitro::camera {
     auto __result = method(_javaPart);
     return static_cast<bool>(__result);
   }
+  double JHybridCameraDeviceSpec::getMaxTorchStrength() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getMaxTorchStrength");
+    auto __result = method(_javaPart);
+    return __result;
+  }
   bool JHybridCameraDeviceSpec::getSupportsLowLightBoost() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getSupportsLowLightBoost");
     auto __result = method(_javaPart);

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
@@ -82,6 +82,7 @@ namespace margelo::nitro::camera {
     bool getSupportsWhiteBalanceLocking() override;
     bool getHasFlash() override;
     bool getHasTorch() override;
+    double getMaxTorchStrength() override;
     bool getSupportsLowLightBoost() override;
     double getMinZoom() override;
     double getMaxZoom() override;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
@@ -155,6 +155,10 @@ abstract class HybridCameraDeviceSpec: HybridObject() {
   
   @get:DoNotStrip
   @get:Keep
+  abstract val maxTorchStrength: Double
+  
+  @get:DoNotStrip
+  @get:Keep
   abstract val supportsLowLightBoost: Boolean
   
   @get:DoNotStrip

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
@@ -218,6 +218,9 @@ namespace margelo::nitro::camera {
     inline bool getHasTorch() noexcept override {
       return _swiftPart.hasTorch();
     }
+    inline double getMaxTorchStrength() noexcept override {
+      return _swiftPart.getMaxTorchStrength();
+    }
     inline bool getSupportsLowLightBoost() noexcept override {
       return _swiftPart.getSupportsLowLightBoost();
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
@@ -42,6 +42,7 @@ public protocol HybridCameraDeviceSpec_protocol: HybridObject {
   var supportsWhiteBalanceLocking: Bool { get }
   var hasFlash: Bool { get }
   var hasTorch: Bool { get }
+  var maxTorchStrength: Double { get }
   var supportsLowLightBoost: Bool { get }
   var minZoom: Double { get }
   var maxZoom: Double { get }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
@@ -393,6 +393,13 @@ open class HybridCameraDeviceSpec_cxx {
     }
   }
   
+  public final var maxTorchStrength: Double {
+    @inline(__always)
+    get {
+      return self.__implementation.maxTorchStrength
+    }
+  }
+  
   public final var supportsLowLightBoost: Bool {
     @inline(__always)
     get {

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
@@ -46,6 +46,7 @@ namespace margelo::nitro::camera {
       prototype.registerHybridGetter("supportsWhiteBalanceLocking", &HybridCameraDeviceSpec::getSupportsWhiteBalanceLocking);
       prototype.registerHybridGetter("hasFlash", &HybridCameraDeviceSpec::getHasFlash);
       prototype.registerHybridGetter("hasTorch", &HybridCameraDeviceSpec::getHasTorch);
+      prototype.registerHybridGetter("maxTorchStrength", &HybridCameraDeviceSpec::getMaxTorchStrength);
       prototype.registerHybridGetter("supportsLowLightBoost", &HybridCameraDeviceSpec::getSupportsLowLightBoost);
       prototype.registerHybridGetter("minZoom", &HybridCameraDeviceSpec::getMinZoom);
       prototype.registerHybridGetter("maxZoom", &HybridCameraDeviceSpec::getMaxZoom);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
@@ -114,6 +114,7 @@ namespace margelo::nitro::camera {
       virtual bool getSupportsWhiteBalanceLocking() = 0;
       virtual bool getHasFlash() = 0;
       virtual bool getHasTorch() = 0;
+      virtual double getMaxTorchStrength() = 0;
       virtual bool getSupportsLowLightBoost() = 0;
       virtual double getMinZoom() = 0;
       virtual double getMaxZoom() = 0;

--- a/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
@@ -492,6 +492,21 @@ export interface CameraDevice
    * @see {@linkcode CameraController.setTorchMode | setTorchMode(...)}
    */
   readonly hasTorch: boolean
+  /**
+   * The maximum `strength` value accepted by
+   * {@linkcode CameraController.setTorchMode | setTorchMode('on', strength)}.
+   *
+   * - `0` — Configurable torch strength is **not supported** on this device.
+   * You may still call {@linkcode CameraController.setTorchMode | setTorchMode('on')}
+   * / `setTorchMode('off')` to toggle the torch, but passing a specific
+   * {@linkcode CameraController.setTorchMode | strength} value is not supported
+   * and will throw.
+   * - `> 0` — Strength is configurable in the normalized range
+   * from `0` (off) to `maxTorchStrength` (brightest).
+   *
+   * @see {@linkcode CameraController.setTorchMode | setTorchMode(...)}
+   */
+  readonly maxTorchStrength: number
 
   // pragma MARK: Low Light Boost
   /**


### PR DESCRIPTION
Fixes a bug in the Harness tests mentioned in #3793 