### PR TITLE
feat: Add `supportedMultiCamDeviceCombinations` (with fixed nitrogen `__element`)

### DIFF
--- a/apps/simple-camera/ios/Podfile.lock
+++ b/apps/simple-camera/ios/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - NitroModules (0.35.5):
+  - NitroModules (0.35.6):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2756,7 +2756,7 @@ SPEC CHECKSUMS:
   MLKitVision: fa8dea9012ac59497c79ddbe9ebf32051047ac4c
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroImage: bf3c19ea96629e5ab1665f61d720efc0df53377a
-  NitroModules: 2ece7b1523f5e1952c5bcea7c318df11b8ac856b
+  NitroModules: 1985a9de2cf4a6de1265c5936b7cc9d7f30e45d8
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32

--- a/apps/simple-camera/package.json
+++ b/apps/simple-camera/package.json
@@ -27,7 +27,7 @@
     "react-native": "0.84.0",
     "react-native-gesture-handler": "^2.30.0",
     "react-native-nitro-image": "0.14.0",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-native-reanimated": "4.3.0",
     "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "^4.24.0",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "react-native": "0.84.0",
         "react-native-gesture-handler": "^2.30.0",
         "react-native-nitro-image": "0.14.0",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-native-reanimated": "4.3.0",
         "react-native-safe-area-context": "^5.7.0",
         "react-native-screens": "^4.24.0",
