### PR TITLE
feat: Allow excluding MLKit with a pod install flag

### DIFF
--- a/apps/simple-camera/ios/Podfile.lock
+++ b/apps/simple-camera/ios/Podfile.lock
@@ -2755,95 +2755,95 @@ SPEC CHECKSUMS:
   MLKitCommon: 26b779f072a182c1603d4c88a101c350cac837b1
   MLKitVision: fa8dea9012ac59497c79ddbe9ebf32051047ac4c
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  NitroImage: bf3c19ea96629e5ab1665f61d720efc0df53377a
-  NitroModules: 2ece7b1523f5e1952c5bcea7c318df11b8ac856b
+  NitroImage: ab426b8e953c0a4464ccc7f34612f659d0064329
+  NitroModules: 4623499842af916a6cb462950b024a47eef7d6ea
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
-  RCTSwiftUIWrapper: e3eed9f50cad9f171e4487e2ff18a9caa4d46bfb
+  RCTSwiftUIWrapper: 55e482219b78c2c652123fea845a6b1716fa97e7
   RCTTypeSafety: e9ba155357c236764934054ee2d393fd76e7b36b
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
-  React-Core: c0fb1df65eb0ed7a8633841831f05f93c3eb3aff
+  React-Core: c609976c034ba9556bef9850a571a71bd458d73f
   React-Core-prebuilt: 4978df8b63170d68b35f64f5e070d67e24e67184
