### PR TITLE
specify target because of MLKit 8.0.0 + update doc

### DIFF
--- a/packages/react-native-vision-camera-barcode-scanner/README.md
+++ b/packages/react-native-vision-camera-barcode-scanner/README.md
@@ -12,6 +12,11 @@ VisionCamera Barcode Scanner depends on VisionCamera Core.
 # Make sure VisionCamera Core is installed.
 ```
 
+## iOS requirements
+
+- Assumed native dependency: `GoogleMLKit/BarcodeScanning` `8.0.0`
+- Minimum supported iOS version: `15.5`
+
 Then, update your native project:
 
 ```sh

--- a/packages/react-native-vision-camera-barcode-scanner/README.md
+++ b/packages/react-native-vision-camera-barcode-scanner/README.md
@@ -12,10 +12,9 @@ VisionCamera Barcode Scanner depends on VisionCamera Core.
 # Make sure VisionCamera Core is installed.
 ```
 
-## iOS requirements
+## Minimum Requirements
 
-- Assumed native dependency: `GoogleMLKit/BarcodeScanning` `8.0.0`
-- Minimum supported iOS version: `15.5`
+The `GoogleMLKit/BarcodeScanning` dependency (version `8.0.0`) requires a minimum iOS target version of 15.5. Adjust in your `Podfile` if needed.
 
 Then, update your native project:
 

--- a/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
+++ b/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "15.5", :visionos => 1.0 }
+  s.platforms    = { :ios => 15.5, :visionos => 1.0 }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   s.source_files = [

--- a/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
+++ b/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
+  s.platforms    = { :ios => "15.5", :visionos => 1.0 }
   s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
 
   s.source_files = [


### PR DESCRIPTION
As barcode-scanner require MLKit 8.0.0, we need to specify ios target.

This close #3770

