### PR TITLE
fix: crash when figCaptureSession is not null

### DIFF
--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraSession.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraSession.ts
@@ -30,10 +30,11 @@ export function useCameraSession({
 
   // session teardown
   useEffect(() => {
-    return () => {
-      // remove all connections
-      session?.stop()
+    return () => { 
+      // Detach outputswhile the session is still running so AVFoundation                                                                                                         
+      // drains each output's figCaptureSession pointer synchronously.  
       session?.configure([])
+      session?.stop()
     }
   }, [session])
 


### PR DESCRIPTION
fixes #3773 

Vor


https://github.com/user-attachments/assets/13b8eb8f-de2c-4806-bc3d-e2871518a47b


nach 

https://github.com/user-attachments/assets/a1c0ae87-cba5-4db5-a5de-a2719a7da105

