### PR TITLE
fix(android): dispatch concurrent permission requests

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ReactApplicationContext+permissions.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ReactApplicationContext+permissions.kt
@@ -8,8 +8,13 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 import com.margelo.nitro.camera.PermissionStatus
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 
 fun ReactApplicationContext.getPermissionStatus(permission: String): PermissionStatus {
   val status = ContextCompat.checkSelfPermission(this, permission)
@@ -43,34 +48,76 @@ fun ReactApplicationContext.getPermissionStatus(permission: String): PermissionS
   }
 }
 
-private var permissionRequestCode: Int = 3682
+private object PermissionRequestDispatcher : PermissionListener {
+  private val nextRequestCode = AtomicInteger(3682)
+  private val pendingRequests = ConcurrentHashMap<Int, PendingPermissionRequest>()
+
+  fun request(
+    context: ReactApplicationContext,
+    permission: String,
+    activity: PermissionAwareActivity,
+    continuation: CancellableContinuation<Boolean>,
+  ) {
+    val requestCode = nextRequestCode.getAndIncrement()
+    val hadRequestedPermission = PermissionStateStore.hasRequestedPermission(context, permission)
+    pendingRequests[requestCode] = PendingPermissionRequest(context, activity, permission, continuation)
+    try {
+      PermissionStateStore.setHasRequestedPermission(context, permission, true)
+      activity.requestPermissions(arrayOf(permission), requestCode, this)
+    } catch (error: Throwable) {
+      pendingRequests.remove(requestCode)
+      PermissionStateStore.setHasRequestedPermission(context, permission, hadRequestedPermission)
+      throw error
+    }
+  }
+
+  override fun onRequestPermissionsResult(
+    requestCode: Int,
+    permissions: Array<String>,
+    grantResults: IntArray,
+  ): Boolean {
+    val pendingRequest =
+      pendingRequests.remove(requestCode) ?: return pendingRequests.isEmpty()
+
+    val permissionStatus = grantResults.firstOrNull() ?: PackageManager.PERMISSION_DENIED
+    val hasPermission = permissionStatus == PackageManager.PERMISSION_GRANTED
+    pendingRequest.updatePermissionState(hasPermission)
+    if (pendingRequest.continuation.isActive) {
+      pendingRequest.continuation.resume(hasPermission)
+    }
+
+    // React Native only clears the currently registered PermissionListener if it returns true.
+    // Keep the shared listener alive until every pending VisionCamera request has completed.
+    return pendingRequests.isEmpty()
+  }
+
+  private data class PendingPermissionRequest(
+    val context: ReactApplicationContext,
+    val activity: PermissionAwareActivity,
+    val permission: String,
+    val continuation: CancellableContinuation<Boolean>,
+  ) {
+    fun updatePermissionState(hasPermission: Boolean) {
+      if (hasPermission) {
+        PermissionStateStore.setHasRequestedPermission(context, permission, false)
+        PermissionStateStore.setPermissionPermanentlyDenied(context, permission, false)
+      } else {
+        val canRequestAgain = activity.shouldShowRequestPermissionRationale(permission)
+        PermissionStateStore.setPermissionPermanentlyDenied(context, permission, !canRequestAgain)
+      }
+    }
+  }
+}
 
 suspend fun ReactApplicationContext.requestPermission(permission: String): Boolean {
-  return suspendCoroutine { continuation ->
-    val activity = currentActivity ?: throw Error("No Activity!")
-    if (activity is PermissionAwareActivity) {
-      PermissionStateStore.setHasRequestedPermission(this, permission, true)
-      val currentRequestCode = permissionRequestCode++
-      val listener =
-        PermissionListener { requestCode: Int, _: Array<String>, grantResults: IntArray ->
-          if (requestCode == currentRequestCode) {
-            val permissionStatus = grantResults.firstOrNull() ?: PackageManager.PERMISSION_DENIED
-            val hasPermission = permissionStatus == PackageManager.PERMISSION_GRANTED
-            if (hasPermission) {
-              PermissionStateStore.setHasRequestedPermission(this, permission, false)
-              PermissionStateStore.setPermissionPermanentlyDenied(this, permission, false)
-            } else {
-              val canRequestAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)
-              PermissionStateStore.setPermissionPermanentlyDenied(this, permission, !canRequestAgain)
-            }
-            continuation.resume(hasPermission)
-            return@PermissionListener true
-          }
-          return@PermissionListener false
-        }
-      activity.requestPermissions(arrayOf(permission), currentRequestCode, listener)
-    } else {
-      throw Error("Activity is not a PermissionAwareActivity!")
+  return withContext(Dispatchers.Main.immediate) {
+    suspendCancellableCoroutine { continuation ->
+      val activity = currentActivity ?: throw Error("No Activity!")
+      if (activity is PermissionAwareActivity) {
+        PermissionRequestDispatcher.request(this@requestPermission, permission, activity, continuation)
+      } else {
+        throw Error("Activity is not a PermissionAwareActivity!")
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace the per-request Android PermissionListener with a shared PermissionRequestDispatcher
- keep pending permission continuations keyed by equestCode so camera, microphone, and location requests can resolve independently
- move permission launches onto Dispatchers.Main.immediate and restore persisted request state if dispatch throws before Android takes over

## Root Cause
React Native's PermissionAwareActivity only stores one active PermissionListener. VisionCamera was creating a fresh listener for every equestPermission() call, so parallel Android permission requests would overwrite the previous listeners before their callbacks arrived.

That left the older suspended coroutines unresolved and eventually surfaced as Nitro's JPromise was destroyed rejection even though the user-facing permission state updated correctly.

## User Impact
Apps can now request camera, microphone, and location permissions in parallel on Android without leaking the earlier promises or hanging equestPermission() callers.

## Testing
- ./gradlew :react-native-vision-camera:compileDebugKotlin --no-daemon --console=plain
- attempted ./gradlew assembleDebug --no-daemon --console=plain in pps/simple-camera/android, but the full native build is currently blocked in this environment by an existing CMake/ninja uild.ninja dirty loop unrelated to this Kotlin-only change

Closes #3834