@@ -104,11 +104,11 @@
       "version": "5.0.7",
       "devDependencies": {
         "@types/react": "19.2.14",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.6",
         "react": "19.2.3",
         "react-native": "0.84.0",
         "react-native-nitro-image": "0.14.0",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "typescript": "5.9.3",
       },
       "peerDependencies": {
@@ -123,10 +123,10 @@
       "version": "5.0.7",
       "devDependencies": {
         "@types/react": "19.2.14",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.6",
         "react": "19.2.3",
         "react-native": "0.84.0",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-native-vision-camera": "*",
         "typescript": "5.9.3",
       },
@@ -142,10 +142,10 @@
       "version": "5.0.7",
       "devDependencies": {
         "@types/react": "19.2.14",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.6",
         "react": "19.2.3",
         "react-native": "0.84.0",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-native-vision-camera": "*",
         "typescript": "5.9.3",
       },
@@ -161,10 +161,10 @@
       "version": "5.0.7",
       "devDependencies": {
         "@types/react": "19.2.14",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.6",
         "react": "19.2.3",
         "react-native": "0.84.0",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-native-vision-camera": "*",
         "typescript": "5.9.3",
       },
@@ -183,7 +183,7 @@
         "@types/react": "19.2.14",
         "react": "19.2.3",
         "react-native": "0.84.0",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-native-reanimated": "4.3.0",
         "react-native-vision-camera": "*",
         "react-native-vision-camera-worklets": "*",
@@ -205,10 +205,10 @@
       "version": "5.0.7",
       "devDependencies": {
         "@types/react": "19.2.14",
-        "nitrogen": "0.35.5",
+        "nitrogen": "0.35.6",
         "react": "19.2.3",
         "react-native": "0.84.0",
-        "react-native-nitro-modules": "0.35.5",
+        "react-native-nitro-modules": "0.35.6",
         "react-native-vision-camera": "*",
         "react-native-worklets": "0.8.1",
         "typescript": "5.9.3",
@@ -2167,7 +2167,7 @@
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
-    "nitrogen": ["nitrogen@0.35.5", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.5", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-Ofl4aTW2rd44+hBcUwLXu01ViHikn2SDI7zOYc+6NcKSpnhoj42k1FwyvRj1QZPDMUT64Bwlb0DYw7Hrfd3BfQ=="],
+    "nitrogen": ["nitrogen@0.35.6", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.35.6", "ts-morph": "^27.0.0", "yargs": "^18.0.0", "zod": "^4.0.5" }, "bin": { "nitrogen": "lib/index.js" } }, "sha512-fUoyqCEQugl49L/lp/v3LceZt8jwL/gqfLhWsxRPxr1pOTnBhyrcEJ2dAJvHl10h7JxaswP6YCnVZMZmjJavKg=="],
 
     "nocache": ["nocache@3.0.4", "", {}, "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw=="],
 
@@ -2355,7 +2355,7 @@
 
     "react-native-nitro-image": ["react-native-nitro-image@0.14.0", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-yLBm+SC/bdssO5XJhYOxVf6UeFfcUoRLwR1YXPJpNZyv65aHPijDg/nklJ/spAonWEl4yfPpATGSqo8mvVEjlQ=="],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.5", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-aa03UzC5dLg5qFfyBkVK+JGSwHTjmK7jUZzyRz11r1Yk9C/nJTFe59EeHPxxNNTagkiwQTM6p3sySgD/TDRC7Q=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 
     "react-native-reanimated": ["react-native-reanimated@4.3.0", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.3.1", "semver": "^7.7.3" }, "peerDependencies": { "react": "*", "react-native": "0.81 - 0.85", "react-native-worklets": "0.8.x" } }, "sha512-HOTTPdKtddXTOsmQxDASXEwLS3lqEHrKERD3XOgzSqWJ7L3x81Pnx7mTcKx1FKdkgomMug/XSmm1C6Z7GIowxA=="],
 

--- a/docs/content/docs/multi-camera.mdx
+++ b/docs/content/docs/multi-camera.mdx
@@ -5,7 +5,7 @@ description: Using multiple Camera Devices in a single Camera Session
 
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
 
-A [`CameraSession`](/api/react-native-vision-camera/hybrid-objects/CameraSession) allows attaching multiple connections to stream from multiple [`CameraDevice`](/api/react-native-vision-camera/hybrid-objects/CameraDevice)s at the same time - if the system supports it.
+A [`CameraSession`](/api/react-native-vision-camera/hybrid-objects/CameraSession) allows attaching multiple connections to stream from multiple [`CameraDevice`](/api/react-native-vision-camera/hybrid-objects/CameraDevice)s at the same time (e.g. Picture-in-Picture mode via front + back Camera) - if the system supports it.
 
 ### Creating a Multi-Camera Session
 
@@ -19,14 +19,35 @@ if (VisionCamera.supportsMultiCamSessions) {
 
 ### Using multiple Connections
 
-With a multi-cam [`CameraSession`](/api/react-native-vision-camera/hybrid-objects/CameraSession), you can now attach multiple [`CameraSessionConnection`](/api/react-native-vision-camera/interfaces/CameraSessionConnection)s - for example to stream and capture from the Front- and Back-Camera at the same time, attach both devices:
+Due to hardware constraints, not every [`CameraDevice`](/api/react-native-vision-camera/hybrid-objects/CameraDevice) can be paired with every other [`CameraDevice`](/api/react-native-vision-camera/hybrid-objects/CameraDevice) - therefore VisionCamera exposes a fixed array of supported combinations via [`CameraDeviceFactory.supportedMultiCamDeviceCombinations`](/api/react-native-vision-camera/hybrid-objects/CameraDeviceFactory#supportedmulticamdevicecombinations) upfront:
 
 ```ts
-const session = ...
-const frontDevice = useCameraDevice('front')
-const backDevice = useCameraDevice('back')
-const frontPreview = usePreviewOutput()
-const backPreview = usePreviewOutput()
+if (!VisionCamera.supportsMultiCamSessions)
+  return
+
+const deviceFactory = await VisionCamera.createDeviceFactory()
+const frontAndBackCombination =
+  deviceFactory.supportedMultiCamDeviceCombinations.find((devices) => {
+    return (
+      devices.some((d) => d.position === 'front') &&
+      devices.some((d) => d.position === 'back')
+    )
+  })
+if (frontAndBackCombination == null)
+  return
+
+const frontDevice = frontAndBackCombination.find((d) => d.position === 'front')
+const backDevice = frontAndBackCombination.find((d) => d.position === 'back')
+```
+
+Then, knowing `frontDevice` and `backDevice` can be used simultaneously in a Multi-Cam session, create the [`CameraSession`](/api/react-native-vision-camera/hybrid-objects/CameraSession), and attach the [`CameraSessionConnection`](/api/react-native-vision-camera/interfaces/CameraSessionConnection)s:
+
+```ts
+const session = await VisionCamera.createCameraSession(true)
+const frontPreviewOutput = VisionCamera.createPreviewOutput()
+const frontPhotoOutput = VisionCamera.createPhotoOutput({})
+const backPreviewOutput = VisionCamera.createPreviewOutput()
+const backPhotoOutput = VisionCamera.createPhotoOutput({})
 
 const [frontController, backController] = await session.configure([
   // Front Camera
@@ -51,6 +72,26 @@ const [frontController, backController] = await session.configure([
 await session.start()
 ```
 
-Then, ensure you display both `frontPreview` and `backPreview` in separate [`<NativePreviewView />`](/api/react-native-vision-camera/views/NativePreviewView) views.
+Each returned [`CameraController`](/api/react-native-vision-camera/hybrid-objects/CameraController) correlates to the connection at that index - e.g. `frontController` allows zooming/exposure/focus the `frontDevice`, and vice-versa.
 
-Each returned [`CameraController`](/api/react-native-vision-camera/hybrid-objects/CameraController) correlates to the connection at that index.
+Then, ensure you display both `frontPreviewOutput` and `backPreviewOutput` in separate [`<NativePreviewView />`](/api/react-native-vision-camera/views/NativePreviewView) views:
+
+```tsx
+function App() {
+  const frontPreviewOutput = ...
+  const backPreviewOutput = ...
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      <NativePreviewView
+        style={{ flex: 1 }}
+        previewOutput={frontPreviewOutput}
+      />
+      <NativePreviewView
+        style={{ flex: 1 }}
+        previewOutput={backPreviewOutput}
+      />
+    </View>
+  )
+}
+```

--- a/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JBarcodeScannerOptions.hpp
+++ b/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JBarcodeScannerOptions.hpp
@@ -36,16 +36,16 @@ namespace margelo::nitro::camera::barcodescanner {
       static const auto fieldBarcodeFormats = clazz->getField<jni::JArrayClass<JTargetBarcodeFormat>>("barcodeFormats");
       jni::local_ref<jni::JArrayClass<JTargetBarcodeFormat>> barcodeFormats = this->getFieldValue(fieldBarcodeFormats);
       return BarcodeScannerOptions(
-        [&]() {
-          size_t __size = barcodeFormats->size();
+        [&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<TargetBarcodeFormat> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = barcodeFormats->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->toCpp());
           }
           return __vector;
-        }()
+        }(barcodeFormats)
       );
     }
 
@@ -60,16 +60,16 @@ namespace margelo::nitro::camera::barcodescanner {
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
-        [&]() {
-          size_t __size = value.barcodeFormats.size();
+        [&](auto&& __input) {
+          size_t __size = __input.size();
           jni::local_ref<jni::JArrayClass<JTargetBarcodeFormat>> __array = jni::JArrayClass<JTargetBarcodeFormat>::newArray(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            const auto& __element = value.barcodeFormats[__i];
+            const auto& __element = __input[__i];
             auto __elementJni = JTargetBarcodeFormat::fromCpp(__element);
             __array->setElement(__i, *__elementJni);
           }
           return __array;
-        }()
+        }(value.barcodeFormats)
       );
     }
   };

--- a/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JBarcodeScannerOutputOptions.hpp
+++ b/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JBarcodeScannerOutputOptions.hpp
@@ -53,16 +53,16 @@ namespace margelo::nitro::camera::barcodescanner {
       static const auto fieldOnError = clazz->getField<JFunc_void_std__exception_ptr::javaobject>("onError");
       jni::local_ref<JFunc_void_std__exception_ptr::javaobject> onError = this->getFieldValue(fieldOnError);
       return BarcodeScannerOutputOptions(
-        [&]() {
-          size_t __size = barcodeFormats->size();
+        [&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<TargetBarcodeFormat> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = barcodeFormats->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->toCpp());
           }
           return __vector;
-        }(),
+        }(barcodeFormats),
         outputResolution != nullptr ? std::make_optional(outputResolution->toCpp()) : std::nullopt,
         [&]() -> std::function<void(const std::vector<std::shared_ptr<HybridBarcodeSpec>>& /* barcodes */)> {
           if (onBarcodeScanned->isInstanceOf(JFunc_void_std__vector_std__shared_ptr_HybridBarcodeSpec___cxx::javaClassStatic())) [[likely]] {
@@ -96,16 +96,16 @@ namespace margelo::nitro::camera::barcodescanner {
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
-        [&]() {
-          size_t __size = value.barcodeFormats.size();
+        [&](auto&& __input) {
+          size_t __size = __input.size();
           jni::local_ref<jni::JArrayClass<JTargetBarcodeFormat>> __array = jni::JArrayClass<JTargetBarcodeFormat>::newArray(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            const auto& __element = value.barcodeFormats[__i];
+            const auto& __element = __input[__i];
             auto __elementJni = JTargetBarcodeFormat::fromCpp(__element);
             __array->setElement(__i, *__elementJni);
           }
           return __array;
-        }(),
+        }(value.barcodeFormats),
         value.outputResolution.has_value() ? JBarcodeScannerOutputResolution::fromCpp(value.outputResolution.value()) : nullptr,
         JFunc_void_std__vector_std__shared_ptr_HybridBarcodeSpec___cxx::fromCpp(value.onBarcodeScanned),
         JFunc_void_std__exception_ptr_cxx::fromCpp(value.onError)

--- a/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JFunc_void_std__vector_std__shared_ptr_HybridBarcodeSpec__.hpp
+++ b/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JFunc_void_std__vector_std__shared_ptr_HybridBarcodeSpec__.hpp
@@ -35,16 +35,16 @@ namespace margelo::nitro::camera::barcodescanner {
      */
     void invoke(const std::vector<std::shared_ptr<HybridBarcodeSpec>>& barcodes) const {
       static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JArrayClass<JHybridBarcodeSpec::JavaPart>> /* barcodes */)>("invoke");
-      method(self(), [&]() {
-        size_t __size = barcodes.size();
+      method(self(), [&](auto&& __input) {
+        size_t __size = __input.size();
         jni::local_ref<jni::JArrayClass<JHybridBarcodeSpec::JavaPart>> __array = jni::JArrayClass<JHybridBarcodeSpec::JavaPart>::newArray(__size);
         for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = barcodes[__i];
+          const auto& __element = __input[__i];
           auto __elementJni = std::dynamic_pointer_cast<JHybridBarcodeSpec>(__element)->getJavaPart();
           __array->setElement(__i, *__elementJni);
         }
         return __array;
-      }());
+      }(barcodes));
     }
   };
 
@@ -62,16 +62,16 @@ namespace margelo::nitro::camera::barcodescanner {
      * Invokes the C++ `std::function<...>` this `JFunc_void_std__vector_std__shared_ptr_HybridBarcodeSpec___cxx` instance holds.
      */
     void invoke_cxx(jni::alias_ref<jni::JArrayClass<JHybridBarcodeSpec::JavaPart>> barcodes) {
-      _func([&]() {
-              size_t __size = barcodes->size();
-              std::vector<std::shared_ptr<HybridBarcodeSpec>> __vector;
-              __vector.reserve(__size);
-              for (size_t __i = 0; __i < __size; __i++) {
-                auto __element = barcodes->getElement(__i);
-                __vector.push_back(__element->getJHybridBarcodeSpec());
-              }
-              return __vector;
-            }());
+      _func([&](auto&& __input) {
+        size_t __size = __input->size();
+        std::vector<std::shared_ptr<HybridBarcodeSpec>> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __input->getElement(__i);
+          __vector.push_back(__element->getJHybridBarcodeSpec());
+        }
+        return __vector;
+      }(barcodes));
     }
 
   public:

--- a/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JHybridBarcodeScannerSpec.cpp
+++ b/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JHybridBarcodeScannerSpec.cpp
@@ -57,16 +57,16 @@ namespace margelo::nitro::camera::barcodescanner {
   std::vector<std::shared_ptr<HybridBarcodeSpec>> JHybridBarcodeScannerSpec::scanCodes(const std::shared_ptr<margelo::nitro::camera::HybridFrameSpec>& frame) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JHybridBarcodeSpec::JavaPart>>(jni::alias_ref<margelo::nitro::camera::JHybridFrameSpec::JavaPart> /* frame */)>("scanCodes");
     auto __result = method(_javaPart, std::dynamic_pointer_cast<margelo::nitro::camera::JHybridFrameSpec>(frame)->getJavaPart());
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<std::shared_ptr<HybridBarcodeSpec>> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->getJHybridBarcodeSpec());
       }
       return __vector;
-    }();
+    }(__result);
   }
   std::shared_ptr<Promise<std::vector<std::shared_ptr<HybridBarcodeSpec>>>> JHybridBarcodeScannerSpec::scanCodesAsync(const std::shared_ptr<margelo::nitro::camera::HybridFrameSpec>& frame) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<margelo::nitro::camera::JHybridFrameSpec::JavaPart> /* frame */)>("scanCodesAsync");