-  React-CoreModules: 7dfe7962360355f1547c85ab52e1fc4b57f17127
-  React-cxxreact: 9e9c7f1710bc58abebf924813b5e825b99adb8e5
+  React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
+  React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
-  React-defaultsnativemodule: a326ccbb71369762888a6be09a23fa5bce2bdb6a
-  React-domnativemodule: 8394c7b535d1b484b1eab677e00b086507cd906a
-  React-Fabric: 682dafd75455062590cd1f63c79199cf72ff27d9
-  React-FabricComponents: 11b13a53213cd1aaca3bf7f4c61c669617b26b5f
-  React-FabricImage: 706c27e82f77b77db96ab3a19009ddb5e777967f
-  React-featureflags: c2898fb2f93ab92cfd9f294b4531d2884e7cfc7e
-  React-featureflagsnativemodule: 1edf93adfa12ba4f15d07079c1675b55ff579477
-  React-graphics: 57d042385bfef5104aafeab189f43b8d6145013b
-  React-hermes: 96d2d439f0477a93fe8e801664088eccc07a16ff
-  React-idlecallbacksnativemodule: ab4dc6c3657f434f82c568ca83c963791e783f6a
-  React-ImageManager: f39057f375cf3f98255fb751df3865a91f2755c1
-  React-intersectionobservernativemodule: 54ce679b183149fd9566a79211f2f54dc0a6fd1f
-  React-jserrorhandler: 2e92acff04ac815c6066c7cc08ea302610045db1
-  React-jsi: dc97891e1ee7fa17cad01cd150c50f21e04bd51b
-  React-jsiexecutor: e1543ba5a8be761331c8158d91211079cc5b73a2
-  React-jsinspector: 7a1d86673986db6666cacc8b95e92125397ab6ea
-  React-jsinspectorcdp: 38a0c116fd4965abf29261721db9b903923cb723
-  React-jsinspectornetwork: cfeace6b40f13ba82980ba7cb730847a35675c7f
-  React-jsinspectortracing: 5507411117e51751dba0543cdee7916eb0388693
-  React-jsitooling: e3a2df9043ab7b9ad11bbbfe4b33eb6762514f05
-  React-jsitracing: ad179fab1c1e08a57fcdb840b7021b453f7a2b6d
-  React-logger: e40cc24a61d3a54c09bf4e83d5556b3b9d4c90aa
-  React-Mapbuffer: 53f28c81b84767a0b2fb4c0109dd7e4571226f76
-  React-microtasksnativemodule: ddaf25a8d69f694bc880fb6055e34d79f1d50138
-  react-native-blur: 4173cfa2b37358b2e767ca690a8afa2cb74b0aae
-  react-native-menu: 17321e8d0d15af018c56ae7e4e42268ef297f6c3
-  react-native-safe-area-context: 29044d05d61f2c60d0828c373bd0ebe17eed58d0
-  react-native-skia: a9c0ab55f18fa812b0db161c333e8bff4d739bb9
+  React-defaultsnativemodule: c1c25636322de460083d9291bc813067aa706552
+  React-domnativemodule: d1734e540ea9344ec1a024de5704d39063935049
+  React-Fabric: 48a292ed21257b0d9639e3c4cc49047a2c8a7f8f
+  React-FabricComponents: 932d81e7e2de71c25a63c1832f76f123e1a091f3
+  React-FabricImage: adbb7b606e96add2785646a1c81e285367f0d249
+  React-featureflags: 2a6f0a8f885559e1192e8bb0c173de638529df20
+  React-featureflagsnativemodule: 255521af601b622048ec50b5dbf104cc886762a8
+  React-graphics: ddca902e78ca64a824c31d206b083a3f207d6d06
+  React-hermes: b5df3aebd45da232c6e8c9d925260e9d64122d03
+  React-idlecallbacksnativemodule: fb05344181eeb52c5fd54597599b6e71b05dcf21
+  React-ImageManager: 4861de430733ee8cf9fd06acb9fdf65d8d551f9d
+  React-intersectionobservernativemodule: 6699faee489b3439a4961270e880d814690f4eea
+  React-jserrorhandler: a3a9796a152ddd2712403d7cd7903624003db4b6
+  React-jsi: 2c0a2219dacbdf776c5c911fae6f8923813d1ff2
+  React-jsiexecutor: 0c4082df04719e747ae6d728e4e238ef1de16457
+  React-jsinspector: f4d6e379303d120888cd1e15e3e7e1b2b4d41b37
+  React-jsinspectorcdp: 0147c000c3a9e05082d974fdb05f8fc0c470787d
+  React-jsinspectornetwork: d5e1b2d72d1a205aee8141906735bd85c4cb9a7c
+  React-jsinspectortracing: 8d52e3fcb00cf6c4fcdeac0ec7b10bfe819693e1
+  React-jsitooling: 455d72275baff87bd39a8a1b315e0bd8b13fa8e9
+  React-jsitracing: 5a15b0ecc476e47533236dbbf2b6e670d6d8aa41
+  React-logger: 9e51e01455f15cb3ef87a09a1ec773cdb22d56c1
+  React-Mapbuffer: 92b99e450e8ff598b27d6e4db3a75e04fd45e9a9
+  React-microtasksnativemodule: 2fe0f2bd2840dedbd66c0ac249c64f977f39cc18
+  react-native-blur: 1b00ef07fe0efdc0c40b37139a5268ccad73c72d
+  react-native-menu: 2de122c54dc10056932c0c0f73b82adfa4231faf
+  react-native-safe-area-context: ae7587b95fb580d1800c5b0b2a7bd48c2868e67a
+  react-native-skia: 0504d57b838167855aaeed61598971aef868a417
   react-native-vector-icons-ionicons: 7bc32eadb4d24c93252430b49f25b8be000e2340
-  react-native-video: 8cfc70ca7f8f99906233b1a65a8b3c937fb32c1a
-  React-NativeModulesApple: 14a8919451154ede904f2bca84b27703a09028ba
-  React-networking: 46c0037f9202c1919493b78662a47cbe13022fdd
+  react-native-video: fd30887fff60629061769a21af574fd9dd52b2ff
+  React-NativeModulesApple: 44a9474594566cd03659f92e38f42599c6b9dee4
+  React-networking: db73d91466cb134fcbdaaa579fb2de14e2c2ea01
   React-oscompat: b924b8609d06899f00ab1aa813b0cde9c5e12771
