### PR TITLE
fix(ios): barcode format filter ignored in react-native-vision-camera-barcode-scanner due to discarded union result

### DIFF
--- a/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeScannerOptions.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeScannerOptions.swift
@@ -13,7 +13,7 @@ extension BarcodeScannerOptions {
     // combines the array into an OptionSet/bitmask
     let combinedFormats = formats.reduce(into: MLKitBarcodeScanning.BarcodeFormat()) {
       partial, next in
-      _ = partial.union(next)
+      partial.formUnion(next)
     }
     return MLKitBarcodeScanning.BarcodeScannerOptions(formats: combinedFormats)
   }
@@ -25,7 +25,7 @@ extension BarcodeScannerOutputOptions {
     // combines the array into an OptionSet/bitmask
     let combinedFormats = formats.reduce(into: MLKitBarcodeScanning.BarcodeFormat()) {
       partial, next in
-      _ = partial.union(next)
+      partial.formUnion(next)
     }
     return MLKitBarcodeScanning.BarcodeScannerOptions(formats: combinedFormats)
   }


### PR DESCRIPTION
The iOS MLKit barcode format was always empty because OptionSet.union() returns a new value rather than mutating in place, so the result was discarded on every iteration. Replaced with formUnion() so the format filter is actually applied. 