@@ -75,16 +75,16 @@ namespace margelo::nitro::camera::barcodescanner {
       auto __promise = Promise<std::vector<std::shared_ptr<HybridBarcodeSpec>>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         auto __result = jni::static_ref_cast<jni::JArrayClass<JHybridBarcodeSpec::JavaPart>>(__boxedResult);
-        __promise->resolve([&]() {
-          size_t __size = __result->size();
+        __promise->resolve([&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<std::shared_ptr<HybridBarcodeSpec>> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = __result->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->getJHybridBarcodeSpec());
           }
           return __vector;
-        }());
+        }(__result));
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);

--- a/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JHybridBarcodeSpec.cpp
+++ b/packages/react-native-vision-camera-barcode-scanner/nitrogen/generated/android/c++/JHybridBarcodeSpec.cpp
@@ -73,16 +73,16 @@ namespace margelo::nitro::camera::barcodescanner {
   std::vector<Point> JHybridBarcodeSpec::getCornerPoints() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JPoint>>()>("getCornerPoints");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<Point> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   std::optional<std::string> JHybridBarcodeSpec::getDisplayValue() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getDisplayValue");

--- a/packages/react-native-vision-camera-barcode-scanner/package.json
+++ b/packages/react-native-vision-camera-barcode-scanner/package.json
@@ -66,10 +66,10 @@
   },
   "devDependencies": {
     "@types/react": "19.2.14",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.6",
     "react": "19.2.3",
     "react-native": "0.84.0",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-native-vision-camera": "*",
     "typescript": "5.9.3"
   },

--- a/packages/react-native-vision-camera-location/package.json
+++ b/packages/react-native-vision-camera-location/package.json
@@ -65,10 +65,10 @@
   },
   "devDependencies": {
     "@types/react": "19.2.14",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.6",
     "react": "19.2.3",
     "react-native": "0.84.0",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-native-vision-camera": "*",
     "typescript": "5.9.3"
   },

--- a/packages/react-native-vision-camera-resizer/package.json
+++ b/packages/react-native-vision-camera-resizer/package.json
@@ -70,10 +70,10 @@
   },
   "devDependencies": {
     "@types/react": "19.2.14",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.6",
     "react": "19.2.3",
     "react-native": "0.84.0",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-native-vision-camera": "*",
     "typescript": "5.9.3"
   },

--- a/packages/react-native-vision-camera-skia/package.json
+++ b/packages/react-native-vision-camera-skia/package.json
@@ -56,7 +56,7 @@
     "@types/react": "19.2.14",
     "react": "19.2.3",
     "react-native": "0.84.0",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-native-reanimated": "4.3.0",
     "react-native-worklets": "0.8.1",
     "react-native-vision-camera": "*",

