### PR TITLE
feat: add support for specifying a video path

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridVideoOutput.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridVideoOutput.kt
@@ -145,8 +145,14 @@ class HybridVideoOutput(
   @SuppressLint("MissingPermission")
   override fun createRecorder(settings: RecorderSettings): Promise<HybridRecorderSpec> {
     return Promise.async {
-      // Create .mp4 file in temp directory
-      val file = File.createTempFile("VisionCamera_", "mp4")
+      val file =
+        if (settings.filePath != null) {
+          File(settings.filePath)
+        } else {
+          // Create .mp4 file in temp directory
+          File.createTempFile("VisionCamera_", "mp4")
+        }
+      file.parentFile?.mkdirs()
 
       // Prepare output options
       val fileOutputOptions =

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridVideoOutput.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridVideoOutput.kt
@@ -152,6 +152,7 @@ class HybridVideoOutput(
           // Create .mp4 file in temp directory
           File.createTempFile("VisionCamera_", "mp4")
         }
+      // Create all parent directories if they don't exist yet.
       file.parentFile?.mkdirs()
 
       // Prepare output options

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/HybridVideoRecorder.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/HybridVideoRecorder.swift
@@ -23,11 +23,15 @@ class HybridVideoRecorder: HybridRecorderSpec {
   ) throws {
     self.videoOutput = videoOutput
     self.queue = queue
-    if let filePath = settings.filePath {
-      self.fileURL = URL(fileURLWithPath: filePath)
+    if let customFilePath = settings.filePath {
+      self.fileURL = URL(fileURLWithPath: customFilePath)
     } else {
       self.fileURL = try URL.createTempURL(fileType: fileType.toUTType())
     }
+    try FileManager.default.createDirectory(
+      at: self.fileURL.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
     self.settings = settings
     super.init()
   }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/HybridVideoRecorder.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/HybridVideoRecorder.swift
@@ -23,7 +23,11 @@ class HybridVideoRecorder: HybridRecorderSpec {
   ) throws {
     self.videoOutput = videoOutput
     self.queue = queue
-    self.fileURL = try URL.createTempURL(fileType: fileType.toUTType())
+    if let filePath = settings.filePath {
+      self.fileURL = URL(fileURLWithPath: filePath)
+    } else {
+      self.fileURL = try URL.createTempURL(fileType: fileType.toUTType())
+    }
     self.settings = settings
     super.init()
   }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/HybridVideoRecorder.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/HybridVideoRecorder.swift
@@ -28,6 +28,7 @@ class HybridVideoRecorder: HybridRecorderSpec {
     } else {
       self.fileURL = try URL.createTempURL(fileType: fileType.toUTType())
     }
+    // Create all parent directories if they don't exist yet.
     try FileManager.default.createDirectory(
       at: self.fileURL.deletingLastPathComponent(),
       withIntermediateDirectories: true

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraVideoOutputSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraVideoOutputSpec.cpp
@@ -38,6 +38,7 @@ namespace margelo::nitro::camera { enum class CameraOrientation; }
 #include "JRecorderSettings.hpp"
 #include "HybridLocationSpec.hpp"
 #include "JHybridLocationSpec.hpp"
+#include <string>
 #include "MediaType.hpp"
 #include "JMediaType.hpp"
 #include "CameraOrientation.hpp"

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JRecorderSettings.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JRecorderSettings.hpp
@@ -14,6 +14,7 @@
 #include "JHybridLocationSpec.hpp"
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace margelo::nitro::camera {
 
@@ -36,12 +37,15 @@ namespace margelo::nitro::camera {
       static const auto clazz = javaClassStatic();
       static const auto fieldLocation = clazz->getField<JHybridLocationSpec::JavaPart>("location");
       jni::local_ref<JHybridLocationSpec::JavaPart> location = this->getFieldValue(fieldLocation);
+      static const auto fieldFilePath = clazz->getField<jni::JString>("filePath");
+      jni::local_ref<jni::JString> filePath = this->getFieldValue(fieldFilePath);
       static const auto fieldMaxDuration = clazz->getField<jni::JDouble>("maxDuration");
       jni::local_ref<jni::JDouble> maxDuration = this->getFieldValue(fieldMaxDuration);
       static const auto fieldMaxFileSize = clazz->getField<jni::JDouble>("maxFileSize");
       jni::local_ref<jni::JDouble> maxFileSize = this->getFieldValue(fieldMaxFileSize);
       return RecorderSettings(
         location != nullptr ? std::make_optional(location->getJHybridLocationSpec()) : std::nullopt,
+        filePath != nullptr ? std::make_optional(filePath->toStdString()) : std::nullopt,
         maxDuration != nullptr ? std::make_optional(maxDuration->value()) : std::nullopt,
         maxFileSize != nullptr ? std::make_optional(maxFileSize->value()) : std::nullopt
       );
@@ -53,12 +57,13 @@ namespace margelo::nitro::camera {
      */
     [[maybe_unused]]
     static jni::local_ref<JRecorderSettings::javaobject> fromCpp(const RecorderSettings& value) {
-      using JSignature = JRecorderSettings(jni::alias_ref<JHybridLocationSpec::JavaPart>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>);
+      using JSignature = JRecorderSettings(jni::alias_ref<JHybridLocationSpec::JavaPart>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
         value.location.has_value() ? std::dynamic_pointer_cast<JHybridLocationSpec>(value.location.value())->getJavaPart() : nullptr,
+        value.filePath.has_value() ? jni::make_jstring(value.filePath.value()) : nullptr,
         value.maxDuration.has_value() ? jni::JDouble::valueOf(value.maxDuration.value()) : nullptr,
         value.maxFileSize.has_value() ? jni::JDouble::valueOf(value.maxFileSize.value()) : nullptr
       );

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/RecorderSettings.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/RecorderSettings.kt
@@ -23,6 +23,9 @@ data class RecorderSettings(
   val location: HybridLocationSpec?,
   @DoNotStrip
   @Keep
+  val filePath: String?,
+  @DoNotStrip
+  @Keep
   val maxDuration: Double?,
   @DoNotStrip
   @Keep
@@ -34,6 +37,7 @@ data class RecorderSettings(
     if (this === other) return true
     if (other !is RecorderSettings) return false
     return Objects.deepEquals(this.location, other.location)
+      && Objects.deepEquals(this.filePath, other.filePath)
       && Objects.deepEquals(this.maxDuration, other.maxDuration)
       && Objects.deepEquals(this.maxFileSize, other.maxFileSize)
   }
@@ -41,6 +45,7 @@ data class RecorderSettings(
   override fun hashCode(): Int {
     return arrayOf(
       location,
+      filePath,
       maxDuration,
       maxFileSize
     ).contentDeepHashCode()
@@ -54,8 +59,8 @@ data class RecorderSettings(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(location: HybridLocationSpec?, maxDuration: Double?, maxFileSize: Double?): RecorderSettings {
-      return RecorderSettings(location, maxDuration, maxFileSize)
+    private fun fromCpp(location: HybridLocationSpec?, filePath: String?, maxDuration: Double?, maxFileSize: Double?): RecorderSettings {
+      return RecorderSettings(location, filePath, maxDuration, maxFileSize)
     }
   }
 }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraVideoOutputSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraVideoOutputSpecSwift.hpp
@@ -34,6 +34,7 @@ namespace margelo::nitro::camera { class HybridCameraOutputSpecSwift; }
 #include "HybridRecorderSpec.hpp"
 #include "RecorderSettings.hpp"
 #include "HybridLocationSpec.hpp"
+#include <string>
 #include "HybridCameraOutputSpecSwift.hpp"
 
 #include "VisionCamera-Swift-Cxx-Umbrella.hpp"

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/RecorderSettings.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/RecorderSettings.swift
@@ -18,13 +18,19 @@ public extension RecorderSettings {
   /**
    * Create a new instance of `RecorderSettings`.
    */
-  init(location: (any HybridLocationSpec)?, maxDuration: Double?, maxFileSize: Double?) {
+  init(location: (any HybridLocationSpec)?, filePath: String?, maxDuration: Double?, maxFileSize: Double?) {
     self.init({ () -> bridge.std__optional_std__shared_ptr_HybridLocationSpec__ in
       if let __unwrappedValue = location {
         return bridge.create_std__optional_std__shared_ptr_HybridLocationSpec__({ () -> bridge.std__shared_ptr_HybridLocationSpec_ in
           let __cxxWrapped = __unwrappedValue.getCxxWrapper()
           return __cxxWrapped.getCxxPart()
         }())
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_std__string_ in
+      if let __unwrappedValue = filePath {
+        return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
       } else {
         return .init()
       }
@@ -53,6 +59,18 @@ public extension RecorderSettings {
           let __instance = HybridLocationSpec_cxx.fromUnsafe(__unsafePointer)
           return __instance.getHybridLocationSpec()
         }()
+      } else {
+        return nil
+      }
+    }()
+  }
+  
+  @inline(__always)
+  var filePath: String? {
+    return { () -> String? in
+      if bridge.has_value_std__optional_std__string_(self.__filePath) {
+        let __unwrapped = bridge.get_std__optional_std__string_(self.__filePath)
+        return String(__unwrapped)
       } else {
         return nil
       }

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/RecorderSettings.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/RecorderSettings.hpp
@@ -34,6 +34,7 @@ namespace margelo::nitro::camera { class HybridLocationSpec; }
 #include <memory>
 #include "HybridLocationSpec.hpp"
 #include <optional>
+#include <string>
 
 namespace margelo::nitro::camera {
 
@@ -43,12 +44,13 @@ namespace margelo::nitro::camera {
   struct RecorderSettings final {
   public:
     std::optional<std::shared_ptr<HybridLocationSpec>> location     SWIFT_PRIVATE;
+    std::optional<std::string> filePath     SWIFT_PRIVATE;
     std::optional<double> maxDuration     SWIFT_PRIVATE;
     std::optional<double> maxFileSize     SWIFT_PRIVATE;
 
   public:
     RecorderSettings() = default;
-    explicit RecorderSettings(std::optional<std::shared_ptr<HybridLocationSpec>> location, std::optional<double> maxDuration, std::optional<double> maxFileSize): location(location), maxDuration(maxDuration), maxFileSize(maxFileSize) {}
+    explicit RecorderSettings(std::optional<std::shared_ptr<HybridLocationSpec>> location, std::optional<std::string> filePath, std::optional<double> maxDuration, std::optional<double> maxFileSize): location(location), filePath(filePath), maxDuration(maxDuration), maxFileSize(maxFileSize) {}
 
   public:
     friend bool operator==(const RecorderSettings& lhs, const RecorderSettings& rhs) = default;
@@ -65,6 +67,7 @@ namespace margelo::nitro {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::camera::RecorderSettings(
         JSIConverter<std::optional<std::shared_ptr<margelo::nitro::camera::HybridLocationSpec>>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "location"))),
+        JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "filePath"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "maxDuration"))),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "maxFileSize")))
       );
@@ -72,6 +75,7 @@ namespace margelo::nitro {
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::camera::RecorderSettings& arg) {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "location"), JSIConverter<std::optional<std::shared_ptr<margelo::nitro::camera::HybridLocationSpec>>>::toJSI(runtime, arg.location));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "filePath"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.filePath));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "maxDuration"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.maxDuration));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "maxFileSize"), JSIConverter<std::optional<double>>::toJSI(runtime, arg.maxFileSize));
       return obj;
@@ -85,6 +89,7 @@ namespace margelo::nitro {
         return false;
       }
       if (!JSIConverter<std::optional<std::shared_ptr<margelo::nitro::camera::HybridLocationSpec>>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "location")))) return false;
+      if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "filePath")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "maxDuration")))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "maxFileSize")))) return false;
       return true;

