### PR TITLE
feat: expose supported photo container formats

### DIFF
--- a/apps/simple-camera/src/components/CameraView.tsx
+++ b/apps/simple-camera/src/components/CameraView.tsx
@@ -21,6 +21,10 @@ export function CameraView({ device, constraints, ...props }: Props) {
       console.log(`Device changed: ${device.localizedName}`)
       console.log(`  - Supported Pixel Formats:`, device.supportedPixelFormats)
       console.log(
+        `  - Supported Photo Container Formats:`,
+        device.supportedPhotoContainerFormats,
+      )
+      console.log(
         `  - Supported Photo Resolutions:`,
         device.getSupportedResolutions('photo'),
       )

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
@@ -24,6 +24,7 @@ import com.margelo.nitro.camera.HybridCameraSessionConfigSpec
 import com.margelo.nitro.camera.MediaType
 import com.margelo.nitro.camera.OutputStreamType
 import com.margelo.nitro.camera.PixelFormat
+import com.margelo.nitro.camera.PhotoContainerFormat
 import com.margelo.nitro.camera.Range
 import com.margelo.nitro.camera.Size
 import com.margelo.nitro.camera.TargetStabilizationMode
@@ -109,6 +110,19 @@ class HybridCameraDevice(
     get() = cameraInfo.isLogicalMultiCameraSupported
   override val supportedPixelFormats: Array<PixelFormat>
     get() = camera2Info?.getPixelFormats() ?: emptyArray()
+  override val supportedPhotoContainerFormats: Array<PhotoContainerFormat>
+    get() =
+      imageCapabilities.supportedOutputFormats
+        .mapNotNull { outputFormat ->
+          when (outputFormat) {
+            ImageCapture.OUTPUT_FORMAT_JPEG,
+            ImageCapture.OUTPUT_FORMAT_JPEG_ULTRA_HDR,
+            -> PhotoContainerFormat.JPEG
+            ImageCapture.OUTPUT_FORMAT_RAW -> PhotoContainerFormat.DNG
+            else -> null
+          }
+        }.distinct()
+        .toTypedArray()
 
   override val focalLength: Double?
     get() = camera2Info?.focalLength?.toDouble()

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridPhysicalCameraDevice.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridPhysicalCameraDevice.kt
@@ -16,6 +16,7 @@ import com.margelo.nitro.camera.HybridCameraSessionConfigSpec
 import com.margelo.nitro.camera.MediaType
 import com.margelo.nitro.camera.OutputStreamType
 import com.margelo.nitro.camera.PixelFormat
+import com.margelo.nitro.camera.PhotoContainerFormat
 import com.margelo.nitro.camera.Range
 import com.margelo.nitro.camera.Size
 import com.margelo.nitro.camera.TargetStabilizationMode
@@ -63,6 +64,7 @@ class HybridPhysicalCameraDevice(
   override val physicalDevices: Array<HybridCameraDeviceSpec> = emptyArray()
   override val isVirtualDevice: Boolean = false
   override val supportedPixelFormats: Array<PixelFormat> = emptyArray()
+  override val supportedPhotoContainerFormats: Array<PhotoContainerFormat> = emptyArray()
   override val supportsPhotoHDR: Boolean = false
   override val supportedVideoDynamicRanges: Array<DynamicRange> = emptyArray()
   override val supportedFPSRanges: Array<Range> = emptyArray()

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
@@ -24,6 +24,9 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
       .map { PixelFormat(mediaSubType: $0.formatDescription.mediaSubType) }
       .withoutDuplicates()
   }()
+  lazy var supportedPhotoContainerFormats: [PhotoContainerFormat] = {
+    return getSupportedPhotoContainerFormats()
+  }()
 
   func getSupportedResolutions(outputStreamType: OutputStreamType) -> [Size] {
     let streamType = streamType(from: outputStreamType)
@@ -42,6 +45,43 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
       return .depthPhoto
     case .depthStream:
       return .depthVideo
+    }
+  }
+
+  private func getSupportedPhotoContainerFormats() -> [PhotoContainerFormat] {
+    let session = AVCaptureSession()
+    let output = AVCapturePhotoOutput()
+
+    do {
+      let input = try AVCaptureDeviceInput(device: device)
+      guard session.canAddInput(input) else {
+        logger.error("Failed to determine supported photo container formats - cannot add camera input.")
+        return [.jpeg]
+      }
+      guard session.canAddOutput(output) else {
+        logger.error("Failed to determine supported photo container formats - cannot add photo output.")
+        return [.jpeg]
+      }
+
+      session.beginConfiguration()
+      session.addInput(input)
+      session.addOutput(output)
+      if output.isAppleProRAWSupported {
+        output.isAppleProRAWEnabled = true
+      }
+      session.commitConfiguration()
+
+      let processedFormats = output.availablePhotoFileTypes
+        .map { PhotoContainerFormat(avFileType: $0) }
+        .filter { $0 == .jpeg || $0 == .heic }
+      let rawFormats = output.availableRawPhotoFileTypes
+        .map { PhotoContainerFormat(avFileType: $0) }
+        .filter { $0 == .dng }
+      let formats = (processedFormats + rawFormats).withoutDuplicates()
+      return formats.isEmpty ? [.jpeg] : formats
+    } catch {
+      logger.error("Failed to determine supported photo container formats: \(error)")
+      return [.jpeg]
     }
   }
 

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
@@ -15,6 +15,8 @@ namespace margelo::nitro::camera { enum class CameraPosition; }
 namespace margelo::nitro::camera { class HybridCameraDeviceSpec; }
 // Forward declaration of `PixelFormat` to properly resolve imports.
 namespace margelo::nitro::camera { enum class PixelFormat; }
+// Forward declaration of `PhotoContainerFormat` to properly resolve imports.
+namespace margelo::nitro::camera { enum class PhotoContainerFormat; }
 // Forward declaration of `DynamicRange` to properly resolve imports.
 namespace margelo::nitro::camera { struct DynamicRange; }
 // Forward declaration of `DynamicRangeBitDepth` to properly resolve imports.
@@ -49,6 +51,8 @@ namespace margelo::nitro::camera { class HybridCameraSessionConfigSpec; }
 #include "JHybridCameraDeviceSpec.hpp"
 #include "PixelFormat.hpp"
 #include "JPixelFormat.hpp"
+#include "PhotoContainerFormat.hpp"
+#include "JPhotoContainerFormat.hpp"
 #include "DynamicRange.hpp"
 #include "JDynamicRange.hpp"
 #include "DynamicRangeBitDepth.hpp"
@@ -158,6 +162,20 @@ namespace margelo::nitro::camera {
     return [&]() {
       size_t __size = __result->size();
       std::vector<PixelFormat> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __result->getElement(__i);
+        __vector.push_back(__element->toCpp());
+      }
+      return __vector;
+    }();
+  }
+  std::vector<PhotoContainerFormat> JHybridCameraDeviceSpec::getSupportedPhotoContainerFormats() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JPhotoContainerFormat>>()>("getSupportedPhotoContainerFormats");
+    auto __result = method(_javaPart);
+    return [&]() {
+      size_t __size = __result->size();
+      std::vector<PhotoContainerFormat> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
         auto __element = __result->getElement(__i);

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::camera {
     std::vector<std::shared_ptr<HybridCameraDeviceSpec>> getPhysicalDevices() override;
     bool getIsVirtualDevice() override;
     std::vector<PixelFormat> getSupportedPixelFormats() override;
+    std::vector<PhotoContainerFormat> getSupportedPhotoContainerFormats() override;
     bool getSupportsPhotoHDR() override;
     std::vector<DynamicRange> getSupportedVideoDynamicRanges() override;
     std::vector<Range> getSupportedFPSRanges() override;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
@@ -60,15 +60,19 @@ abstract class HybridCameraDeviceSpec: HybridObject() {
   @get:DoNotStrip
   @get:Keep
   abstract val supportedPixelFormats: Array<PixelFormat>
-  
+
+  @get:DoNotStrip
+  @get:Keep
+  abstract val supportedPhotoContainerFormats: Array<PhotoContainerFormat>
+
   @get:DoNotStrip
   @get:Keep
   abstract val supportsPhotoHDR: Boolean
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val supportedVideoDynamicRanges: Array<DynamicRange>
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val supportedFPSRanges: Array<Range>

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
@@ -124,6 +124,8 @@ namespace margelo::nitro::camera { enum class MeteringMode; }
 namespace margelo::nitro::camera { enum class MirrorMode; }
 // Forward declaration of `NativeBuffer` to properly resolve imports.
 namespace margelo::nitro::camera { struct NativeBuffer; }
+// Forward declaration of `PhotoContainerFormat` to properly resolve imports.
+namespace margelo::nitro::camera { enum class PhotoContainerFormat; }
 // Forward declaration of `PhotoFile` to properly resolve imports.
 namespace margelo::nitro::camera { struct PhotoFile; }
 // Forward declaration of `PhotoHDRConstraint` to properly resolve imports.
@@ -302,6 +304,7 @@ namespace VisionCamera { class HybridZoomGestureControllerSpec_cxx; }
 #include "MeteringMode.hpp"
 #include "MirrorMode.hpp"
 #include "NativeBuffer.hpp"
+#include "PhotoContainerFormat.hpp"
 #include "PhotoFile.hpp"
 #include "PhotoHDRConstraint.hpp"
 #include "PixelFormat.hpp"
@@ -1308,6 +1311,17 @@ namespace margelo::nitro::camera::bridge::swift {
     return vector;
   }
   
+  // pragma MARK: std::vector<PhotoContainerFormat>
+  /**
+   * Specialized version of `std::vector<PhotoContainerFormat>`.
+   */
+  using std__vector_PhotoContainerFormat_ = std::vector<PhotoContainerFormat>;
+  inline std::vector<PhotoContainerFormat> create_std__vector_PhotoContainerFormat_(size_t size) noexcept {
+    std::vector<PhotoContainerFormat> vector;
+    vector.reserve(size);
+    return vector;
+  }
+
   // pragma MARK: std::vector<Size>
   /**
    * Specialized version of `std::vector<Size>`.

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
@@ -20,6 +20,8 @@ namespace margelo::nitro::camera { enum class CameraPosition; }
 namespace margelo::nitro::camera { class HybridCameraDeviceSpec; }
 // Forward declaration of `PixelFormat` to properly resolve imports.
 namespace margelo::nitro::camera { enum class PixelFormat; }
+// Forward declaration of `PhotoContainerFormat` to properly resolve imports.
+namespace margelo::nitro::camera { enum class PhotoContainerFormat; }
 // Forward declaration of `DynamicRange` to properly resolve imports.
 namespace margelo::nitro::camera { struct DynamicRange; }
 // Forward declaration of `DynamicRangeBitDepth` to properly resolve imports.
@@ -50,6 +52,7 @@ namespace margelo::nitro::camera { class HybridCameraSessionConfigSpec; }
 #include "HybridCameraDeviceSpec.hpp"
 #include <vector>
 #include "PixelFormat.hpp"
+#include "PhotoContainerFormat.hpp"
 #include "DynamicRange.hpp"
 #include "DynamicRangeBitDepth.hpp"
 #include "ColorSpace.hpp"
@@ -142,6 +145,10 @@ namespace margelo::nitro::camera {
     }
     inline std::vector<PixelFormat> getSupportedPixelFormats() noexcept override {
       auto __result = _swiftPart.getSupportedPixelFormats();
+      return __result;
+    }
+    inline std::vector<PhotoContainerFormat> getSupportedPhotoContainerFormats() noexcept override {
+      auto __result = _swiftPart.getSupportedPhotoContainerFormats();
       return __result;
     }
     inline bool getSupportsPhotoHDR() noexcept override {

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
@@ -19,6 +19,7 @@ public protocol HybridCameraDeviceSpec_protocol: HybridObject {
   var physicalDevices: [(any HybridCameraDeviceSpec)] { get }
   var isVirtualDevice: Bool { get }
   var supportedPixelFormats: [PixelFormat] { get }
+  var supportedPhotoContainerFormats: [PhotoContainerFormat] { get }
   var supportsPhotoHDR: Bool { get }
   var supportedVideoDynamicRanges: [DynamicRange] { get }
   var supportedFPSRanges: [Range] { get }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
@@ -199,6 +199,19 @@ open class HybridCameraDeviceSpec_cxx {
     }
   }
   
+  public final var supportedPhotoContainerFormats: bridge.std__vector_PhotoContainerFormat_ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__vector_PhotoContainerFormat_ in
+        var __vector = bridge.create_std__vector_PhotoContainerFormat_(self.__implementation.supportedPhotoContainerFormats.count)
+        for __item in self.__implementation.supportedPhotoContainerFormats {
+          __vector.push_back(__item)
+        }
+        return __vector
+      }()
+    }
+  }
+
   public final var supportsPhotoHDR: Bool {
     @inline(__always)
     get {

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
@@ -23,6 +23,7 @@ namespace margelo::nitro::camera {
       prototype.registerHybridGetter("physicalDevices", &HybridCameraDeviceSpec::getPhysicalDevices);
       prototype.registerHybridGetter("isVirtualDevice", &HybridCameraDeviceSpec::getIsVirtualDevice);
       prototype.registerHybridGetter("supportedPixelFormats", &HybridCameraDeviceSpec::getSupportedPixelFormats);
+      prototype.registerHybridGetter("supportedPhotoContainerFormats", &HybridCameraDeviceSpec::getSupportedPhotoContainerFormats);
       prototype.registerHybridGetter("supportsPhotoHDR", &HybridCameraDeviceSpec::getSupportsPhotoHDR);
       prototype.registerHybridGetter("supportedVideoDynamicRanges", &HybridCameraDeviceSpec::getSupportedVideoDynamicRanges);
       prototype.registerHybridGetter("supportedFPSRanges", &HybridCameraDeviceSpec::getSupportedFPSRanges);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
@@ -21,6 +21,8 @@ namespace margelo::nitro::camera { enum class CameraPosition; }
 namespace margelo::nitro::camera { class HybridCameraDeviceSpec; }
 // Forward declaration of `PixelFormat` to properly resolve imports.
 namespace margelo::nitro::camera { enum class PixelFormat; }
+// Forward declaration of `PhotoContainerFormat` to properly resolve imports.
+namespace margelo::nitro::camera { enum class PhotoContainerFormat; }
 // Forward declaration of `DynamicRange` to properly resolve imports.
 namespace margelo::nitro::camera { struct DynamicRange; }
 // Forward declaration of `Range` to properly resolve imports.
@@ -45,6 +47,7 @@ namespace margelo::nitro::camera { class HybridCameraSessionConfigSpec; }
 #include "HybridCameraDeviceSpec.hpp"
 #include <vector>
 #include "PixelFormat.hpp"
+#include "PhotoContainerFormat.hpp"
 #include "DynamicRange.hpp"
 #include "Range.hpp"
 #include <optional>
@@ -91,6 +94,7 @@ namespace margelo::nitro::camera {
       virtual std::vector<std::shared_ptr<HybridCameraDeviceSpec>> getPhysicalDevices() = 0;
       virtual bool getIsVirtualDevice() = 0;
       virtual std::vector<PixelFormat> getSupportedPixelFormats() = 0;
+      virtual std::vector<PhotoContainerFormat> getSupportedPhotoContainerFormats() = 0;
       virtual bool getSupportsPhotoHDR() = 0;
       virtual std::vector<DynamicRange> getSupportedVideoDynamicRanges() = 0;
       virtual std::vector<Range> getSupportedFPSRanges() = 0;

--- a/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
@@ -20,6 +20,7 @@ import type { MeteringMode } from '../common-types/FocusOptions'
 import type { MediaType } from '../common-types/MediaType'
 import type { OutputStreamType } from '../common-types/OutputStreamType'
 import type { PixelFormat } from '../common-types/PixelFormat'
+import type { PhotoContainerFormat } from '../common-types/PhotoContainerFormat'
 import type { QualityPrioritization } from '../common-types/QualityPrioritization'
 import type { Range } from '../common-types/Range'
 import type { Size } from '../common-types/Size'
@@ -115,6 +116,27 @@ export interface CameraDevice
    * {@linkcode CameraDevice} can stream in.
    */
   readonly supportedPixelFormats: PixelFormat[]
+  /**
+   * Gets the explicit {@linkcode PhotoContainerFormat | Photo Container Formats}
+   * this {@linkcode CameraDevice} can capture in when using
+   * {@linkcode PhotoOutputOptions.containerFormat}.
+   *
+   * This only includes real container formats such as
+   * {@linkcode PhotoContainerFormat | 'jpeg'}, {@linkcode PhotoContainerFormat | 'heic'}
+   * or {@linkcode PhotoContainerFormat | 'dng'}.
+   *
+   * The platform default alias {@linkcode TargetPhotoContainerFormat | 'native'}
+   * is intentionally not listed here, because it resolves to a platform-specific
+   * processed format (`'jpeg'` on Android and typically `'heic'` on iOS).
+   *
+   * @example
+   * ```ts
+   * const format = device.supportedPhotoContainerFormats.includes('heic')
+   *   ? 'heic'
+   *   : 'jpeg'
+   * ```
+   */
+  readonly supportedPhotoContainerFormats: PhotoContainerFormat[]
 
   /**
    * Get a list of all supported resolutions this {@linkcode CameraDevice}

--- a/packages/react-native-vision-camera/src/specs/outputs/CameraPhotoOutput.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/outputs/CameraPhotoOutput.nitro.ts
@@ -11,7 +11,6 @@ import type { CameraSessionConfig } from '../session/CameraSessionConfig.nitro'
 import type { CameraOutput } from './CameraOutput.nitro'
 
 // TODO: Move depth data into configuration upfront, I think we need to prepare the Photo Output for that natively.
-// TODO: I think there is no way to get `containerFormat` upfront - we dont know what formats are supported! We need to expose that probably via `CameraDevice.supportedPhotoContainerFormats`
 
 /**
  * Configuration options for a {@linkcode CameraPhotoOutput}.
@@ -40,6 +39,9 @@ export interface PhotoOutputOptions {
   /**
    * Specifies the {@linkcode TargetPhotoContainerFormat} to
    * shoot the {@linkcode Photo} in.
+   *
+   * To check which explicit container formats are supported upfront,
+   * inspect {@linkcode CameraDevice.supportedPhotoContainerFormats}.
    */
   containerFormat: TargetPhotoContainerFormat
   /**


### PR DESCRIPTION
## Summary
- expose `CameraDevice.supportedPhotoContainerFormats` so apps can choose a valid photo container format before capture
- implement platform-aware format discovery on Android and iOS and wire the new property through Nitro-generated bindings
- log the new capability in the simple camera example and document `PhotoOutputOptions.containerFormat` against the new property

## Testing
- `cd packages/react-native-vision-camera && tsc --noEmit false && nitrogen`
- `cd apps/simple-camera/android && ./gradlew.bat :react-native-vision-camera:compileDebugKotlin --no-daemon --console=plain`

## Notes
- iOS build was not run in this environment