--- a/packages/react-native-vision-camera-worklets/package.json
+++ b/packages/react-native-vision-camera-worklets/package.json
@@ -66,10 +66,10 @@
   },
   "devDependencies": {
     "@types/react": "19.2.14",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.6",
     "react": "19.2.3",
     "react-native": "0.84.0",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "react-native-worklets": "0.8.1",
     "react-native-vision-camera": "*",
     "typescript": "5.9.3"

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/HybridCameraDeviceFactory.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/HybridCameraDeviceFactory.kt
@@ -38,6 +38,13 @@ class HybridCameraDeviceFactory(
   override val cameraDevices: Array<HybridCameraDeviceSpec>
     get() = cameraProvider.availableCameraInfos.mapToArray { HybridCameraDevice(it) }
 
+  override val supportedMultiCamDeviceCombinations: Array<Array<HybridCameraDeviceSpec>>
+    get() {
+      return cameraProvider.availableConcurrentCameraInfos.mapToArray { devices ->
+        return@mapToArray devices.mapToArray { HybridCameraDevice(it) }
+      }
+    }
+
   override var userPreferredCamera: HybridCameraDeviceSpec?
     get() {
       val preferredCameraId =

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraDeviceFactory.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraDeviceFactory.swift
@@ -9,17 +9,23 @@ import Foundation
 import NitroModules
 
 class HybridCameraDeviceFactory: HybridCameraDeviceFactorySpec {
-  let discoverySession: AVCaptureDevice.DiscoverySession
-  var cameraDevices: [any HybridCameraDeviceSpec] {
-    return discoverySession.devices.map { HybridCameraDevice(device: $0) }
-  }
-
   override init() {
     self.discoverySession = AVCaptureDevice.DiscoverySession(
       deviceTypes: AVCaptureDevice.DeviceType.all,
       mediaType: nil,
       position: .unspecified)
     super.init()
+  }
+
+  let discoverySession: AVCaptureDevice.DiscoverySession
+  var cameraDevices: [any HybridCameraDeviceSpec] {
+    return discoverySession.devices.map { HybridCameraDevice(device: $0) }
+  }
+
+  var supportedMultiCamDeviceCombinations: [[any HybridCameraDeviceSpec]] {
+    return discoverySession.supportedMultiCamDeviceSets.map { devices in
+      return devices.map { HybridCameraDevice(device: $0) }
+    }
   }
 
   var userPreferredCamera: (any HybridCameraDeviceSpec)? {
@@ -36,7 +42,7 @@ class HybridCameraDeviceFactory: HybridCameraDeviceFactorySpec {
       guard #available(iOS 17.0, *) else {
         return
       }
-      guard let hybridDevice = newValue as? HybridCameraDevice else {
+      guard let hybridDevice = newValue as? any NativeCameraDevice else {
         return
       }
       AVCaptureDevice.userPreferredCamera = hybridDevice.device

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JCameraSessionConnection.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JCameraSessionConnection.hpp
@@ -90,26 +90,26 @@ namespace margelo::nitro::camera {
       jni::local_ref<JFunc_void_std__shared_ptr_HybridCameraSessionConfigSpec_::javaobject> onSessionConfigSelected = this->getFieldValue(fieldOnSessionConfigSelected);
       return CameraSessionConnection(
         input->getJHybridCameraDeviceSpec(),
-        [&]() {
-          size_t __size = outputs->size();
+        [&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<CameraOutputConfiguration> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = outputs->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->toCpp());
           }
           return __vector;
-        }(),
-        [&]() {
-          size_t __size = constraints->size();
+        }(outputs),
+        [&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<std::variant<FPSConstraint, VideoStabilizationModeConstraint, PreviewStabilizationModeConstraint, ResolutionBiasConstraint, VideoDynamicRangeConstraint, PhotoHDRConstraint, PixelFormatConstraint, BinnedConstraint>> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = constraints->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->toCpp());
           }
           return __vector;
-        }(),
+        }(constraints),
         initialZoom != nullptr ? std::make_optional(initialZoom->value()) : std::nullopt,
         initialExposureBias != nullptr ? std::make_optional(initialExposureBias->value()) : std::nullopt,
         onSessionConfigSelected != nullptr ? std::make_optional([&]() -> std::function<void(const std::shared_ptr<HybridCameraSessionConfigSpec>& /* config */)> {
@@ -136,26 +136,26 @@ namespace margelo::nitro::camera {
       return create(
         clazz,
         std::dynamic_pointer_cast<JHybridCameraDeviceSpec>(value.input)->getJavaPart(),
-        [&]() {
-          size_t __size = value.outputs.size();
+        [&](auto&& __input) {
+          size_t __size = __input.size();
           jni::local_ref<jni::JArrayClass<JCameraOutputConfiguration>> __array = jni::JArrayClass<JCameraOutputConfiguration>::newArray(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            const auto& __element = value.outputs[__i];
+            const auto& __element = __input[__i];
             auto __elementJni = JCameraOutputConfiguration::fromCpp(__element);
             __array->setElement(__i, *__elementJni);
           }
           return __array;
-        }(),
-        [&]() {
-          size_t __size = value.constraints.size();
+        }(value.outputs),
+        [&](auto&& __input) {
+          size_t __size = __input.size();
           jni::local_ref<jni::JArrayClass<JConstraint>> __array = jni::JArrayClass<JConstraint>::newArray(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            const auto& __element = value.constraints[__i];
+            const auto& __element = __input[__i];
             auto __elementJni = JConstraint::fromCpp(__element);
             __array->setElement(__i, *__elementJni);
           }
           return __array;
-        }(),
+        }(value.constraints),
         value.initialZoom.has_value() ? jni::JDouble::valueOf(value.initialZoom.value()) : nullptr,
         value.initialExposureBias.has_value() ? jni::JDouble::valueOf(value.initialExposureBias.value()) : nullptr,
         value.onSessionConfigSelected.has_value() ? JFunc_void_std__shared_ptr_HybridCameraSessionConfigSpec__cxx::fromCpp(value.onSessionConfigSelected.value()) : nullptr

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFocusOptions.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFocusOptions.hpp
@@ -53,16 +53,16 @@ namespace margelo::nitro::camera {
       return FocusOptions(
         responsiveness != nullptr ? std::make_optional(responsiveness->toCpp()) : std::nullopt,
         adaptiveness != nullptr ? std::make_optional(adaptiveness->toCpp()) : std::nullopt,
-        modes != nullptr ? std::make_optional([&]() {
-          size_t __size = modes->size();
+        modes != nullptr ? std::make_optional([&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<MeteringMode> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = modes->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->toCpp());
           }
           return __vector;
-        }()) : std::nullopt,
+        }(modes)) : std::nullopt,
         autoResetAfter != nullptr ? std::make_optional(autoResetAfter->toCpp()) : std::nullopt
       );
     }
@@ -80,16 +80,16 @@ namespace margelo::nitro::camera {
         clazz,
         value.responsiveness.has_value() ? JFocusResponsiveness::fromCpp(value.responsiveness.value()) : nullptr,
         value.adaptiveness.has_value() ? JSceneAdaptiveness::fromCpp(value.adaptiveness.value()) : nullptr,
-        value.modes.has_value() ? [&]() {
-          size_t __size = value.modes.value().size();
+        value.modes.has_value() ? [&](auto&& __input) {
+          size_t __size = __input.size();
           jni::local_ref<jni::JArrayClass<JMeteringMode>> __array = jni::JArrayClass<JMeteringMode>::newArray(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            const auto& __element = value.modes.value()[__i];
+            const auto& __element = __input[__i];
             auto __elementJni = JMeteringMode::fromCpp(__element);
             __array->setElement(__i, *__elementJni);
           }
           return __array;
-        }() : nullptr,
+        }(value.modes.value()) : nullptr,
         value.autoResetAfter.has_value() ? JVariant_NullType_Double::fromCpp(value.autoResetAfter.value()) : nullptr
       );
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFunc_bool_std__vector_std__variant_std__shared_ptr_HybridFrameSpec___std__shared_ptr_HybridDepthSpec___.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFunc_bool_std__vector_std__variant_std__shared_ptr_HybridFrameSpec___std__shared_ptr_HybridDepthSpec___.hpp
@@ -39,16 +39,16 @@ namespace margelo::nitro::camera {
      */
     bool invoke(const std::vector<std::variant<std::shared_ptr<HybridFrameSpec>, std::shared_ptr<HybridDepthSpec>>>& frames) const {
       static const auto method = javaClassStatic()->getMethod<jboolean(jni::alias_ref<jni::JArrayClass<JVariant_HybridFrameSpec_HybridDepthSpec>> /* frames */)>("invoke");
-      auto __result = method(self(), [&]() {
-        size_t __size = frames.size();
+      auto __result = method(self(), [&](auto&& __input) {
+        size_t __size = __input.size();
         jni::local_ref<jni::JArrayClass<JVariant_HybridFrameSpec_HybridDepthSpec>> __array = jni::JArrayClass<JVariant_HybridFrameSpec_HybridDepthSpec>::newArray(__size);
         for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = frames[__i];
+          const auto& __element = __input[__i];
           auto __elementJni = JVariant_HybridFrameSpec_HybridDepthSpec::fromCpp(__element);
           __array->setElement(__i, *__elementJni);
         }
         return __array;
-      }());
+      }(frames));
       return static_cast<bool>(__result);
     }
   };
@@ -67,16 +67,16 @@ namespace margelo::nitro::camera {
      * Invokes the C++ `std::function<...>` this `JFunc_bool_std__vector_std__variant_std__shared_ptr_HybridFrameSpec___std__shared_ptr_HybridDepthSpec____cxx` instance holds.
      */
     jboolean invoke_cxx(jni::alias_ref<jni::JArrayClass<JVariant_HybridFrameSpec_HybridDepthSpec>> frames) {
-      bool __result = _func([&]() {
-              size_t __size = frames->size();
-              std::vector<std::variant<std::shared_ptr<HybridFrameSpec>, std::shared_ptr<HybridDepthSpec>>> __vector;
-              __vector.reserve(__size);
-              for (size_t __i = 0; __i < __size; __i++) {
-                auto __element = frames->getElement(__i);
-                __vector.push_back(__element->toCpp());
-              }
-              return __vector;
-            }());
+      bool __result = _func([&](auto&& __input) {
+        size_t __size = __input->size();
+        std::vector<std::variant<std::shared_ptr<HybridFrameSpec>, std::shared_ptr<HybridDepthSpec>>> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __input->getElement(__i);
+          __vector.push_back(__element->toCpp());
+        }
+        return __vector;
+      }(frames));
       return __result;
     }
 

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFunc_void_std__vector_std__shared_ptr_HybridCameraDeviceSpec__.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFunc_void_std__vector_std__shared_ptr_HybridCameraDeviceSpec__.hpp
@@ -35,16 +35,16 @@ namespace margelo::nitro::camera {
      */
     void invoke(const std::vector<std::shared_ptr<HybridCameraDeviceSpec>>& newDevices) const {
       static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>> /* newDevices */)>("invoke");
-      method(self(), [&]() {
-        size_t __size = newDevices.size();
+      method(self(), [&](auto&& __input) {
+        size_t __size = __input.size();
         jni::local_ref<jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>> __array = jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>::newArray(__size);
         for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = newDevices[__i];
+          const auto& __element = __input[__i];
           auto __elementJni = std::dynamic_pointer_cast<JHybridCameraDeviceSpec>(__element)->getJavaPart();
           __array->setElement(__i, *__elementJni);
         }
         return __array;
-      }());
+      }(newDevices));
     }
   };
 
@@ -62,16 +62,16 @@ namespace margelo::nitro::camera {
      * Invokes the C++ `std::function<...>` this `JFunc_void_std__vector_std__shared_ptr_HybridCameraDeviceSpec___cxx` instance holds.
      */
     void invoke_cxx(jni::alias_ref<jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>> newDevices) {
-      _func([&]() {
-              size_t __size = newDevices->size();
-              std::vector<std::shared_ptr<HybridCameraDeviceSpec>> __vector;
-              __vector.reserve(__size);
-              for (size_t __i = 0; __i < __size; __i++) {
-                auto __element = newDevices->getElement(__i);
-                __vector.push_back(__element->getJHybridCameraDeviceSpec());
-              }
-              return __vector;
-            }());
+      _func([&](auto&& __input) {
+        size_t __size = __input->size();
+        std::vector<std::shared_ptr<HybridCameraDeviceSpec>> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __input->getElement(__i);
+          __vector.push_back(__element->getJHybridCameraDeviceSpec());
+        }
+        return __vector;
+      }(newDevices));
     }
 
   public:

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFunc_void_std__vector_std__shared_ptr_HybridScannedObjectSpec__.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JFunc_void_std__vector_std__shared_ptr_HybridScannedObjectSpec__.hpp
@@ -35,16 +35,16 @@ namespace margelo::nitro::camera {
      */
     void invoke(const std::vector<std::shared_ptr<HybridScannedObjectSpec>>& objects) const {
       static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JArrayClass<JHybridScannedObjectSpec::JavaPart>> /* objects */)>("invoke");
-      method(self(), [&]() {
-        size_t __size = objects.size();
+      method(self(), [&](auto&& __input) {
+        size_t __size = __input.size();
         jni::local_ref<jni::JArrayClass<JHybridScannedObjectSpec::JavaPart>> __array = jni::JArrayClass<JHybridScannedObjectSpec::JavaPart>::newArray(__size);
         for (size_t __i = 0; __i < __size; __i++) {
-          const auto& __element = objects[__i];
+          const auto& __element = __input[__i];
           auto __elementJni = std::dynamic_pointer_cast<JHybridScannedObjectSpec>(__element)->getJavaPart();
           __array->setElement(__i, *__elementJni);
         }
         return __array;
-      }());
+      }(objects));
     }
   };
 
@@ -62,16 +62,16 @@ namespace margelo::nitro::camera {
      * Invokes the C++ `std::function<...>` this `JFunc_void_std__vector_std__shared_ptr_HybridScannedObjectSpec___cxx` instance holds.
      */
     void invoke_cxx(jni::alias_ref<jni::JArrayClass<JHybridScannedObjectSpec::JavaPart>> objects) {
-      _func([&]() {
-              size_t __size = objects->size();
-              std::vector<std::shared_ptr<HybridScannedObjectSpec>> __vector;
-              __vector.reserve(__size);
-              for (size_t __i = 0; __i < __size; __i++) {
-                auto __element = objects->getElement(__i);
-                __vector.push_back(__element->getJHybridScannedObjectSpec());
-              }
-              return __vector;
-            }());
+      _func([&](auto&& __input) {
+        size_t __size = __input->size();
+        std::vector<std::shared_ptr<HybridScannedObjectSpec>> __vector;
+        __vector.reserve(__size);
+        for (size_t __i = 0; __i < __size; __i++) {
+          auto __element = __input->getElement(__i);
+          __vector.push_back(__element->getJHybridScannedObjectSpec());
+        }
+        return __vector;
+      }(objects));
     }
 
   public:

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.cpp
@@ -88,6 +88,29 @@ namespace margelo::nitro::camera {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JHybridCameraDeviceSpec::JavaPart> /* userPreferredCamera */)>("setUserPreferredCamera");
     method(_javaPart, userPreferredCamera.has_value() ? std::dynamic_pointer_cast<JHybridCameraDeviceSpec>(userPreferredCamera.value())->getJavaPart() : nullptr);
   }
+  std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> JHybridCameraDeviceFactorySpec::getSupportedMultiCamDeviceCombinations() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>>>()>("getSupportedMultiCamDeviceCombinations");
+    auto __result = method(_javaPart);
+    return [&]() {
+      size_t __size = __result->size();
+      std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __result->getElement(__i);
+        __vector.push_back([&]() {
+      size_t __size = __element->size();
+      std::vector<std::shared_ptr<HybridCameraDeviceSpec>> __vector;
+      __vector.reserve(__size);
+      for (size_t __i = 0; __i < __size; __i++) {
+        auto __element = __element->getElement(__i);
+        __vector.push_back(__element->getJHybridCameraDeviceSpec());
+      }
+      return __vector;
+    }());
+      }
+      return __vector;
+    }();
+  }
 
   // Methods
   ListenerSubscription JHybridCameraDeviceFactorySpec::addOnCameraDevicesChangedListener(const std::function<void(const std::vector<std::shared_ptr<HybridCameraDeviceSpec>>& /* newDevices */)>& listener) {

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.cpp
@@ -91,25 +91,25 @@ namespace margelo::nitro::camera {
   std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> JHybridCameraDeviceFactorySpec::getSupportedMultiCamDeviceCombinations() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>>>()>("getSupportedMultiCamDeviceCombinations");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
-        __vector.push_back([&]() {
-      size_t __size = __element->size();
-      std::vector<std::shared_ptr<HybridCameraDeviceSpec>> __vector;
-      __vector.reserve(__size);
-      for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __element->getElement(__i);
-        __vector.push_back(__element->getJHybridCameraDeviceSpec());
+        auto __element = __input->getElement(__i);
+        __vector.push_back([&](auto&& __input) {
+          size_t __size = __input->size();
+          std::vector<std::shared_ptr<HybridCameraDeviceSpec>> __vector;
+          __vector.reserve(__size);
+          for (size_t __i = 0; __i < __size; __i++) {
+            auto __element = __input->getElement(__i);
+            __vector.push_back(__element->getJHybridCameraDeviceSpec());
+          }
+          return __vector;
+        }(__element));
       }
       return __vector;
-    }());
-      }
-      return __vector;
-    }();
+    }(__result);
   }
 
   // Methods

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.cpp
@@ -68,16 +68,16 @@ namespace margelo::nitro::camera {
   std::vector<std::shared_ptr<HybridCameraDeviceSpec>> JHybridCameraDeviceFactorySpec::getCameraDevices() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>>()>("getCameraDevices");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<std::shared_ptr<HybridCameraDeviceSpec>> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->getJHybridCameraDeviceSpec());
       }
       return __vector;
