### PR TITLE
fix(ios): Crash when taking a photo on iOS 15

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
@@ -83,6 +83,9 @@ class HybridCameraPhotoOutput: HybridCameraPhotoOutputSpec, NativeCameraOutput {
           try? prepareDefaultPhotoSettings()
         }
       }
+    } else {
+      // For iOS 15 and earlier, enabling AVCapturePhotoSettings.isHighResolutionPhotoEnabled requires setting isHighResolutionCaptureEnabled = true on the AVCapturePhotoOutput instance.
+      output.isHighResolutionCaptureEnabled = true
     }
   }
 


### PR DESCRIPTION
This PR fixes a crash that occurs on iOS 15 when attempting to capture a photo.

For iOS versions earlier than 16, AVCapturePhotoSettings.isHighResolutionPhotoEnabled is explicitly set. However, this flag requires isHighResolutionCaptureEnabled = true to be configured on the corresponding AVCapturePhotoOutput. Without this, the app crashes at runtime.