--- a/packages/react-native-vision-camera/src/specs/outputs/CameraVideoOutput.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/outputs/CameraVideoOutput.nitro.ts
@@ -144,6 +144,12 @@ export interface RecorderSettings {
    */
   location?: Location
   /**
+   * The absolute path where the recording file should be written.
+   *
+   * If omitted, the recording will be written to a temporary file.
+   */
+  filePath?: string;
+  /**
    * If set, the recording automatically stops once it reaches
    * this duration, in seconds.
    *
@@ -210,8 +216,9 @@ export interface CameraVideoOutput extends CameraOutput {
    * Creates and prepares a new {@linkcode Recorder}
    * instance with the given {@linkcode RecorderSettings}.
    *
-   * The {@linkcode Recorder} will record to a temporary
-   * file, and can only record once.
+   * The {@linkcode Recorder} will record to the configured
+   * file path, or to a temporary file if no path was provided.
+   * It can only record once.
    *
    * If you want to create a second recording,
    * you must create a new {@linkcode Recorder}.

--- a/packages/react-native-vision-camera/src/specs/outputs/CameraVideoOutput.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/outputs/CameraVideoOutput.nitro.ts
@@ -144,9 +144,14 @@ export interface RecorderSettings {
    */
   location?: Location
   /**
-   * The absolute path where the recording file should be written.
-   *
-   * If omitted, the recording will be written to a temporary file.
+   * The absolute path (including file name and extension) where
+   * the recording file should be written to, or `undefined` to
+   * create a file in the device's temporary directory.
+   * 
+   * All parent directories in this {@linkcode filePath} will
+   * be automatically created if they do not yet exist.
+   * 
+   * @default undefined
    */
   filePath?: string
   /**

--- a/packages/react-native-vision-camera/src/specs/outputs/CameraVideoOutput.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/outputs/CameraVideoOutput.nitro.ts
@@ -148,7 +148,7 @@ export interface RecorderSettings {
    *
    * If omitted, the recording will be written to a temporary file.
    */
-  filePath?: string;
+  filePath?: string
   /**
    * If set, the recording automatically stops once it reaches
    * this duration, in seconds.


### PR DESCRIPTION
This PR adds support for specifying a video path when creating a video output. This was a [supported feature on v4](https://visioncamera4.margelo.com/docs/api/interfaces/RecordVideoOptions#path) but is missing on v5.