-    }();
+    }(__result);
   }
   std::optional<std::shared_ptr<HybridCameraDeviceSpec>> JHybridCameraDeviceFactorySpec::getUserPreferredCamera() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridCameraDeviceSpec::JavaPart>()>("getUserPreferredCamera");
@@ -107,16 +107,16 @@ namespace margelo::nitro::camera {
       auto __promise = Promise<std::vector<std::shared_ptr<HybridCameraExtensionSpec>>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         auto __result = jni::static_ref_cast<jni::JArrayClass<JHybridCameraExtensionSpec::JavaPart>>(__boxedResult);
-        __promise->resolve([&]() {
-          size_t __size = __result->size();
+        __promise->resolve([&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<std::shared_ptr<HybridCameraExtensionSpec>> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = __result->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->getJHybridCameraExtensionSpec());
           }
           return __vector;
-        }());
+        }(__result));
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceFactorySpec.hpp
@@ -53,6 +53,7 @@ namespace margelo::nitro::camera {
     std::vector<std::shared_ptr<HybridCameraDeviceSpec>> getCameraDevices() override;
     std::optional<std::shared_ptr<HybridCameraDeviceSpec>> getUserPreferredCamera() override;
     void setUserPreferredCamera(const std::optional<std::shared_ptr<HybridCameraDeviceSpec>>& userPreferredCamera) override;
+    std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> getSupportedMultiCamDeviceCombinations() override;
 
   public:
     // Methods

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
@@ -136,16 +136,16 @@ namespace margelo::nitro::camera {
   std::vector<std::shared_ptr<HybridCameraDeviceSpec>> JHybridCameraDeviceSpec::getPhysicalDevices() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JHybridCameraDeviceSpec::JavaPart>>()>("getPhysicalDevices");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<std::shared_ptr<HybridCameraDeviceSpec>> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->getJHybridCameraDeviceSpec());
       }
       return __vector;
-    }();
+    }(__result);
   }
   bool JHybridCameraDeviceSpec::getIsVirtualDevice() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("isVirtualDevice");
