### PR TITLE
fix(android): preserve Photo file metadata in memory

### DIFF
--- a/docs/content/docs/a-photo.mdx
+++ b/docs/content/docs/a-photo.mdx
@@ -101,6 +101,8 @@ const pixelBuffer = await image.toRawPixelData()
 
 The [`Photo`](/api/react-native-vision-camera/hybrid-objects/Photo) also provides access to its Encoded Image Data - which is what would be written to a File if it was saved - including container metadata and EXIF flags.
 
+This is especially useful when you need metadata-bearing image bytes entirely in-memory, for example to preserve orientation, timestamps, or GPS/location EXIF tags while uploading a Photo without first saving it yourself.
+
 You can get the Encoded Image Data via [`getFileDataAsync()`](/api/react-native-vision-camera/hybrid-objects/Photo#getfiledataasync), for example to write this to a network stream entirely in-memory;
 
 ```ts

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
@@ -35,6 +35,7 @@ class HybridPhoto(
   val location: Location?,
 ) : HybridPhotoSpec() {
   private val ioScope = CoroutineScope(Dispatchers.IO)
+  private val encodedFileDataLock = Any()
 
   override val width: Double
     get() = image.width.toDouble()
@@ -71,9 +72,12 @@ class HybridPhoto(
     super.dispose()
     image.close()
     cachedPixelBuffer?.dispose()
+    cachedEncodedFileDataBytes = null
   }
 
   private var cachedPixelBuffer: DisposableArrayBuffer? = null
+  @Volatile
+  private var cachedEncodedFileDataBytes: ByteArray? = null
 
   override fun getPixelBuffer(): ArrayBuffer {
     cachedPixelBuffer?.let {
@@ -85,15 +89,34 @@ class HybridPhoto(
     return pixelBuffer.arrayBuffer
   }
 
+  private fun getRawImageBytes(): ByteArray {
+    return when (image.format) {
+      android.graphics.ImageFormat.JPEG -> {
+        // Always read from a duplicate so callers don't consume ImageProxy state.
+        val buffer = image.planes.single().buffer.duplicate()
+        buffer.rewind()
+        ByteArray(buffer.remaining()).also { bytes -> buffer.get(bytes) }
+      }
+      else -> {
+        throw Error(
+          "Photos with ImageFormat \"${image.format}\" cannot be encoded to bytes " +
+            "until https://issuetracker.google.com/u/3/issues/482079661 is implemented!",
+        )
+      }
+    }
+  }
+
   private fun saveToFile(file: File) {
     when (image.format) {
       android.graphics.ImageFormat.JPEG -> {
-        // JPEG Images have a single plane of image data.
-        val plane = image.planes.single()
-        val buffer = plane.buffer
-        val bytes = ByteArray(buffer.remaining()).also { bytes -> buffer.get(bytes) }
+        cachedEncodedFileDataBytes?.let { encodedBytes ->
+          FileOutputStream(file).use { stream ->
+            stream.write(encodedBytes)
+          }
+          return
+        }
         FileOutputStream(file).use { stream ->
-          stream.write(bytes)
+          stream.write(getRawImageBytes())
         }
         attachExifData(file)
       }
@@ -124,27 +147,48 @@ class HybridPhoto(
     }
   }
 
-  override fun getFileData(): ArrayBuffer {
-    when (image.format) {
-      android.graphics.ImageFormat.JPEG -> {
-        // JPEG Images have a single plane of image data.
-        val plane = image.planes.single()
-        return ArrayBuffer.wrap(plane.buffer)
-      }
-      else -> {
-        // TODO: If the CameraX team implements https://issuetracker.google.com/u/3/issues/482079661,
-        //       we could avoid manually reading the buffer and "just get the file data representation",
-        //       just like on iOS via `AVCapturePhoto.fileDataRepresentation()` - no matter the format.
-        throw Error(
-          "Cannot get File Data for Photos with Image Format \"${image.format}\" " +
-            "until https://issuetracker.google.com/u/3/issues/482079661 is implemented!",
-        )
+  private fun getEncodedFileDataBytes(): ByteArray {
+    cachedEncodedFileDataBytes?.let { return it }
+
+    return synchronized(encodedFileDataLock) {
+      cachedEncodedFileDataBytes?.let { return@synchronized it }
+
+      when (image.format) {
+        android.graphics.ImageFormat.JPEG -> {
+          val tempFile = File.createTempFile("VisionCamera_", containerFormat.fileExtension)
+          try {
+            // Reuse the same pipeline as saveToFile() so JS receives identical EXIF/location flags.
+            val encodedBytes = if (cachedEncodedFileDataBytes != null) {
+              cachedEncodedFileDataBytes!!
+            } else {
+              saveToFile(tempFile)
+              tempFile.readBytes()
+            }
+            cachedEncodedFileDataBytes = encodedBytes
+            return@synchronized encodedBytes
+          } finally {
+            tempFile.delete()
+          }
+        }
+        else -> {
+          // TODO: If the CameraX team implements https://issuetracker.google.com/u/3/issues/482079661,
+          //       we could avoid manually reading the buffer and "just get the file data representation",
+          //       just like on iOS via `AVCapturePhoto.fileDataRepresentation()` - no matter the format.
+          throw Error(
+            "Cannot get File Data for Photos with Image Format \"${image.format}\" " +
+              "until https://issuetracker.google.com/u/3/issues/482079661 is implemented!",
+          )
+        }
       }
     }
   }
 
+  override fun getFileData(): ArrayBuffer {
+    return ArrayBuffer.copy(getEncodedFileDataBytes())
+  }
+
   override fun getFileDataAsync(): Promise<ArrayBuffer> {
-    return Promise.async { getFileData() }
+    return Promise.async(ioScope) { getFileData() }
   }
 
   override fun toImage(): HybridImageSpec {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
@@ -35,7 +35,6 @@ class HybridPhoto(
   val location: Location?,
 ) : HybridPhotoSpec() {
   private val ioScope = CoroutineScope(Dispatchers.IO)
-  private val encodedFileDataLock = Any()
 
   override val width: Double
     get() = image.width.toDouble()
@@ -72,12 +71,9 @@ class HybridPhoto(
     super.dispose()
     image.close()
     cachedPixelBuffer?.dispose()
-    cachedEncodedFileDataBytes = null
   }
 
   private var cachedPixelBuffer: DisposableArrayBuffer? = null
-  @Volatile
-  private var cachedEncodedFileDataBytes: ByteArray? = null
 
   override fun getPixelBuffer(): ArrayBuffer {
     cachedPixelBuffer?.let {
@@ -109,12 +105,6 @@ class HybridPhoto(
   private fun saveToFile(file: File) {
     when (image.format) {
       android.graphics.ImageFormat.JPEG -> {
-        cachedEncodedFileDataBytes?.let { encodedBytes ->
-          FileOutputStream(file).use { stream ->
-            stream.write(encodedBytes)
-          }
-          return
-        }
         FileOutputStream(file).use { stream ->
           stream.write(getRawImageBytes())
         }
@@ -147,44 +137,15 @@ class HybridPhoto(
     }
   }
 
-  private fun getEncodedFileDataBytes(): ByteArray {
-    cachedEncodedFileDataBytes?.let { return it }
-
-    return synchronized(encodedFileDataLock) {
-      cachedEncodedFileDataBytes?.let { return@synchronized it }
-
-      when (image.format) {
-        android.graphics.ImageFormat.JPEG -> {
-          val tempFile = File.createTempFile("VisionCamera_", containerFormat.fileExtension)
-          try {
-            // Reuse the same pipeline as saveToFile() so JS receives identical EXIF/location flags.
-            val encodedBytes = if (cachedEncodedFileDataBytes != null) {
-              cachedEncodedFileDataBytes!!
-            } else {
-              saveToFile(tempFile)
-              tempFile.readBytes()
-            }
-            cachedEncodedFileDataBytes = encodedBytes
-            return@synchronized encodedBytes
-          } finally {
-            tempFile.delete()
-          }
-        }
-        else -> {
-          // TODO: If the CameraX team implements https://issuetracker.google.com/u/3/issues/482079661,
-          //       we could avoid manually reading the buffer and "just get the file data representation",
-          //       just like on iOS via `AVCapturePhoto.fileDataRepresentation()` - no matter the format.
-          throw Error(
-            "Cannot get File Data for Photos with Image Format \"${image.format}\" " +
-              "until https://issuetracker.google.com/u/3/issues/482079661 is implemented!",
-          )
-        }
-      }
-    }
-  }
-
   override fun getFileData(): ArrayBuffer {
-    return ArrayBuffer.copy(getEncodedFileDataBytes())
+    val tempFile = File.createTempFile("VisionCamera_", containerFormat.fileExtension)
+    try {
+      // Reuse the same save pipeline so JS receives the same EXIF/location flags as a saved file.
+      saveToFile(tempFile)
+      return ArrayBuffer.copy(tempFile.readBytes())
+    } finally {
+      tempFile.delete()
+    }
   }
 
   override fun getFileDataAsync(): Promise<ArrayBuffer> {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
@@ -85,7 +85,7 @@ class HybridPhoto(
     return pixelBuffer.arrayBuffer
   }
 
-  private fun getRawImageBytes(): ByteArray {
+  private fun getEncodedImageBytes(): ByteArray {
     return when (image.format) {
       android.graphics.ImageFormat.JPEG -> {
         // Always read from a duplicate so callers don't consume ImageProxy state.
@@ -106,7 +106,7 @@ class HybridPhoto(
     when (image.format) {
       android.graphics.ImageFormat.JPEG -> {
         FileOutputStream(file).use { stream ->
-          stream.write(getRawImageBytes())
+          stream.write(getEncodedImageBytes())
         }
         attachExifData(file)
       }
@@ -144,7 +144,9 @@ class HybridPhoto(
       saveToFile(tempFile)
       return ArrayBuffer.copy(tempFile.readBytes())
     } finally {
-      tempFile.delete()
+      if (!tempFile.delete()) {
+        tempFile.deleteOnExit()
+      }
     }
   }
 

--- a/packages/react-native-vision-camera/src/specs/instances/Photo.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/instances/Photo.nitro.ts
@@ -163,14 +163,20 @@ export interface Photo
    */
   saveToTemporaryFileAsync(): Promise<string>
   /**
-   * Gets the raw file data of the {@linkcode Photo} after
-   * processing and including EXIF flags.
+   * Gets the encoded file data of the {@linkcode Photo}.
+   *
+   * This matches what {@linkcode saveToFileAsync} or
+   * {@linkcode saveToTemporaryFileAsync} would write to disk,
+   * including container metadata and EXIF flags.
    */
   getFileData(): ArrayBuffer
   /**
-   * Asynchronously ets the raw file data of
-   * the {@linkcode Photo} after processing
-   * and including EXIF flags.
+   * Asynchronously gets the encoded file data of
+   * the {@linkcode Photo}.
+   *
+   * This matches what {@linkcode saveToFileAsync} or
+   * {@linkcode saveToTemporaryFileAsync} would write to disk,
+   * including container metadata and EXIF flags.
    */
   getFileDataAsync(): Promise<ArrayBuffer>
 


### PR DESCRIPTION
## Summary
- make Android `Photo.getFileData()` and `getFileDataAsync()` reuse the saved-file pipeline so in-memory encoded bytes preserve the same metadata-bearing representation as `saveToFile*()`
- remove the native encoded-bytes cache per review feedback
- clarify the public `Photo.getFileData*()` contract around saved-file parity and EXIF/container metadata

## Testing
- `npm run typecheck`
- `./gradlew.bat :react-native-vision-camera:compileDebugKotlin --no-daemon --console=plain`