### PR TITLE
fix: Fix `NullPointerException` in `acquireLatestImage()` for `PRIVATE` `ImageReaderProxy`

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/utils/PrivateImageReaderProxy.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/utils/PrivateImageReaderProxy.kt
@@ -37,13 +37,17 @@ class PrivateImageReaderProxy : ImageReaderProxy {
     }
   }
 
-  override fun acquireLatestImage(): ImageProxy {
-    val image = imageReader.acquireLatestImage()
+  override fun acquireLatestImage(): ImageProxy? {
+    val image =
+      imageReader.acquireLatestImage()
+        ?: return null
     return PrivateImageProxy(image)
   }
 
-  override fun acquireNextImage(): ImageProxy {
-    val image = imageReader.acquireNextImage()
+  override fun acquireNextImage(): ImageProxy? {
+    val image =
+      imageReader.acquireNextImage()
+        ?: return null
     return PrivateImageProxy(image)
   }
 


### PR DESCRIPTION
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3807