-  React-perflogger: c3bb13800f795287e73a8c1991a2b8e5008ea3d0
-  React-performancecdpmetrics: 851d2b18ba3d3d8cfb309bf468e5e93e46601122
-  React-performancetimeline: 0a960aee139987151d2976813c47bef17dea3d3a
+  React-perflogger: 8afbf1c6c0e6d8f869cb2917492db19dc212312d
+  React-performancecdpmetrics: 9034e89102afda66d6c6fcb43233c24f3927fa78
+  React-performancetimeline: 7860aafe1782694fa6b5ce7bae0dfd199fe049f7
   React-RCTActionSheet: 21fbcd85f552d5d6575453d2e8c149535d9c6f46
-  React-RCTAnimation: 2c8cb9508864bb15e9f8fe86242d8918f05278e9
-  React-RCTAppDelegate: 1d52e34d25f5f1bed5c07e0717c40dc572a80010
-  React-RCTBlob: bc487ebb909c23920af75c842b1405edba61b8ea
-  React-RCTFabric: 7de87d2635b95171a06d9fffd907c4ac17823ef2
-  React-RCTFBReactNativeSpec: b3936c48bf5262dc57ba28f8c8208cd1b570964c
-  React-RCTImage: a591fc9f08dc6c7b63b9fb34f51a7c1f32bd9595
-  React-RCTLinking: cb9553b27de77a63beb4e3ce95f82aa8f3bed602
-  React-RCTNetwork: 576ba853aef49628238b4840e969217b826af156
-  React-RCTRuntime: e0aa5ea63ba4e06c9028da5ae8b05cf72bc8a1ea
-  React-RCTSettings: 8caa15edae452a5c4cd064569d5357a2bee8de15
-  React-RCTText: af9a1c8d7c135c4d3ffa2de253ca95544234a521
-  React-RCTVibration: c1dd36479ca1c1a59d16db81e5a994e9be06a68b
+  React-RCTAnimation: e8840d9f68bbbcf766909d738b021d2c0df1be36
+  React-RCTAppDelegate: 0a491adac54f255d549656cc016c61102aaddfb7
+  React-RCTBlob: f3eceaf519cf0f7f159bb653b3431b26c956400f
+  React-RCTFabric: 6278c2bc45c4b5685f7d7027d86343048b3d906b
+  React-RCTFBReactNativeSpec: ba5c77a9658d3acb7cbc5653162661df1d63ed25
+  React-RCTImage: 928e5125c8e5407f3c6c62d51593eb8000fb2a36
+  React-RCTLinking: 80c236e6e837d297750aac8da269fab24d4e0fc1
+  React-RCTNetwork: 9554720800c31ec6608ed8047a314252e40008ac
+  React-RCTRuntime: d37d53534c207677f86df9b9cb30b7dde8857327
+  React-RCTSettings: 52a066ceedda0253d75755909ee14a11972b16dc
+  React-RCTText: dd2964c3f003549ef3ce9ac5b7966d1c79dc5875
+  React-RCTVibration: dc9e7490a0e270b1ec905c13714434c809a276fa
   React-rendererconsistency: 32e7b98c05a3f237ecb524add21190036962e868