@@ -155,16 +155,16 @@ namespace margelo::nitro::camera {
   std::vector<PixelFormat> JHybridCameraDeviceSpec::getSupportedPixelFormats() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JPixelFormat>>()>("getSupportedPixelFormats");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<PixelFormat> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   bool JHybridCameraDeviceSpec::getSupportsPhotoHDR() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getSupportsPhotoHDR");
@@ -174,30 +174,30 @@ namespace margelo::nitro::camera {
   std::vector<DynamicRange> JHybridCameraDeviceSpec::getSupportedVideoDynamicRanges() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JDynamicRange>>()>("getSupportedVideoDynamicRanges");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<DynamicRange> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   std::vector<Range> JHybridCameraDeviceSpec::getSupportedFPSRanges() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JRange>>()>("getSupportedFPSRanges");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<Range> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   bool JHybridCameraDeviceSpec::getSupportsPreviewImage() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getSupportsPreviewImage");
@@ -232,16 +232,16 @@ namespace margelo::nitro::camera {
   std::vector<MediaType> JHybridCameraDeviceSpec::getMediaTypes() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JMediaType>>()>("getMediaTypes");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<MediaType> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   bool JHybridCameraDeviceSpec::getSupportsFocusMetering() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getSupportsFocusMetering");
@@ -343,16 +343,16 @@ namespace margelo::nitro::camera {
   std::vector<Size> JHybridCameraDeviceSpec::getSupportedResolutions(OutputStreamType outputStreamType) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JSize>>(jni::alias_ref<JOutputStreamType> /* outputStreamType */)>("getSupportedResolutions");
     auto __result = method(_javaPart, JOutputStreamType::fromCpp(outputStreamType));
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<Size> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   bool JHybridCameraDeviceSpec::supportsOutput(const std::shared_ptr<HybridCameraOutputSpec>& output) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean(jni::alias_ref<JHybridCameraOutputSpec::JavaPart> /* output */)>("supportsOutput");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraFactorySpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraFactorySpec.cpp
@@ -297,25 +297,25 @@ namespace margelo::nitro::camera {
   }
   std::shared_ptr<Promise<std::shared_ptr<HybridCameraSessionConfigSpec>>> JHybridCameraFactorySpec::resolveConstraints(const std::shared_ptr<HybridCameraDeviceSpec>& device, const std::vector<CameraOutputConfiguration>& outputConfigurations, const std::vector<std::variant<FPSConstraint, VideoStabilizationModeConstraint, PreviewStabilizationModeConstraint, ResolutionBiasConstraint, VideoDynamicRangeConstraint, PhotoHDRConstraint, PixelFormatConstraint, BinnedConstraint>>& constraints, std::optional<bool> requiresMultiCam) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JHybridCameraDeviceSpec::JavaPart> /* device */, jni::alias_ref<jni::JArrayClass<JCameraOutputConfiguration>> /* outputConfigurations */, jni::alias_ref<jni::JArrayClass<JConstraint>> /* constraints */, jni::alias_ref<jni::JBoolean> /* requiresMultiCam */)>("resolveConstraints");
-    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridCameraDeviceSpec>(device)->getJavaPart(), [&]() {
-      size_t __size = outputConfigurations.size();
+    auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridCameraDeviceSpec>(device)->getJavaPart(), [&](auto&& __input) {
+      size_t __size = __input.size();
       jni::local_ref<jni::JArrayClass<JCameraOutputConfiguration>> __array = jni::JArrayClass<JCameraOutputConfiguration>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = outputConfigurations[__i];
+        const auto& __element = __input[__i];
         auto __elementJni = JCameraOutputConfiguration::fromCpp(__element);
         __array->setElement(__i, *__elementJni);
       }
       return __array;
-    }(), [&]() {
-      size_t __size = constraints.size();
+    }(outputConfigurations), [&](auto&& __input) {
+      size_t __size = __input.size();
       jni::local_ref<jni::JArrayClass<JConstraint>> __array = jni::JArrayClass<JConstraint>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = constraints[__i];
+        const auto& __element = __input[__i];
         auto __elementJni = JConstraint::fromCpp(__element);
         __array->setElement(__i, *__elementJni);
       }
       return __array;
-    }(), requiresMultiCam.has_value() ? jni::JBoolean::valueOf(requiresMultiCam.value()) : nullptr);
+    }(constraints), requiresMultiCam.has_value() ? jni::JBoolean::valueOf(requiresMultiCam.value()) : nullptr);
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridCameraSessionConfigSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
@@ -377,16 +377,16 @@ namespace margelo::nitro::camera {
   }
   std::shared_ptr<HybridCameraOutputSynchronizerSpec> JHybridCameraFactorySpec::createOutputSynchronizer(const std::vector<std::shared_ptr<HybridCameraOutputSpec>>& outputs) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridCameraOutputSynchronizerSpec::JavaPart>(jni::alias_ref<jni::JArrayClass<JHybridCameraOutputSpec::JavaPart>> /* outputs */)>("createOutputSynchronizer");
-    auto __result = method(_javaPart, [&]() {
-      size_t __size = outputs.size();
+    auto __result = method(_javaPart, [&](auto&& __input) {
+      size_t __size = __input.size();
       jni::local_ref<jni::JArrayClass<JHybridCameraOutputSpec::JavaPart>> __array = jni::JArrayClass<JHybridCameraOutputSpec::JavaPart>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = outputs[__i];
+        const auto& __element = __input[__i];
         auto __elementJni = std::dynamic_pointer_cast<JHybridCameraOutputSpec>(__element)->getJavaPart();
         __array->setElement(__i, *__elementJni);
       }
       return __array;
-    }());
+    }(outputs));
     return __result->getJHybridCameraOutputSynchronizerSpec();
   }
   std::shared_ptr<HybridZoomGestureControllerSpec> JHybridCameraFactorySpec::createZoomGestureController() {

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraOutputSynchronizerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraOutputSynchronizerSpec.cpp
@@ -80,16 +80,16 @@ namespace margelo::nitro::camera {
   std::vector<std::shared_ptr<HybridCameraOutputSpec>> JHybridCameraOutputSynchronizerSpec::getOutputs() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JHybridCameraOutputSpec::JavaPart>>()>("getOutputs");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<std::shared_ptr<HybridCameraOutputSpec>> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->getJHybridCameraOutputSpec());
       }
       return __vector;
-    }();
+    }(__result);
   }
 
   // Methods

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraSessionSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraSessionSpec.cpp
@@ -159,30 +159,30 @@ namespace margelo::nitro::camera {
   // Methods
   std::shared_ptr<Promise<std::vector<std::shared_ptr<HybridCameraControllerSpec>>>> JHybridCameraSessionSpec::configure(const std::vector<CameraSessionConnection>& connections, const std::optional<CameraSessionConfiguration>& config) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JArrayClass<JCameraSessionConnection>> /* connections */, jni::alias_ref<JCameraSessionConfiguration> /* config */)>("configure");
-    auto __result = method(_javaPart, [&]() {
-      size_t __size = connections.size();
+    auto __result = method(_javaPart, [&](auto&& __input) {
+      size_t __size = __input.size();
       jni::local_ref<jni::JArrayClass<JCameraSessionConnection>> __array = jni::JArrayClass<JCameraSessionConnection>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = connections[__i];
+        const auto& __element = __input[__i];
         auto __elementJni = JCameraSessionConnection::fromCpp(__element);
         __array->setElement(__i, *__elementJni);
       }
       return __array;
-    }(), config.has_value() ? JCameraSessionConfiguration::fromCpp(config.value()) : nullptr);
+    }(connections), config.has_value() ? JCameraSessionConfiguration::fromCpp(config.value()) : nullptr);
     return [&]() {
       auto __promise = Promise<std::vector<std::shared_ptr<HybridCameraControllerSpec>>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
         auto __result = jni::static_ref_cast<jni::JArrayClass<JHybridCameraControllerSpec::JavaPart>>(__boxedResult);
-        __promise->resolve([&]() {
-          size_t __size = __result->size();
+        __promise->resolve([&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<std::shared_ptr<HybridCameraControllerSpec>> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = __result->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->getJHybridCameraControllerSpec());
           }
           return __vector;
-        }());
+        }(__result));
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraVideoOutputSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraVideoOutputSpec.cpp
@@ -92,16 +92,16 @@ namespace margelo::nitro::camera {
   std::vector<VideoCodec> JHybridCameraVideoOutputSpec::getSupportedVideoCodecs() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JVideoCodec>>()>("getSupportedVideoCodecs");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<VideoCodec> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   std::shared_ptr<Promise<void>> JHybridCameraVideoOutputSpec::setOutputSettings(const VideoOutputSettings& settings) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JVideoOutputSettings> /* settings */)>("setOutputSettings");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridDepthSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridDepthSpec.cpp
@@ -143,16 +143,16 @@ namespace margelo::nitro::camera {
   std::vector<DepthPixelFormat> JHybridDepthSpec::getAvailableDepthPixelFormats() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JDepthPixelFormat>>()>("getAvailableDepthPixelFormats");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<DepthPixelFormat> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   std::optional<std::shared_ptr<HybridCameraCalibrationDataSpec>> JHybridDepthSpec::getCameraCalibrationData() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridCameraCalibrationDataSpec::JavaPart>()>("getCameraCalibrationData");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridFrameSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridFrameSpec.cpp
@@ -127,16 +127,16 @@ namespace margelo::nitro::camera {
   std::vector<std::shared_ptr<HybridFramePlaneSpec>> JHybridFrameSpec::getPlanes() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JHybridFramePlaneSpec::JavaPart>>()>("getPlanes");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<std::shared_ptr<HybridFramePlaneSpec>> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->getJHybridFramePlaneSpec());
       }
       return __vector;
-    }();
+    }(__result);
   }
   std::shared_ptr<ArrayBuffer> JHybridFrameSpec::getPixelBuffer() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JArrayBuffer::javaobject>()>("getPixelBuffer");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridPreviewViewSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridPreviewViewSpec.cpp
@@ -109,29 +109,29 @@ namespace margelo::nitro::camera {
   std::optional<std::vector<std::shared_ptr<HybridGestureControllerSpec>>> JHybridPreviewViewSpec::getGestureControllers() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JHybridGestureControllerSpec::JavaPart>>()>("getGestureControllers");
     auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional([&]() {
-      size_t __size = __result->size();
+    return __result != nullptr ? std::make_optional([&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<std::shared_ptr<HybridGestureControllerSpec>> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->getJHybridGestureControllerSpec());
       }
       return __vector;
-    }()) : std::nullopt;
+    }(__result)) : std::nullopt;
   }
   void JHybridPreviewViewSpec::setGestureControllers(const std::optional<std::vector<std::shared_ptr<HybridGestureControllerSpec>>>& gestureControllers) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JArrayClass<JHybridGestureControllerSpec::JavaPart>> /* gestureControllers */)>("setGestureControllers");
