### PR TITLE
feat(android): Camera Intrinsics 

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/CameraInfo+cameraIntrinsicCalibration.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/CameraInfo+cameraIntrinsicCalibration.kt
@@ -1,0 +1,14 @@
+package com.margelo.nitro.camera.extensions
+
+import android.hardware.camera2.CameraCharacteristics
+import androidx.annotation.OptIn
+import androidx.camera.camera2.interop.Camera2CameraInfo
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
+import androidx.camera.core.CameraInfo
+
+@OptIn(ExperimentalCamera2Interop::class)
+fun CameraInfo.getCameraIntrinsicCalibrationOrNull(): FloatArray? {
+  return Camera2CameraInfo
+    .fromSafe(this)
+    ?.getCameraCharacteristic(CameraCharacteristics.LENS_INTRINSIC_CALIBRATION)
+}

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/FloatArray+cameraIntrinsicMatrix.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/FloatArray+cameraIntrinsicMatrix.kt
@@ -13,9 +13,15 @@ fun FloatArray.toCameraIntrinsicMatrix(sensorToBufferTransform: Matrix? = null):
 
   if (sensorToBufferTransform == null) {
     return doubleArrayOf(
-      fx, 0.0, 0.0,
-      s, fy, 0.0,
-      cx, cy, 1.0,
+      fx,
+      0.0,
+      0.0,
+      s,
+      fy,
+      0.0,
+      cx,
+      cy,
+      1.0,
     )
   }
 

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/FloatArray+cameraIntrinsicMatrix.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/FloatArray+cameraIntrinsicMatrix.kt
@@ -1,0 +1,46 @@
+package com.margelo.nitro.camera.extensions
+
+import android.graphics.Matrix
+
+fun FloatArray.toCameraIntrinsicMatrix(sensorToBufferTransform: Matrix? = null): DoubleArray? {
+  if (size < 5) return null
+
+  val fx = this[0].toDouble()
+  val fy = this[1].toDouble()
+  val cx = this[2].toDouble()
+  val cy = this[3].toDouble()
+  val s = this[4].toDouble()
+
+  if (sensorToBufferTransform == null) {
+    return doubleArrayOf(
+      fx, 0.0, 0.0,
+      s, fy, 0.0,
+      cx, cy, 1.0,
+    )
+  }
+
+  val transformValues = FloatArray(9)
+  sensorToBufferTransform.getValues(transformValues)
+
+  val a = transformValues[Matrix.MSCALE_X].toDouble()
+  val b = transformValues[Matrix.MSKEW_X].toDouble()
+  val c = transformValues[Matrix.MTRANS_X].toDouble()
+  val d = transformValues[Matrix.MSKEW_Y].toDouble()
+  val e = transformValues[Matrix.MSCALE_Y].toDouble()
+  val f = transformValues[Matrix.MTRANS_Y].toDouble()
+  val g = transformValues[Matrix.MPERSP_0].toDouble()
+  val h = transformValues[Matrix.MPERSP_1].toDouble()
+  val i = transformValues[Matrix.MPERSP_2].toDouble()
+
+  return doubleArrayOf(
+    a * fx,
+    d * fx,
+    g * fx,
+    a * s + b * fy,
+    d * s + e * fy,
+    g * s + h * fy,
+    a * cx + b * cy + c,
+    d * cx + e * cy + f,
+    g * cx + h * cy + i,
+  )
+}

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+cameraIntrinsicCalibration.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+cameraIntrinsicCalibration.kt
@@ -1,0 +1,12 @@
+package com.margelo.nitro.camera.extensions
+
+import android.annotation.SuppressLint
+import android.hardware.camera2.CaptureResult
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.impl.CameraCaptureResults
+
+@SuppressLint("RestrictedApi")
+fun ImageProxy.getCameraIntrinsicCalibrationOrNull(): FloatArray? {
+  val captureResult = CameraCaptureResults.retrieveCameraCaptureResult(imageInfo)?.captureResult
+  return captureResult?.get(CaptureResult.LENS_INTRINSIC_CALIBRATION)
+}

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
@@ -112,7 +112,7 @@ class HybridCameraSession(
                     ?: throw Error("Output ${it.output} is not of type `NativeCameraOutput`!")
                 }
               val outputConfig = emptyList<Constraint>().toConfig()
