### PR TITLE
fix(ios): guard unsupportedCaptureOutputClasses against SimCam crash on simulator

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice.Format+supportsOutput.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice.Format+supportsOutput.swift
@@ -9,7 +9,15 @@ import Foundation
 
 extension AVCaptureDevice.Format {
   func supportsOutput(_ output: AVCaptureOutput) -> Bool {
+    #if targetEnvironment(simulator)
+    // SimCam's DummyCaptureDeviceFormat doesn't implement isStreamingDisparitySupported,
+    // which is called internally by unsupportedCaptureOutputClasses, causing a SIGSEGV
+    // on the com.margelo.camera.session queue. On simulator all outputs are assumed
+    // supported since we're using a fake camera anyway.
+    return true
+    #else
     let targetOutputClass = type(of: output)
     return self.unsupportedCaptureOutputClasses.allSatisfy { $0 != targetOutputClass }
+    #endif
   }
 }


### PR DESCRIPTION
## Problem

When using [SimCam](https://simcam.swmansion.com/) (Software Mansion's simulator camera injection tool) with VisionCamera on the iOS Simulator, the app crashes immediately on launch with `EXC_BAD_ACCESS (SIGSEGV)` on the `com.margelo.camera.session` queue.

**Crash stack:**
```
Thread crashed: com.margelo.camera.session
0  AVFCapture   -[AVCaptureDeviceFormat isStreamingDisparitySupported]  <-- SIGSEGV (null ptr @ 0x59)
1  AVFCapture   -[AVCaptureDeviceFormat unsupportedCaptureOutputClasses]
2  VisionCamera  AVCaptureDeviceFormat.supportsOutput(_:)  (AVCaptureDevice.Format+supportsOutput.swift:13)
3  VisionCamera  ConstraintResolver.filterFormats(_:outputs:isMultiCam:)  (ConstraintResolver.swift:176)
4  VisionCamera  HybridCameraSession.configureConnection(_:isMultiCam:)  (HybridCameraSession.swift:120)
```

**Root cause:** SimCam injects a `DummyCaptureDeviceFormat` into the simulator. When `ConstraintResolver.filterFormats` calls `format.supportsOutput()` for each camera format at session startup, it reads `unsupportedCaptureOutputClasses`, which internally calls `isStreamingDisparitySupported`. SimCam's dummy format has a null ivar at offset `0x59` for this property, causing the crash.

## Fix

Guard `unsupportedCaptureOutputClasses` behind `#if targetEnvironment(simulator)`. On the simulator the camera is fake regardless, so assuming all outputs are supported is correct and safe.

## Testing

Tested on iOS Simulator (iOS 26.3) with SimCam running — app no longer crashes on launch and the simulated camera feed displays correctly.  Tested iPhone Air device confirming camera working correctly.  Tested on Android Pixel 8 confirming camera working correctly.