### PR TITLE
fix: Fix iOS <15 crash in photo capture (`isHighResolutionPhotoEnabled`)

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/Converters/AV+CapturePhotoSettings.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/Converters/AV+CapturePhotoSettings.swift
@@ -110,8 +110,6 @@ extension CapturePhotoSettings {
     // Shoot in max resolution
     if #available(iOS 16.0, *) {
       settings.maxPhotoDimensions = output.maxPhotoDimensions
-    } else {
-      settings.isHighResolutionPhotoEnabled = true
     }
 
     // photoQualityPrioritization can only be set on processed photos.


### PR DESCRIPTION
Fixes a crash on iOS <=15 devices where `isHighResolutionPhotoEnabled = true` was set for a photo request, but `isHighResolutionCaptureEnabled` was **NOT** enabled on the photo output itself.

One other fix could've been to simply always enable it, like in #3827 - but I thought about it and iOS <=15 has a very small market share anyways and the reduced branching/test matrix might make things simpler - for the future we work with dimensions, not a simple boolean flag anyways.