-              val preparedUseCases = outputs.map { it.createUseCase(it.mirrorMode, outputConfig) }
+              val preparedUseCases = outputs.map { it.createUseCase(cameraInfo, it.mirrorMode, outputConfig) }
               allPreparedUseCases.addAll(preparedUseCases)
               val useCaseGroup = UseCaseGroup.Builder()
               preparedUseCases.forEach { useCaseGroup.addUseCase(it.useCase) }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
@@ -111,8 +111,8 @@ class HybridCameraSession(
                   it.output as? NativeCameraOutput
                     ?: throw Error("Output ${it.output} is not of type `NativeCameraOutput`!")
                 }
-              val outputConfig = emptyList<Constraint>().toConfig()
-              val preparedUseCases = outputs.map { it.createUseCase(cameraInfo, it.mirrorMode, outputConfig) }
+              val outputConfig = emptyList<Constraint>().toConfig(cameraInfo)
+              val preparedUseCases = outputs.map { it.createUseCase(it.mirrorMode, outputConfig) }
               allPreparedUseCases.addAll(preparedUseCases)
               val useCaseGroup = UseCaseGroup.Builder()
               preparedUseCases.forEach { useCaseGroup.addUseCase(it.useCase) }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridDepthFrame.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridDepthFrame.kt
