### PR TITLE
feat(ios): expose custom audio session control

### DIFF
--- a/docs/content/docs/video-output.mdx
+++ b/docs/content/docs/video-output.mdx
@@ -95,6 +95,34 @@ const videoOutput = VisionCamera.createVideoOutput({
 > [!WARNING]
 > Enabling Audio requires microphone permission.
 
+#### Custom iOS Audio Session Control
+
+On iOS, `AVCaptureSession` normally configures the app's `AVAudioSession` automatically when audio recording is active.
+
+If you only want to keep already-playing audio alive while recording, enable [`allowBackgroundAudioPlayback`](/api/react-native-vision-camera/interfaces/CameraProps#allowbackgroundaudioplayback):
+
+```tsx
+const camera = useCamera({
+  isActive: true,
+  device: device,
+  outputs: [videoOutput],
+  allowBackgroundAudioPlayback: true,
+})
+```
+
+If you need full control over the app's `AVAudioSession` category or mode, disable [`automaticallyConfiguresApplicationAudioSession`](/api/react-native-vision-camera/interfaces/CameraProps#automaticallyconfiguresapplicationaudiosession) and configure `AVAudioSession` yourself using your preferred native integration:
+
+```tsx
+const camera = useCamera({
+  isActive: true,
+  device: device,
+  outputs: [videoOutput],
+  automaticallyConfiguresApplicationAudioSession: false,
+})
+```
+
+This is especially useful for FaceTime-style experiences where you want to use a custom `AVAudioSession` mode such as `videoChat`, `voiceChat`, or `measurement` through a library like `react-native-volume-manager`.
+
 #### Persistent Video Outputs
 
 By default, an active recording will be automatically stopped when the input [`CameraDevice`](/api/react-native-vision-camera/hybrid-objects/CameraDevice) changes (e.g. when the user flips the Camera from front to back).

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Audio/AudioSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Audio/AudioSession.swift
@@ -16,7 +16,10 @@ class AudioSession {
   private let queue: DispatchQueue
   private let delegate: AudioFrameDelegate
 
-  init() throws {
+  init(
+    automaticallyConfiguresApplicationAudioSession: Bool,
+    allowBackgroundAudioPlayback: Bool?
+  ) throws {
     logger.log("Initializing AudioSession...")
     // 1. Create AVCaptureSession
     self.audioSession = AVCaptureSession()
@@ -24,6 +27,12 @@ class AudioSession {
     self.audioSession.beginConfiguration()
     let audioSession = self.audioSession
     defer { audioSession.commitConfiguration() }
+
+    updateConfiguration(
+      automaticallyConfiguresApplicationAudioSession:
+        automaticallyConfiguresApplicationAudioSession,
+      allowBackgroundAudioPlayback: allowBackgroundAudioPlayback
+    )
 
     // 3. Create audio input
     guard let microphone = AVCaptureDevice.default(for: .audio) else {
@@ -56,6 +65,18 @@ class AudioSession {
     // 8. Add delegate/listener
     self.delegate = AudioFrameDelegate()
     output.setSampleBufferDelegate(delegate, queue: queue)
+  }
+
+  func updateConfiguration(
+    automaticallyConfiguresApplicationAudioSession: Bool,
+    allowBackgroundAudioPlayback: Bool?
+  ) {
+    audioSession.automaticallyConfiguresApplicationAudioSession =
+      automaticallyConfiguresApplicationAudioSession
+    if #available(iOS 18.0, *) {
+      audioSession.configuresApplicationAudioSessionToMixWithOthers =
+        automaticallyConfiguresApplicationAudioSession && (allowBackgroundAudioPlayback ?? false)
+    }
   }
 
   func setOnFrameListener(onFrame: @escaping (CMSampleBuffer, CMTime) -> Void) {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
@@ -62,6 +62,11 @@ class HybridCameraSession: HybridCameraSessionSpec {
         )
       }
 
+      let automaticallyConfiguresApplicationAudioSession =
+        config?.automaticallyConfiguresApplicationAudioSession ?? true
+      self.session.automaticallyConfiguresApplicationAudioSession =
+        automaticallyConfiguresApplicationAudioSession
+
       // Remove all unwanted inputs and add all new inputs
       try self.updateInputs(connections)
       // Remove all unwanted outputs and add all new outputs
@@ -79,7 +84,7 @@ class HybridCameraSession: HybridCameraSessionSpec {
           switch outputConfiguration.output {
           case let output as any NativeCameraOutput:
             // Configure AVCaptureOutput
-            output.configure(config: outputConfiguration)
+            output.configure(config: outputConfiguration, sessionConfig: config)
           case let previewOutput as any NativePreviewViewOutput:
             // Configure AVCaptureVideoPreviewLayer
             previewOutput.configure(config: outputConfiguration)
@@ -100,10 +105,10 @@ class HybridCameraSession: HybridCameraSessionSpec {
       self.session.automaticallyConfiguresCaptureDeviceForWideColor = !hasCustomDynamicRangeConstraint
 
       // Background Audio Playback
-      if let allowBackgroundAudioPlayback = config?.allowBackgroundAudioPlayback {
-        if #available(iOS 18.0, *) {
-          self.session.configuresApplicationAudioSessionToMixWithOthers = allowBackgroundAudioPlayback
-        }
+      if #available(iOS 18.0, *) {
+        self.session.configuresApplicationAudioSessionToMixWithOthers =
+          automaticallyConfiguresApplicationAudioSession
+          && (config?.allowBackgroundAudioPlayback ?? false)
       }
 
       // Return CameraControllers per connection to adjust camera settings (focus, etc)

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoFrameOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoFrameOutput.swift
@@ -14,6 +14,7 @@ class HybridCameraVideoFrameOutput: HybridCameraVideoOutputSpec, NativeCameraOut
   private let queue: DispatchQueue
   private let videoQueue: DispatchQueue
   private var audioSession: AudioSession? = nil
+  private var sessionConfiguration: CameraSessionConfiguration? = nil
   let mediaType: MediaType = .video
   let requiresAudioInput: Bool = false
   let requiresDepthFormat: Bool = false
@@ -83,6 +84,22 @@ class HybridCameraVideoFrameOutput: HybridCameraVideoOutputSpec, NativeCameraOut
     }
     try? connection.setMirrorMode(config.mirrorMode)
     try? connection.setOrientation(outputOrientation)
+  }
+
+  func configure(
+    config: CameraOutputConfiguration,
+    sessionConfig: CameraSessionConfiguration?
+  ) {
+    self.sessionConfiguration = sessionConfig
+    self.configure(config: config)
+
+    if let audioSession {
+      audioSession.updateConfiguration(
+        automaticallyConfiguresApplicationAudioSession:
+          sessionConfig?.automaticallyConfiguresApplicationAudioSession ?? true,
+        allowBackgroundAudioPlayback: sessionConfig?.allowBackgroundAudioPlayback
+      )
+    }
   }
 
   func getSupportedVideoCodecs() throws -> [VideoCodec] {
@@ -212,7 +229,11 @@ class HybridCameraVideoFrameOutput: HybridCameraVideoOutputSpec, NativeCameraOut
       return audioSession
     }
     // 1. Create session
-    let audioSession = try AudioSession()
+    let audioSession = try AudioSession(
+      automaticallyConfiguresApplicationAudioSession:
+        sessionConfiguration?.automaticallyConfiguresApplicationAudioSession ?? true,
+      allowBackgroundAudioPlayback: sessionConfiguration?.allowBackgroundAudioPlayback
+    )
     // 2. Add on frame listener
     audioSession.setOnFrameListener { [weak self] buffer, timestamp in
       guard let self else { return }

--- a/packages/react-native-vision-camera/ios/Public/NativeCameraOutput.swift
+++ b/packages/react-native-vision-camera/ios/Public/NativeCameraOutput.swift
@@ -56,4 +56,25 @@ public protocol NativeCameraOutput: AnyObject, ResolutionNegotionParticipant {
    * such as orientation or mirroring settings in here.
    */
   func configure(config: CameraOutputConfiguration)
+  /**
+   * Called whenever the `CameraOutputConfiguration` or
+   * session-wide configuration might change.
+   *
+   * Outputs that need session-wide settings can override
+   * this method. The default implementation delegates to
+   * `configure(config:)`.
+   */
+  func configure(
+    config: CameraOutputConfiguration,
+    sessionConfig: CameraSessionConfiguration?
+  )
+}
+
+public extension NativeCameraOutput {
+  func configure(
+    config: CameraOutputConfiguration,
+    sessionConfig: CameraSessionConfiguration?
+  ) {
+    self.configure(config: config)
+  }
 }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JCameraSessionConfiguration.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JCameraSessionConfiguration.hpp
@@ -31,9 +31,12 @@ namespace margelo::nitro::camera {
     [[nodiscard]]
     CameraSessionConfiguration toCpp() const {
       static const auto clazz = javaClassStatic();
+      static const auto fieldAutomaticallyConfiguresApplicationAudioSession = clazz->getField<jni::JBoolean>("automaticallyConfiguresApplicationAudioSession");
+      jni::local_ref<jni::JBoolean> automaticallyConfiguresApplicationAudioSession = this->getFieldValue(fieldAutomaticallyConfiguresApplicationAudioSession);
       static const auto fieldAllowBackgroundAudioPlayback = clazz->getField<jni::JBoolean>("allowBackgroundAudioPlayback");
       jni::local_ref<jni::JBoolean> allowBackgroundAudioPlayback = this->getFieldValue(fieldAllowBackgroundAudioPlayback);
       return CameraSessionConfiguration(
+        automaticallyConfiguresApplicationAudioSession != nullptr ? std::make_optional(static_cast<bool>(automaticallyConfiguresApplicationAudioSession->value())) : std::nullopt,
         allowBackgroundAudioPlayback != nullptr ? std::make_optional(static_cast<bool>(allowBackgroundAudioPlayback->value())) : std::nullopt
       );
     }
@@ -44,11 +47,12 @@ namespace margelo::nitro::camera {
      */
     [[maybe_unused]]
     static jni::local_ref<JCameraSessionConfiguration::javaobject> fromCpp(const CameraSessionConfiguration& value) {
-      using JSignature = JCameraSessionConfiguration(jni::alias_ref<jni::JBoolean>);
+      using JSignature = JCameraSessionConfiguration(jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
+        value.automaticallyConfiguresApplicationAudioSession.has_value() ? jni::JBoolean::valueOf(value.automaticallyConfiguresApplicationAudioSession.value()) : nullptr,
         value.allowBackgroundAudioPlayback.has_value() ? jni::JBoolean::valueOf(value.allowBackgroundAudioPlayback.value()) : nullptr
       );
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/CameraSessionConfiguration.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/CameraSessionConfiguration.kt
@@ -19,6 +19,9 @@ import com.facebook.proguard.annotations.DoNotStrip
 data class CameraSessionConfiguration(
   @DoNotStrip
   @Keep
+  val automaticallyConfiguresApplicationAudioSession: Boolean?,
+  @DoNotStrip
+  @Keep
   val allowBackgroundAudioPlayback: Boolean?
 ) {
   /* primary constructor */
@@ -31,8 +34,8 @@ data class CameraSessionConfiguration(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(allowBackgroundAudioPlayback: Boolean?): CameraSessionConfiguration {
-      return CameraSessionConfiguration(allowBackgroundAudioPlayback)
+    private fun fromCpp(automaticallyConfiguresApplicationAudioSession: Boolean?, allowBackgroundAudioPlayback: Boolean?): CameraSessionConfiguration {
+      return CameraSessionConfiguration(automaticallyConfiguresApplicationAudioSession, allowBackgroundAudioPlayback)
     }
   }
 }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/CameraSessionConfiguration.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/CameraSessionConfiguration.swift
@@ -18,8 +18,14 @@ public extension CameraSessionConfiguration {
   /**
    * Create a new instance of `CameraSessionConfiguration`.
    */
-  init(allowBackgroundAudioPlayback: Bool?) {
+  init(automaticallyConfiguresApplicationAudioSession: Bool?, allowBackgroundAudioPlayback: Bool?) {
     self.init({ () -> bridge.std__optional_bool_ in
+      if let __unwrappedValue = automaticallyConfiguresApplicationAudioSession {
+        return bridge.create_std__optional_bool_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_bool_ in
       if let __unwrappedValue = allowBackgroundAudioPlayback {
         return bridge.create_std__optional_bool_(__unwrappedValue)
       } else {
@@ -28,6 +34,18 @@ public extension CameraSessionConfiguration {
     }())
   }
 
+  @inline(__always)
+  var automaticallyConfiguresApplicationAudioSession: Bool? {
+    return { () -> Bool? in
+      if bridge.has_value_std__optional_bool_(self.__automaticallyConfiguresApplicationAudioSession) {
+        let __unwrapped = bridge.get_std__optional_bool_(self.__automaticallyConfiguresApplicationAudioSession)
+        return __unwrapped
+      } else {
+        return nil
+      }
+    }()
+  }
+  
   @inline(__always)
   var allowBackgroundAudioPlayback: Bool? {
     return { () -> Bool? in

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/CameraSessionConfiguration.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/CameraSessionConfiguration.hpp
@@ -39,11 +39,12 @@ namespace margelo::nitro::camera {
    */
   struct CameraSessionConfiguration final {
   public:
+    std::optional<bool> automaticallyConfiguresApplicationAudioSession     SWIFT_PRIVATE;
     std::optional<bool> allowBackgroundAudioPlayback     SWIFT_PRIVATE;
 
   public:
     CameraSessionConfiguration() = default;
-    explicit CameraSessionConfiguration(std::optional<bool> allowBackgroundAudioPlayback): allowBackgroundAudioPlayback(allowBackgroundAudioPlayback) {}
+    explicit CameraSessionConfiguration(std::optional<bool> automaticallyConfiguresApplicationAudioSession, std::optional<bool> allowBackgroundAudioPlayback): automaticallyConfiguresApplicationAudioSession(automaticallyConfiguresApplicationAudioSession), allowBackgroundAudioPlayback(allowBackgroundAudioPlayback) {}
 
   public:
     friend bool operator==(const CameraSessionConfiguration& lhs, const CameraSessionConfiguration& rhs) = default;
@@ -59,11 +60,13 @@ namespace margelo::nitro {
     static inline margelo::nitro::camera::CameraSessionConfiguration fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::camera::CameraSessionConfiguration(
+        JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "automaticallyConfiguresApplicationAudioSession"))),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "allowBackgroundAudioPlayback")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::camera::CameraSessionConfiguration& arg) {
       jsi::Object obj(runtime);
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "automaticallyConfiguresApplicationAudioSession"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.automaticallyConfiguresApplicationAudioSession));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "allowBackgroundAudioPlayback"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.allowBackgroundAudioPlayback));
       return obj;
     }
@@ -75,6 +78,7 @@ namespace margelo::nitro {
       if (!nitro::isPlainObject(runtime, obj)) {
         return false;
       }
+      if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "automaticallyConfiguresApplicationAudioSession")))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "allowBackgroundAudioPlayback")))) return false;
       return true;
     }

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
@@ -10,6 +10,7 @@ import { useMemoizedArray } from './useMemoizedArray'
 import { useStableCallback } from './useStableCallback'
 
 interface Config {
+  automaticallyConfiguresApplicationAudioSession?: boolean
   mirrorMode?: MirrorMode
   allowBackgroundAudioPlayback?: boolean
   constraints?: Constraint[]
@@ -32,6 +33,7 @@ export function useCameraController(
   device: CameraDevice | undefined,
   outputs: CameraOutput[],
   {
+    automaticallyConfiguresApplicationAudioSession,
     mirrorMode = 'auto',
     constraints = [],
     onSessionConfigSelected,
@@ -98,7 +100,11 @@ export function useCameraController(
               onSessionConfigSelected: stableOnSessionConfigSelected,
             },
           ],
-          { allowBackgroundAudioPlayback: allowBackgroundAudioPlayback },
+          {
+            automaticallyConfiguresApplicationAudioSession:
+              automaticallyConfiguresApplicationAudioSession,
+            allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
+          },
         )
         if (isCanceled) {
           controllers.forEach((c) => {
@@ -116,6 +122,7 @@ export function useCameraController(
     }
   }, [
     device,
+    automaticallyConfiguresApplicationAudioSession,
     mirrorMode,
     session,
     allowBackgroundAudioPlayback,

--- a/packages/react-native-vision-camera/src/hooks/useCamera.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCamera.ts
@@ -27,6 +27,30 @@ export interface CameraProps {
   // Session Configuration
   isActive: boolean
   enableMultiCamSupport?: boolean
+  /**
+   * Whether the underlying iOS `AVCaptureSession`s should automatically
+   * configure the application's `AVAudioSession` when audio recording is enabled.
+   *
+   * Disable this if you want to manage `AVAudioSession` yourself,
+   * for example to set a custom `videoChat` or `measurement` mode via
+   * another library.
+   *
+   * @default true
+   * @platform iOS
+   */
+  automaticallyConfiguresApplicationAudioSession?: boolean
+  /**
+   * If enabled, audio that is already playing can continue while a recording
+   * is in progress instead of being interrupted by the Camera.
+   *
+   * This only applies when
+   * {@linkcode CameraProps.automaticallyConfiguresApplicationAudioSession}
+   * is enabled.
+   *
+   * @default false
+   * @platform iOS
+   */
+  allowBackgroundAudioPlayback?: boolean
 
   // Connection Configuration
   device: CameraDevice | CameraPosition
@@ -100,6 +124,8 @@ function defaultOnErrorHandler(error: Error) {
 export function useCamera({
   isActive,
   enableMultiCamSupport = false,
+  automaticallyConfiguresApplicationAudioSession,
+  allowBackgroundAudioPlayback,
   device,
   outputs = [],
   constraints,
@@ -153,6 +179,9 @@ export function useCamera({
 
   // 4. Configure the session with the input + outputs to create a `CameraController`
   const controller = useCameraController(session, input, outputs, {
+    automaticallyConfiguresApplicationAudioSession:
+      automaticallyConfiguresApplicationAudioSession,
+    allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
     mirrorMode: mirrorMode,
     onConfigured: onConfigured,
     getInitialExposureBias: getInitialExposureBias,

--- a/packages/react-native-vision-camera/src/specs/session/CameraSession.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/session/CameraSession.nitro.ts
@@ -115,7 +115,8 @@ export interface CameraSession
    * as a multi-cam session (see {@linkcode CameraFactory.createCameraSession | createCameraSession(enableMultiCam)}),
    * you can add multiple {@linkcode CameraSessionConnection}s.
    * @param config Configures session-wide configuration,
-   * such as {@linkcode CameraSessionConfiguration.allowBackgroundAudioPlayback}.
+   * such as {@linkcode CameraSessionConfiguration.automaticallyConfiguresApplicationAudioSession}
+   * or {@linkcode CameraSessionConfiguration.allowBackgroundAudioPlayback}.
    *
    * @returns One {@linkcode CameraController} per {@linkcode CameraSessionConnection}.
    *

--- a/packages/react-native-vision-camera/src/specs/session/CameraSessionConfiguration.ts
+++ b/packages/react-native-vision-camera/src/specs/session/CameraSessionConfiguration.ts
@@ -5,12 +5,33 @@ import type { CameraSession } from './CameraSession.nitro'
  */
 export interface CameraSessionConfiguration {
   /**
+   * Whether the underlying iOS `AVCaptureSession`s should automatically
+   * configure the application's `AVAudioSession` while recording audio.
+   *
+   * Disable this if you want to fully manage the app-wide
+   * `AVAudioSession` yourself, for example via
+   * `react-native-volume-manager`.
+   *
+   * This setting also applies to the persistent recorder's
+   * dedicated audio capture session.
+   *
+   * If disabled, {@linkcode allowBackgroundAudioPlayback} has no effect.
+   *
+   * @default true
+   * @platform iOS
+   */
+  automaticallyConfiguresApplicationAudioSession?: boolean
+  /**
    * If enabled, the {@linkcode CameraSession} does not interrupt
    * currently playing audio (e.g. music from a different app),
    * while recording.
    *
    * If disabled (the default), any playing audio will be stopped
    * when a recording is started.
+   *
+   * This only applies when
+   * {@linkcode automaticallyConfiguresApplicationAudioSession}
+   * is enabled.
    * @default false
    * @platform iOS
    */


### PR DESCRIPTION
## Summary
- expose `automaticallyConfiguresApplicationAudioSession` on `CameraSessionConfiguration` and the public `useCamera()` / `<Camera />` API
- surface the existing `allowBackgroundAudioPlayback` session option on the public React API
- apply the audio-session setting to both iOS recording paths, including the persistent recorder's dedicated audio capture session
- document how to keep background audio playing or hand `AVAudioSession` control to another library such as `react-native-volume-manager`
- regenerate the Nitro bridge for the updated session config shape

## Why
Issue #2581 asks for more customized audio control, especially for apps that behave more like FaceTime where media playback and microphone capture need to coexist.

The most important missing piece today is that VisionCamera's iOS capture sessions still own application-level audio-session behavior, while apps have no supported way to tell VisionCamera to stop auto-configuring `AVAudioSession`. That makes it hard to use custom `videoChat`, `voiceChat`, or `measurement` modes through another native integration, and it blocks the exact `disableAudioSession` style escape hatch requested in the issue.

This change adds that escape hatch while also exposing the already-implemented background-audio-mixing flag on the public React API.

## Implementation
- add `automaticallyConfiguresApplicationAudioSession?: boolean` to `CameraSessionConfiguration`
- thread the new session setting through `useCameraController()` and `useCamera()` / `<Camera />`
- on iOS, set `AVCaptureSession.automaticallyConfiguresApplicationAudioSession` on the main `HybridCameraSession`
- keep `configuresApplicationAudioSessionToMixWithOthers` in sync when VisionCamera is still managing the app audio session
- extend `NativeCameraOutput` with a session-aware configure hook so outputs that need session-wide state can opt in without changing every output implementation
- make the persistent recorder's separate `AudioSession` respect the same audio-session-management setting and background-audio-mixing flag
- update the video docs with examples for:
  - continuing already-playing audio during recording
  - disabling automatic app audio-session management to let another library control `AVAudioSession`

## Behavior
- by default, behavior stays the same: iOS capture sessions continue to auto-configure the app audio session
- setting `automaticallyConfiguresApplicationAudioSession: false` tells VisionCamera to stop auto-managing the app audio session on iOS
- with automatic management disabled, apps can configure `AVAudioSession` themselves through another native module
- `allowBackgroundAudioPlayback` is now reachable from the public React API and continues to work when VisionCamera is managing the app audio session
- the persistent recorder now follows the same policy as the main camera session instead of silently re-enabling automatic app audio-session management

## Testing
- `npm run typecheck`
- `tsc --noEmit false && nitrogen`
- `.\gradlew.bat :react-native-vision-camera:compileDebugKotlin --no-daemon --console=plain`

## Notes
- this change is implemented for iOS, because the issue's requested `AVAudioSession` escape hatch is iOS-specific
- the new API is intentionally session-scoped so both the normal recorder and persistent recorder can stay aligned

Closes #2581