-  React-renderercss: d65e9232e5033cd9c07b13fa429ce925b8143bd7
-  React-rendererdebug: 25c6151116b7ea1f78af72afc64f2066ad29a61d
-  React-RuntimeApple: e036929884cc0d8088fe8a5a2d210e068d35e608
-  React-RuntimeCore: 0c8a252051fe6b627f5147ac5b6a5298951472a8
-  React-runtimeexecutor: 0765dddf1842e23e87ad13b2cb1bb72bb9005aeb
-  React-RuntimeHermes: 44cd4fdc4afa44fa782ddce8600e3cc90215fbc5
-  React-runtimescheduler: 1966ff307933cdbafd480cb3aa1fdc90d9a6d539
-  React-timing: 94c4a44dd2d10e4fc51fd42654fd5f67d68247ad
-  React-utils: 172d467a9c037d5ed51ee6eeaa6ad30ca1ebe1b1
-  React-webperformancenativemodule: 9e3c5032dd30bf6418b741ab54ad26187b1c94c3
-  ReactAppDependencyProvider: 625d2f6d9d5ef01acc9dfe2b5385504bbffd2ad0
-  ReactCodegen: e6f176b40e56d6fa6d441baf3bc2e351172a41a6
-  ReactCommon: cc0e38600f82487c5fe5d29150abb6fa9d981986
+  React-renderercss: b5f27fdea2162033c44af42bd9da7eefb08603a6
+  React-rendererdebug: 09e9a23444c9319c965d7f981f8f2d57d2f88428
+  React-RuntimeApple: 7c2c6aff02da8f1d89c211baa0a98bb76b01dfed
+  React-RuntimeCore: 4b3688f2ddcaf644f8e645ec45b4d77ec9cf58f9
+  React-runtimeexecutor: 8540253f799008af0485a9ec417b001e73a9dede
+  React-RuntimeHermes: abc8b8b62dec3d3f5d685d586dd4b2381fc36ea8
+  React-runtimescheduler: a64d5a112f8f8bc58af6f3e3382452f6f91002c6
+  React-timing: 1f40175beb4b55fa3f6de9f947cd7ed9275deb25
+  React-utils: e157d1837edbb842b9c0201a6a144a4d3d395246
+  React-webperformancenativemodule: 295dde5803df595cd9a266f44e4371bbf12a600e
+  ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
+  ReactCodegen: 2fe81bae8e7b638d8d9b78c3dc1ccc1eeabfc613
+  ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
   ReactNativeDependencies: 15a6a8ab2c09e708aea8edc0a7f90a8a112aef63
-  RNGestureHandler: 6d378fd1aa991c7ab62a4215ee6cc417895a6954
-  RNReanimated: 9c65860a356274f39a796983d10ff58ce828ac9c
-  RNScreens: 088d923c4327c63c9f8c942cae17a9d038f47d97
-  RNVectorIcons: af977c18ed27deba54ed038b439fca2911a08cfc
-  RNWorklets: e72cc4f0a1ffc40ca93479b191f0f33191d0dd97
-  VisionCamera: 48821db425302ff492f57d900110c3c3db9a209a
-  VisionCameraBarcodeScanner: 62a51c41b82e511bb98665400231dcdca7acd451
-  VisionCameraLocation: 12629ff723ba50bc49ed37081436c34b1b99a905
-  VisionCameraResizer: c256f9513c486b4b875ff7baabf558e813067a68
-  VisionCameraWorklets: 7e9c94d19f3eb50968f6f28e95a691d315ae0d98
+  RNGestureHandler: 07de6f059e0ee5744ae9a56feb07ee345338cc31
+  RNReanimated: c05b534f68caa202da4dcc3fd619eab48f67f7bd
+  RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
+  RNVectorIcons: 4351544f100d4f12cac156a7c13399e60bab3e26
+  RNWorklets: 9df54090e67c12b662f1eb1dc98132adafcfa666
+  VisionCamera: 64fe6113ed7b11fc687a1fddc47c812870e09b5b
+  VisionCameraBarcodeScanner: e8677155c49fc8dd1083a4c926ac1c87f1c7f181
+  VisionCameraLocation: 2311e24d07c397bea36c42ded1963cc4bbefc29c
+  VisionCameraResizer: d83707f23ee97fff5b0a20020cd84cb2518ec20a
+  VisionCameraWorklets: d41ba8a2df4103b40b249f26f5cfeb1d497d6636
   Yoga: 0a3b1e85da3524bdc3e0161818c8881ad363f97b
 
 PODFILE CHECKSUM: 225e4ff5bb6719c47fa66724251c4ad2098c76da