@@ -124,7 +124,7 @@ class HybridDepthFrame(
   }
 
   override fun toFrame(): HybridFrameSpec {
-    return HybridFrame(image, orientation, isMirrored)
+    return HybridFrame(image, orientation, isMirrored, null)
   }
 
   override fun toFrameAsync(): Promise<HybridFrameSpec> {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridFrame.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridFrame.kt
@@ -21,6 +21,7 @@ class HybridFrame(
   override val image: ImageProxy,
   override val orientation: CameraOrientation,
   override val isMirrored: Boolean,
+  override val cameraIntrinsicMatrix: DoubleArray?,
 ) : HybridFrameSpec(),
   NativeFrame {
   override val timestamp: Double
@@ -50,10 +51,6 @@ class HybridFrame(
     get() = image.pixelFormat
   override val isPlanar: Boolean
     get() = image.planes.size > 1
-
-  // TODO: Implement `cameraIntrinsicMatrix`
-  override val cameraIntrinsicMatrix: DoubleArray?
-    get() = null
 
   override val memorySize: Long
     get() = image.width * image.height * 4L

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridFrameOutput.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridFrameOutput.kt
@@ -1,15 +1,8 @@
 package com.margelo.nitro.camera.hybrids.outputs
 
 import android.annotation.SuppressLint
-import android.hardware.camera2.CameraCharacteristics
-import android.hardware.camera2.CaptureResult
-import androidx.annotation.OptIn
-import androidx.camera.camera2.interop.Camera2CameraInfo
-import androidx.camera.camera2.interop.ExperimentalCamera2Interop
-import androidx.camera.core.CameraInfo
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
-import androidx.camera.core.impl.CameraCaptureResults
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import com.margelo.nitro.camera.CameraOrientation
 import com.margelo.nitro.camera.FrameDroppedReason
@@ -21,7 +14,7 @@ import com.margelo.nitro.camera.MediaType
 import com.margelo.nitro.camera.MirrorMode
 import com.margelo.nitro.camera.TargetVideoPixelFormat
 import com.margelo.nitro.camera.extensions.converters.toSize
-import com.margelo.nitro.camera.extensions.fromSafe
+import com.margelo.nitro.camera.extensions.getCameraIntrinsicCalibrationOrNull
 import com.margelo.nitro.camera.extensions.orientation
 import com.margelo.nitro.camera.extensions.setAllowDroppingLateFrames
 import com.margelo.nitro.camera.extensions.sortedByClosestTo
@@ -61,37 +54,16 @@ class HybridFrameOutput(
 
   private var staticCameraIntrinsicCalibration: FloatArray? = null
 
-  @OptIn(ExperimentalCamera2Interop::class)
   override fun createUseCase(
-    cameraInfo: CameraInfo,
     mirrorMode: MirrorMode,
     config: NativeCameraOutput.Config,
   ): NativeCameraOutput.PreparedUseCase {
-    val staticCameraIntrinsicCalibration =
+    staticCameraIntrinsicCalibration =
       if (options.enableCameraMatrixDelivery) {
-        Camera2CameraInfo
-          .fromSafe(cameraInfo)
-          ?.getCameraCharacteristic(CameraCharacteristics.LENS_INTRINSIC_CALIBRATION)
+        config.cameraInfo?.getCameraIntrinsicCalibrationOrNull()
       } else {
         null
       }
-
-    return createUseCase(mirrorMode, config, staticCameraIntrinsicCalibration)
-  }
-
-  override fun createUseCase(
-    mirrorMode: MirrorMode,
-    config: NativeCameraOutput.Config,
-  ): NativeCameraOutput.PreparedUseCase {
-    return createUseCase(mirrorMode, config, null)
-  }
-
-  private fun createUseCase(
-    mirrorMode: MirrorMode,
-    config: NativeCameraOutput.Config,
-    staticCameraIntrinsicCalibration: FloatArray?,
-  ): NativeCameraOutput.PreparedUseCase {
-    this.staticCameraIntrinsicCalibration = staticCameraIntrinsicCalibration
 
     val resolutionSelector =
       ResolutionSelector
@@ -173,13 +145,11 @@ class HybridFrameOutput(
     }
   }
 
-  @SuppressLint("RestrictedApi")
   private fun getCameraIntrinsicMatrix(image: ImageProxy): DoubleArray? {
     if (!options.enableCameraMatrixDelivery) return null
 
-    val captureResult = CameraCaptureResults.retrieveCameraCaptureResult(image.imageInfo)?.captureResult
     val cameraIntrinsicCalibration =
-      captureResult?.get(CaptureResult.LENS_INTRINSIC_CALIBRATION)
+      image.getCameraIntrinsicCalibrationOrNull()
         ?: staticCameraIntrinsicCalibration
 
     return cameraIntrinsicCalibration?.toCameraIntrinsicMatrix(image.imageInfo.sensorToBufferTransformMatrix)

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridFrameOutput.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridFrameOutput.kt
@@ -1,7 +1,15 @@
 package com.margelo.nitro.camera.hybrids.outputs
 
 import android.annotation.SuppressLint
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CaptureResult
+import androidx.annotation.OptIn
+import androidx.camera.camera2.interop.Camera2CameraInfo
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
+import androidx.camera.core.CameraInfo
 import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.impl.CameraCaptureResults
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import com.margelo.nitro.camera.CameraOrientation
 import com.margelo.nitro.camera.FrameDroppedReason
@@ -13,10 +21,12 @@ import com.margelo.nitro.camera.MediaType
 import com.margelo.nitro.camera.MirrorMode
 import com.margelo.nitro.camera.TargetVideoPixelFormat
 import com.margelo.nitro.camera.extensions.converters.toSize
+import com.margelo.nitro.camera.extensions.fromSafe
 import com.margelo.nitro.camera.extensions.orientation
 import com.margelo.nitro.camera.extensions.setAllowDroppingLateFrames
 import com.margelo.nitro.camera.extensions.sortedByClosestTo
 import com.margelo.nitro.camera.extensions.surfaceRotation
+import com.margelo.nitro.camera.extensions.toCameraIntrinsicMatrix
 import com.margelo.nitro.camera.hybrids.HybridNativeThread
 import com.margelo.nitro.camera.hybrids.instances.HybridFrame
 import com.margelo.nitro.camera.public.NativeCameraOutput
@@ -49,10 +59,40 @@ class HybridFrameOutput(
       updateAnalyzer()
     }
 
+  private var staticCameraIntrinsicCalibration: FloatArray? = null
+
+  @OptIn(ExperimentalCamera2Interop::class)
+  override fun createUseCase(
+    cameraInfo: CameraInfo,
+    mirrorMode: MirrorMode,
+    config: NativeCameraOutput.Config,
+  ): NativeCameraOutput.PreparedUseCase {
+    val staticCameraIntrinsicCalibration =
+      if (options.enableCameraMatrixDelivery) {
+        Camera2CameraInfo
+          .fromSafe(cameraInfo)
+          ?.getCameraCharacteristic(CameraCharacteristics.LENS_INTRINSIC_CALIBRATION)
+      } else {
+        null
+      }
+
+    return createUseCase(mirrorMode, config, staticCameraIntrinsicCalibration)
+  }
+
   override fun createUseCase(
     mirrorMode: MirrorMode,
     config: NativeCameraOutput.Config,
   ): NativeCameraOutput.PreparedUseCase {
+    return createUseCase(mirrorMode, config, null)
+  }
+
+  private fun createUseCase(
+    mirrorMode: MirrorMode,
+    config: NativeCameraOutput.Config,
+    staticCameraIntrinsicCalibration: FloatArray?,
+  ): NativeCameraOutput.PreparedUseCase {
+    this.staticCameraIntrinsicCalibration = staticCameraIntrinsicCalibration
+
     val resolutionSelector =
       ResolutionSelector
         .Builder()
@@ -124,12 +164,25 @@ class HybridFrameOutput(
         // target orientation.
         val orientation = image.orientation
         val isMirrored = mirrorMode == MirrorMode.ON
-        val frame = HybridFrame(image, orientation, isMirrored)
+        val cameraIntrinsicMatrix = getCameraIntrinsicMatrix(image)
+        val frame = HybridFrame(image, orientation, isMirrored, cameraIntrinsicMatrix)
         onFrame(frame)
       }
     } else {
       imageAnalysis.clearAnalyzer()
     }
+  }
+
+  @SuppressLint("RestrictedApi")
+  private fun getCameraIntrinsicMatrix(image: ImageProxy): DoubleArray? {
+    if (!options.enableCameraMatrixDelivery) return null
+
+    val captureResult = CameraCaptureResults.retrieveCameraCaptureResult(image.imageInfo)?.captureResult
+    val cameraIntrinsicCalibration =
+      captureResult?.get(CaptureResult.LENS_INTRINSIC_CALIBRATION)
+        ?: staticCameraIntrinsicCalibration
+
+    return cameraIntrinsicCalibration?.toCameraIntrinsicMatrix(image.imageInfo.sensorToBufferTransformMatrix)
   }
 
   override fun setOnFrameCallback(onFrame: ((HybridFrameSpec) -> Boolean)?) {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/public/NativeCameraOutput.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/public/NativeCameraOutput.kt
@@ -1,6 +1,7 @@
 package com.margelo.nitro.camera.public
 
 import android.util.Range
+import androidx.camera.core.CameraInfo
 import androidx.camera.core.UseCase
 import com.margelo.nitro.camera.MirrorMode
 import com.margelo.nitro.camera.TargetDynamicRange
@@ -57,6 +58,15 @@ interface NativeCameraOutput {
    * [UseCase], which could result in better
    * performance and session start times with large
    * allocations.
+   */
+  fun createUseCase(
+    cameraInfo: CameraInfo,
+    mirrorMode: MirrorMode,
+    config: Config,
+  ): PreparedUseCase = createUseCase(mirrorMode, config)
+
+  /**
+   * Creates a [PreparedUseCase] for the given [Config].
    */
   fun createUseCase(
     mirrorMode: MirrorMode,

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/public/NativeCameraOutput.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/public/NativeCameraOutput.kt
@@ -18,6 +18,7 @@ interface NativeCameraOutput {
     val videoStabilizationMode: TargetStabilizationMode?,
     val videoDynamicRange: TargetDynamicRange?,
     val photoHDR: Boolean?,
+    val cameraInfo: CameraInfo? = null,
   )
 
   /**
@@ -58,15 +59,6 @@ interface NativeCameraOutput {
    * [UseCase], which could result in better
    * performance and session start times with large
    * allocations.
-   */
-  fun createUseCase(
-    cameraInfo: CameraInfo,
-    mirrorMode: MirrorMode,
-    config: Config,
-  ): PreparedUseCase = createUseCase(mirrorMode, config)
-
-  /**
-   * Creates a [PreparedUseCase] for the given [Config].
    */
   fun createUseCase(
     mirrorMode: MirrorMode,

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/session/ConstraintResolver.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/session/ConstraintResolver.kt
@@ -58,13 +58,13 @@ object ConstraintResolver {
     // Pass 1: Resolve features (stab, HDR, etc.) via isSessionConfigSupported.
     // SessionConfig is built WITHOUT FPS — FPS ranges depend on the resolved features.
     while (true) {
-      val config = activeConstraints.toConfig()
+      val config = activeConstraints.toConfig(cameraInfo)
       val preparedUseCases =
         outputConfigurations.map { outputConfiguration ->
           val output =
             outputConfiguration.output as? NativeCameraOutput
               ?: throw Error("The given `output` (${outputConfiguration.output}) is not of type `NativeCameraOutput`!")
-          return@map output.createUseCase(cameraInfo, outputConfiguration.mirrorMode, config)
+          return@map output.createUseCase(outputConfiguration.mirrorMode, config)
         }
       val sessionConfig =
         SessionConfig
@@ -140,13 +140,14 @@ object ConstraintResolver {
  * FPS is not resolved here — it requires a validated [SessionConfig]
  * and is resolved separately in [FPSConstraint.resolveFPSRange].
  */
-internal fun List<Constraint>.toConfig(): NativeCameraOutput.Config {
+internal fun List<Constraint>.toConfig(cameraInfo: CameraInfo? = null): NativeCameraOutput.Config {
   return NativeCameraOutput.Config(
     fpsRange = null, // resolved after feature validation
     previewStabilizationMode = firstNotNullOfOrNull { it.asType<PreviewStabilizationModeConstraint>() }?.previewStabilizationMode,
     videoStabilizationMode = firstNotNullOfOrNull { it.asType<VideoStabilizationModeConstraint>() }?.videoStabilizationMode,
     videoDynamicRange = firstNotNullOfOrNull { it.asType<VideoDynamicRangeConstraint>() }?.videoDynamicRange,
     photoHDR = firstNotNullOfOrNull { it.asType<PhotoHDRConstraint>() }?.photoHDR,
+    cameraInfo = cameraInfo,
   )
 }
 

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/session/ConstraintResolver.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/session/ConstraintResolver.kt
@@ -64,7 +64,7 @@ object ConstraintResolver {
           val output =
             outputConfiguration.output as? NativeCameraOutput
               ?: throw Error("The given `output` (${outputConfiguration.output}) is not of type `NativeCameraOutput`!")
-          return@map output.createUseCase(outputConfiguration.mirrorMode, config)
+          return@map output.createUseCase(cameraInfo, outputConfiguration.mirrorMode, config)
         }
       val sessionConfig =
         SessionConfig

--- a/packages/react-native-vision-camera/src/specs/instances/Frame.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/instances/Frame.nitro.ts
@@ -299,18 +299,24 @@ export interface Frame
    * Its origin is the top-left of the Frame.
    *
    * ```
-   * K = [ fx   0  cx ]
+   * K = [ fx   s  cx ]
    *     [  0  fy  cy ]
    *     [  0   0   1 ]
    * ```
    * - `fx`, `fy`: focal length in pixels
+   * - `s`: skew
    * - `cx`, `cy`: principal point in pixels
    *
    *
-   * @platform iOS
    * @note The {@linkcode Frame} only has a Camera intrinsic matrix attached
    * if {@linkcode FrameOutputOptions.enableCameraMatrixDelivery | enableCameraMatrixDelivery}
    * is set to true on the `CameraFrameOutput`.
+   * @note On Android, VisionCamera first reads the per-frame Camera2
+   * {@link https://developer.android.com/reference/android/hardware/camera2/CaptureResult#LENS_INTRINSIC_CALIBRATION | CaptureResult.LENS_INTRINSIC_CALIBRATION}
+   * value, and falls back to the static Camera2
+   * {@link https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics#LENS_INTRINSIC_CALIBRATION | CameraCharacteristics.LENS_INTRINSIC_CALIBRATION}
+   * value if the per-frame value is unavailable. The Camera2 calibration is
+   * transformed into Frame coordinates before it is exposed here.
    * @example
    * ```ts
    * const matrix = frame.cameraIntrinsicMatrix

--- a/packages/react-native-vision-camera/src/specs/outputs/CameraFrameOutput.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/outputs/CameraFrameOutput.nitro.ts
@@ -138,8 +138,10 @@ export interface FrameOutputOptions {
    *
    *
    * @see {@linkcode Frame.cameraIntrinsicMatrix}
-   * @throws If video stabilization is enabled, as intrinsic matrix delivery only works when video stabilization is `'off'`.
-   * @platform iOS
+   * @throws On iOS, if video stabilization is enabled, as intrinsic matrix delivery only works when video stabilization is `'off'`.
+   * @note On Android, the intrinsic matrix is read from Camera2 capture metadata
+   * when available, with static camera characteristics as a fallback. Camera2
+   * calibration values are transformed into Frame coordinates.
    * @default false
    */
   enableCameraMatrixDelivery: boolean


### PR DESCRIPTION
## What
Adds Android support for `Frame.cameraIntrinsicMatrix` on Frame Outputs.

Android now honors the existing `enableCameraMatrixDelivery` option. When enabled, each `HybridFrame` attempts to resolve camera intrinsics from Camera2 metadata and exposes them through the existing `Frame.cameraIntrinsicMatrix` property. No new JS API is added.

## Implementation

On Android, intrinsics are resolved in this order:

1. Per-frame Camera2 metadata:
   `CaptureResult.LENS_INTRINSIC_CALIBRATION`
2. Static camera metadata fallback:
   `CameraCharacteristics.LENS_INTRINSIC_CALIBRATION`

Camera2 exposes intrinsics as five calibration values:

```txt
[fx, fy, cx, cy, s]
```

VisionCamera converts those into the existing 3x3 matrix shape:
``` txt
[ fx  s  cx ]
[  0 fy  cy ]
[  0  0   1 ]
```
serialized consistently with the existing native matrix array convention.

The Android implementation also applies CameraX’s `ImageInfo.sensorToBufferTransformMatrix` before exposing the matrix, so the returned values are in the Frame/buffer coordinate space expected by Frame.cameraIntrinsicMatrix.

This PR intentionally does not use CaptureResult.STATISTICS_LENS_INTRINSICS_SAMPLES. That key is API 35+, optional, and represents multiple intra-frame lens intrinsics samples rather than a single frame-level matrix. The existing JS API exposes a single number[] intrinsic matrix on Frame, so those samples would require a different API shape to represent correctly.

## Validation
Android Kotlin compile:
`./gradlew :react-native-vision-camera:compileDebugKotlin :react-native-vision-camera-barcode-scanner:compileDebugKotlin`

Typecheck:
`npm run typecheck --workspace react-native-vision-camera`

Manual Android validation on Pixel 6a:
enableCameraMatrixDelivery: true returns a 9-number matrix.
Returned cx/cy are transformed into frame coordinates.
Unsupported or initially unavailable metadata keeps streaming and returns undefined.