-    method(_javaPart, gestureControllers.has_value() ? [&]() {
-      size_t __size = gestureControllers.value().size();
+    method(_javaPart, gestureControllers.has_value() ? [&](auto&& __input) {
+      size_t __size = __input.size();
       jni::local_ref<jni::JArrayClass<JHybridGestureControllerSpec::JavaPart>> __array = jni::JArrayClass<JHybridGestureControllerSpec::JavaPart>::newArray(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        const auto& __element = gestureControllers.value()[__i];
+        const auto& __element = __input[__i];
         auto __elementJni = std::dynamic_pointer_cast<JHybridGestureControllerSpec>(__element)->getJavaPart();
         __array->setElement(__i, *__elementJni);
       }
       return __array;
-    }() : nullptr);
+    }(gestureControllers.value()) : nullptr);
   }
   std::optional<std::function<void()>> JHybridPreviewViewSpec::getOnPreviewStarted() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>()>("getOnPreviewStarted_cxx");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridScannedCodeSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridScannedCodeSpec.cpp
@@ -62,16 +62,16 @@ namespace margelo::nitro::camera {
   std::vector<Point> JHybridScannedCodeSpec::getCornerPoints() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<JPoint>>()>("getCornerPoints");
     auto __result = method(_javaPart);
-    return [&]() {
-      size_t __size = __result->size();
+    return [&](auto&& __input) {
+      size_t __size = __input->size();
       std::vector<Point> __vector;
       __vector.reserve(__size);
       for (size_t __i = 0; __i < __size; __i++) {
-        auto __element = __result->getElement(__i);
+        auto __element = __input->getElement(__i);
         __vector.push_back(__element->toCpp());
       }
       return __vector;
-    }();
+    }(__result);
   }
   ScannedObjectType JHybridScannedCodeSpec::getType() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JScannedObjectType>()>("getType");

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JObjectOutputOptions.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JObjectOutputOptions.hpp
@@ -36,16 +36,16 @@ namespace margelo::nitro::camera {
       static const auto fieldEnabledObjectTypes = clazz->getField<jni::JArrayClass<JScannedObjectType>>("enabledObjectTypes");
       jni::local_ref<jni::JArrayClass<JScannedObjectType>> enabledObjectTypes = this->getFieldValue(fieldEnabledObjectTypes);
       return ObjectOutputOptions(
-        [&]() {
-          size_t __size = enabledObjectTypes->size();
+        [&](auto&& __input) {
+          size_t __size = __input->size();
           std::vector<ScannedObjectType> __vector;
           __vector.reserve(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            auto __element = enabledObjectTypes->getElement(__i);
+            auto __element = __input->getElement(__i);
             __vector.push_back(__element->toCpp());
           }
           return __vector;
-        }()
+        }(enabledObjectTypes)
       );
     }
 