--- a/packages/react-native-vision-camera-barcode-scanner/README.md
+++ b/packages/react-native-vision-camera-barcode-scanner/README.md
@@ -19,3 +19,17 @@ npx pod-install
 ```
 
 And rebuild your app.
+
+## iOS: Building without MLKit (CI / arm64 Simulator)
+
+The barcode scanner uses Google's MLKit on iOS. MLKit's binaries don't ship an `arm64-iphonesimulator` slice — only `arm64-iphoneos` and `x86_64-iphonesimulator`. To work around this, MLKit's pods set `EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64`, which propagates to your app and forces simulators to run as x86_64 via Rosetta on Apple Silicon Macs. This is automatic and requires no setup for typical local development.
+
+CI builds that explicitly target the arm64 iOS Simulator (e.g. `xcodebuild -arch arm64 -destination 'platform=iOS Simulator,arch=arm64,...'`, or Apple Silicon runners without Rosetta installed) will fail to link MLKit. If you need the build to succeed in that environment, you can opt out of MLKit at `pod install` time:
+
+```sh
+VISION_CAMERA_DISABLE_MLKIT=1 npx pod-install
+```
+
+This drops the `GoogleMLKit/BarcodeScanning` pod entirely, removes the `EXCLUDED_ARCHS` constraint, and lets your app build natively on arm64 iOS Simulator. The barcode scanner JS API still exists, but `useBarcodeScanner` and the `barcodeScanner` output throw a clear runtime error when invoked. This is intended for compile-only CI smoke tests — barcode scanning never works in simulators anyway because the camera isn't real.
+
+To go back to a normal build, run `pod install` again without the env var.

--- a/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
+++ b/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
@@ -26,7 +26,12 @@ Pod::Spec.new do |s|
   load 'nitrogen/generated/ios/VisionCameraBarcodeScanner+autolinking.rb'
   add_nitrogen_files(s)
 
-  s.dependency 'GoogleMLKit/BarcodeScanning', '8.0.0'
+  if ENV['VISION_CAMERA_DISABLE_MLKIT'] == '1'
+    Pod::UI.warn "VISION_CAMERA_DISABLE_MLKIT=1 — skipping GoogleMLKit/BarcodeScanning. " \
+                 "BarcodeScanner will throw at runtime in this build."
+  else
+    s.dependency 'GoogleMLKit/BarcodeScanning', '8.0.0'
+  end
   s.dependency 'VisionCamera'
   s.dependency 'React-jsi'
   s.dependency 'React-callinvoker'

--- a/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeFormat.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeFormat.swift
@@ -5,6 +5,7 @@
 //  Created by Marc Rousavy on 08.02.26.
 //
 
+#if canImport(MLKitBarcodeScanning)
 import MLKitBarcodeScanning
 
 extension BarcodeFormat {
@@ -76,3 +77,4 @@ extension TargetBarcodeFormat {
     }
   }
 }
+#endif

--- a/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeScannerOptions.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeScannerOptions.swift
@@ -5,6 +5,7 @@
 //  Created by Marc Rousavy on 08.02.26.
 //
 
+#if canImport(MLKitBarcodeScanning)
 import MLKitBarcodeScanning
 
 extension BarcodeScannerOptions {
@@ -30,3 +31,4 @@ extension BarcodeScannerOutputOptions {
     return MLKitBarcodeScanning.BarcodeScannerOptions(formats: combinedFormats)
   }
 }
+#endif

--- a/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeValueType.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+BarcodeValueType.swift
@@ -5,6 +5,7 @@
 //  Created by Marc Rousavy on 08.02.26.
 //
 
+#if canImport(MLKitBarcodeScanning)
 import MLKitBarcodeScanning
 
 extension BarcodeValueType {
@@ -41,3 +42,4 @@ extension BarcodeValueType {
     }
   }
 }
+#endif

--- a/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+HybridFrameSpec.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/Extensions/ML+HybridFrameSpec.swift
@@ -5,9 +5,11 @@
 //  Created by Marc Rousavy on 08.02.26.
 //
 
-import MLKitVision
 import NitroModules
 import VisionCamera
+
+#if canImport(MLKitBarcodeScanning)
+import MLKitVision
 
 extension HybridFrameSpec_protocol {
   func toMLImage() throws -> MLImage {
@@ -24,3 +26,4 @@ extension HybridFrameSpec_protocol {
     return image
   }
 }
+#endif

--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcode.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcode.swift
@@ -5,8 +5,10 @@
 //  Created by Marc Rousavy on 08.02.26.
 //
 
-import MLKitBarcodeScanning
 import NitroModules
+
+#if canImport(MLKitBarcodeScanning)
+import MLKitBarcodeScanning
 
 final class HybridBarcode: HybridBarcodeSpec {
   private let barcode: Barcode
@@ -60,3 +62,4 @@ final class HybridBarcode: HybridBarcodeSpec {
     return BarcodeValueType(fromMLKitValueType: barcode.valueType)
   }
 }
+#endif

--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScanner.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScanner.swift
@@ -5,10 +5,12 @@
 //  Created by Marc Rousavy on 08.02.26.
 //
 
-import MLKitBarcodeScanning
-import MLKitVision
 import NitroModules
 import VisionCamera
+
+#if canImport(MLKitBarcodeScanning)
+import MLKitBarcodeScanning
+import MLKitVision
 
 class HybridBarcodeScanner: HybridBarcodeScannerSpec {
   private let scanner: BarcodeScanner
@@ -40,3 +42,4 @@ class HybridBarcodeScanner: HybridBarcodeScannerSpec {
     return promise
   }
 }
+#endif

--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerFactory.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerFactory.swift
@@ -10,12 +10,26 @@ import VisionCamera
 
 class HybridBarcodeScannerFactory: HybridBarcodeScannerFactorySpec {
   func createBarcodeScanner(options: BarcodeScannerOptions) throws -> any HybridBarcodeScannerSpec {
+#if canImport(MLKitBarcodeScanning)
     return HybridBarcodeScanner(options: options)
+#else
+    throw RuntimeError.error(withMessage:
+      "BarcodeScanner is not available in this build because MLKit was excluded " +
+      "(VISION_CAMERA_DISABLE_MLKIT=1 was set at `pod install` time). " +
+      "Run on a real device, or rebuild without VISION_CAMERA_DISABLE_MLKIT.")
+#endif
   }
 
   func createBarcodeScannerOutput(options: BarcodeScannerOutputOptions) throws
     -> any HybridCameraOutputSpec
   {
+#if canImport(MLKitBarcodeScanning)
     return HybridBarcodeScannerOutput(options: options)
+#else
+    throw RuntimeError.error(withMessage:
+      "BarcodeScannerOutput is not available in this build because MLKit was excluded " +
+      "(VISION_CAMERA_DISABLE_MLKIT=1 was set at `pod install` time). " +
+      "Run on a real device, or rebuild without VISION_CAMERA_DISABLE_MLKIT.")
+#endif
   }
 }

--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
@@ -6,10 +6,12 @@
 //
 
 import AVFoundation
-import MLKitBarcodeScanning
-import MLKitVision
 import NitroModules
 import VisionCamera
+
+#if canImport(MLKitBarcodeScanning)
+import MLKitBarcodeScanning
+import MLKitVision
 
 final class HybridBarcodeScannerOutput: HybridCameraOutputSpec, NativeCameraOutput {
   private let scanner: BarcodeScanner
@@ -79,3 +81,4 @@ final class HybridBarcodeScannerOutput: HybridCameraOutputSpec, NativeCameraOutp
     connection.preferredVideoStabilizationMode = .off
   }
 }
+#endif


### PR DESCRIPTION
This allows users to build in the CI (or on other places) without the MLKit dependency on iOS:

```sh
VISION_CAMERA_DISABLE_MLKIT=1 npx pod-install
```

Then, the Barcode scanner package will just throw at runtime on iOS, and continue to work on Android.

On iOS people could use the native Object Output instead.