@@ -60,16 +60,16 @@ namespace margelo::nitro::camera {
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
-        [&]() {
-          size_t __size = value.enabledObjectTypes.size();
+        [&](auto&& __input) {
+          size_t __size = __input.size();
           jni::local_ref<jni::JArrayClass<JScannedObjectType>> __array = jni::JArrayClass<JScannedObjectType>::newArray(__size);
           for (size_t __i = 0; __i < __size; __i++) {
-            const auto& __element = value.enabledObjectTypes[__i];
+            const auto& __element = __input[__i];
             auto __elementJni = JScannedObjectType::fromCpp(__element);
             __array->setElement(__i, *__elementJni);
           }
           return __array;
-        }()
+        }(value.enabledObjectTypes)
       );
     }
   };

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceFactorySpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceFactorySpec.kt
@@ -35,6 +35,10 @@ abstract class HybridCameraDeviceFactorySpec: HybridObject() {
   @set:DoNotStrip
   @set:Keep
   abstract var userPreferredCamera: HybridCameraDeviceSpec?
+  
+  @get:DoNotStrip
+  @get:Keep
+  abstract val supportedMultiCamDeviceCombinations: Array<Array<HybridCameraDeviceSpec>>
 
   // Methods
   abstract fun addOnCameraDevicesChangedListener(listener: (newDevices: Array<HybridCameraDeviceSpec>) -> Unit): ListenerSubscription

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
@@ -1426,6 +1426,17 @@ namespace margelo::nitro::camera::bridge::swift {
     return Result<bool>::withError(error);
   }
   
+  // pragma MARK: std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>>
+  /**
+   * Specialized version of `std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>>`.
+   */
+  using std__vector_std__vector_std__shared_ptr_HybridCameraDeviceSpec___ = std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>>;
+  inline std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> create_std__vector_std__vector_std__shared_ptr_HybridCameraDeviceSpec___(size_t size) noexcept {
+    std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> vector;
+    vector.reserve(size);
+    return vector;
+  }
+  
   // pragma MARK: std::function<void(const std::vector<std::shared_ptr<HybridCameraDeviceSpec>>& /* newDevices */)>
   /**
    * Specialized version of `std::function<void(const std::vector<std::shared_ptr<HybridCameraDeviceSpec>>&)>`.

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceFactorySpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceFactorySpecSwift.hpp
@@ -89,6 +89,10 @@ namespace margelo::nitro::camera {
     inline void setUserPreferredCamera(const std::optional<std::shared_ptr<HybridCameraDeviceSpec>>& userPreferredCamera) noexcept override {
       _swiftPart.setUserPreferredCamera(userPreferredCamera);
     }
+    inline std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> getSupportedMultiCamDeviceCombinations() noexcept override {
+      auto __result = _swiftPart.getSupportedMultiCamDeviceCombinations();
+      return __result;
+    }
 
   public:
     // Methods

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceFactorySpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceFactorySpec.swift
@@ -12,6 +12,7 @@ public protocol HybridCameraDeviceFactorySpec_protocol: HybridObject {
   // Properties
   var cameraDevices: [(any HybridCameraDeviceSpec)] { get }
   var userPreferredCamera: (any HybridCameraDeviceSpec)? { get set }
+  var supportedMultiCamDeviceCombinations: [[(any HybridCameraDeviceSpec)]] { get }
 
   // Methods
   func addOnCameraDevicesChangedListener(listener: @escaping (_ newDevices: [(any HybridCameraDeviceSpec)]) -> Void) throws -> ListenerSubscription

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceFactorySpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceFactorySpec_cxx.swift
@@ -167,6 +167,28 @@ open class HybridCameraDeviceFactorySpec_cxx {
       }()
     }
   }
+  
+  public final var supportedMultiCamDeviceCombinations: bridge.std__vector_std__vector_std__shared_ptr_HybridCameraDeviceSpec___ {
+    @inline(__always)
+    get {
+      return { () -> bridge.std__vector_std__vector_std__shared_ptr_HybridCameraDeviceSpec___ in
+        var __vector = bridge.create_std__vector_std__vector_std__shared_ptr_HybridCameraDeviceSpec___(self.__implementation.supportedMultiCamDeviceCombinations.count)
+        for __item in self.__implementation.supportedMultiCamDeviceCombinations {
+          __vector.push_back({ () -> bridge.std__vector_std__shared_ptr_HybridCameraDeviceSpec__ in
+            var __vector = bridge.create_std__vector_std__shared_ptr_HybridCameraDeviceSpec__(__item.count)
+            for __item in __item {
+              __vector.push_back({ () -> bridge.std__shared_ptr_HybridCameraDeviceSpec_ in
+                let __cxxWrapped = __item.getCxxWrapper()
+                return __cxxWrapped.getCxxPart()
+              }())
+            }
+            return __vector
+          }())
+        }
+        return __vector
+      }()
+    }
+  }
 
   // Methods
   @inline(__always)

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceFactorySpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceFactorySpec.cpp
@@ -17,6 +17,7 @@ namespace margelo::nitro::camera {
       prototype.registerHybridGetter("cameraDevices", &HybridCameraDeviceFactorySpec::getCameraDevices);
       prototype.registerHybridGetter("userPreferredCamera", &HybridCameraDeviceFactorySpec::getUserPreferredCamera);
       prototype.registerHybridSetter("userPreferredCamera", &HybridCameraDeviceFactorySpec::setUserPreferredCamera);
+      prototype.registerHybridGetter("supportedMultiCamDeviceCombinations", &HybridCameraDeviceFactorySpec::getSupportedMultiCamDeviceCombinations);
       prototype.registerHybridMethod("addOnCameraDevicesChangedListener", &HybridCameraDeviceFactorySpec::addOnCameraDevicesChangedListener);
       prototype.registerHybridMethod("getCameraForId", &HybridCameraDeviceFactorySpec::getCameraForId);
       prototype.registerHybridMethod("getSupportedExtensions", &HybridCameraDeviceFactorySpec::getSupportedExtensions);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceFactorySpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceFactorySpec.hpp
@@ -63,6 +63,7 @@ namespace margelo::nitro::camera {
       virtual std::vector<std::shared_ptr<HybridCameraDeviceSpec>> getCameraDevices() = 0;
       virtual std::optional<std::shared_ptr<HybridCameraDeviceSpec>> getUserPreferredCamera() = 0;
       virtual void setUserPreferredCamera(const std::optional<std::shared_ptr<HybridCameraDeviceSpec>>& userPreferredCamera) = 0;
+      virtual std::vector<std::vector<std::shared_ptr<HybridCameraDeviceSpec>>> getSupportedMultiCamDeviceCombinations() = 0;
 
     public:
       // Methods

--- a/packages/react-native-vision-camera/package.json
+++ b/packages/react-native-vision-camera/package.json
@@ -70,11 +70,11 @@
   },
   "devDependencies": {
     "@types/react": "19.2.14",
-    "nitrogen": "0.35.5",
+    "nitrogen": "0.35.6",
     "react": "19.2.3",
     "react-native": "0.84.0",
     "react-native-nitro-image": "0.14.0",
-    "react-native-nitro-modules": "0.35.5",
+    "react-native-nitro-modules": "0.35.6",
     "typescript": "5.9.3"
   },
   "peerDependencies": {

--- a/packages/react-native-vision-camera/src/specs/inputs/CameraDeviceFactory.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/inputs/CameraDeviceFactory.nitro.ts
@@ -1,4 +1,5 @@
 import type { HybridObject } from 'react-native-nitro-modules'
+import type { CameraFactory } from '../CameraFactory.nitro'
 import type { CameraPosition } from '../common-types/CameraPosition'
 import type { ListenerSubscription } from '../common-types/ListenerSubscription'
 import type { CameraSession } from '../session/CameraSession.nitro'
@@ -12,8 +13,12 @@ import type { CameraExtension } from './CameraExtension.nitro'
 export interface CameraDeviceFactory
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
   /**
-   * Get a list of all devices.
-   * This list may change as camera devices get plugged in/out.
+   * Get a list of all {@linkcode CameraDevice}s on this platform.
+   *
+   * This list may change as {@linkcode CameraDevice}s get plugged in/out (e.g.
+   * {@linkcode CameraPosition | 'external'} Cameras via USB/UVC), devices
+   * become available/unavailable (e.g. continuity Cameras), or Camera positions
+   * change (e.g. on foldable phones).
    */
   readonly cameraDevices: CameraDevice[]
   /**
@@ -21,6 +26,64 @@ export interface CameraDeviceFactory
    * Setting a device here will persist the preference between apps.
    */
   userPreferredCamera?: CameraDevice
+
+  /**
+   * A list of all {@linkcode CameraDevice} combinations that are supported
+   * in Multi-Cam {@linkcode CameraSession}s.
+   *
+   * This list always contains a subset of {@linkcode cameraDevices}, often
+   * less.
+   *
+   * @discussion
+   * For example, on many platforms only a {@linkcode CameraPosition | 'front'}
+   * and a {@linkcode CameraPosition | 'back'} {@linkcode CameraDevice} are
+   * supported to be used in a Multi-Cam {@linkcode CameraSession} - in this case,
+   * the returned 2D Array looks something like this:
+   * ```
+   * [
+   *   [{ position: 'back', ... }, { position: 'front', ... }]
+   * ]
+   * ```
+   * Two {@linkcode CameraPosition | 'back'}-, or two {@linkcode CameraPosition | 'front'}
+   * {@linkcode CameraDevice}s are often not supported together in a Multi-Cam
+   * {@linkcode CameraSession}.
+   *
+   * When creating a Multi-Cam {@linkcode CameraSession}, you must ensure
+   * that you are using Device combinations that are actually supported
+   * on the platform, otherwise the session might fail to configure.
+   *
+   * @discussion
+   * If the platform does not support Multi-Cam {@linkcode CameraSession}s,
+   * an empty array (`[]`) will be returned.
+   *
+   *
+   * @example
+   * ```ts
+   * if (VisionCamera.supportsMultiCamSessions) {
+   *   const deviceFactory = await VisionCamera.createDeviceFactory()
+   *   const deviceCombinations = deviceFactory.supportedMultiCamDeviceCombinations[0]
+   *   if (deviceCombinations != null) {
+   *     const connections = deviceCombinations.map((device) => {
+   *       const previewOutput = VisionCamera.createPreviewOutput()
+   *       return {
+   *         input: device,
+   *         outputs: [
+   *           { output: previewOutput, mirrorMode: 'auto' }
+   *         ],
+   *         constraints: []
+   *       } satisfies CameraSessionConnection
+   *     })
+   *
+   *     const session = await VisionCamera.createCameraSession(true)
+   *     const controllers = await session.configure(connections)
+   *     await session.start()
+   *   }
+   * }
+   * ```
+   *
+   * @see {@linkcode CameraFactory.supportsMultiCamSessions}
+   */
+  readonly supportedMultiCamDeviceCombinations: CameraDevice[][]
 
   /**
    * Add a listener to be called whenever the

--- a/packages/react-native-vision-camera/src/specs/session/CameraSession.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/session/CameraSession.nitro.ts
@@ -68,6 +68,10 @@ export type InterruptionReason =
  * and back-Camera using the imperative API:
  * ```ts
  * if (VisionCamera.supportsMultiCamSessions) {
+ *   const deviceFactory = await VisionCamera.createDeviceFactory()
+ *   const deviceCombinations = deviceFactory.supportedMultiCamDeviceCombinations
+ *   // ... get `frontDevice` and `backDevice` from one of
+ *   //     the combinations in `deviceCombinations`.
  *   const session = await VisionCamera.createCameraSession(true)
  *   const [frontController, backController] = await session.configure([
  *     // Front Camera
@@ -110,6 +114,12 @@ export interface CameraSession
    * from one {@linkcode CameraDevice} (the _input_) to multiple
    * {@linkcode CameraOutput}s (the _outputs_).
    *
+   * @note In a Multi-Cam Camera Session, the given {@linkcode connections}' input devices
+   * must be supported to be used together in a Multi-Cam Camera Session, as not every
+   * {@linkcode CameraDevice} can be used with every other {@linkcode CameraDevice}
+   * simultaneously. See {@linkcode CameraDeviceFactory.supportedMultiCamDeviceCombinations}
+   * for a full list of supported combinations.
+   *
    * @param connections The list of connections from one _input_ to
    * multiple _outputs_. If this {@linkcode CameraSession} was created
    * as a multi-cam session (see {@linkcode CameraFactory.createCameraSession | createCameraSession(enableMultiCam)}),
@@ -122,6 +132,9 @@ export interface CameraSession
    * @throws If Camera Permission has not been granted - see {@linkcode CameraFactory.cameraPermissionStatus}
    * @throws If multiple {@linkcode connections} are added, but the
    * {@linkcode CameraSession} was not created as a multi-cam session.
+   * @throws If hardware resources are being exhausted by too large connection graphs.
+   * @throws If this is a Multi-Cam session, but the connection inputs are not supported to
+   * be used together - see {@linkcode CameraDeviceFactory.supportedMultiCamDeviceCombinations}
    *
    * @example
    * Creating a simple Preview + Photo connection:
@@ -162,6 +175,10 @@ export interface CameraSession
    * Creating a multi-cam session with front- and back Camera:
    * ```ts
    * if (VisionCamera.supportsMultiCamSessions) {
+   *   const deviceFactory = await VisionCamera.createDeviceFactory()
+   *   const deviceCombinations = deviceFactory.supportedMultiCamDeviceCombinations
+   *   // ... get `frontDevice` and `backDevice` from one of
+   *   //     the combinations in `deviceCombinations`.
    *   const session = await VisionCamera.createCameraSession(true)
    *   const [frontController, backController] = await session.configure([
    *     // Front Camera


### PR DESCRIPTION
Same as #3817, but now with an updated Nitrogen version that fixed the `__element` name shadowing build error.