### PR TITLE
fix: Fix `ByteBuffer` not being rewinded for `ExifInterface` save

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -63,6 +63,49 @@ describe('VisionCamera - Photo', () => {
     await session.stop()
   })
 
+  it('saves a JPEG Photo to a temporary file after converting it to an Image', async () => {
+    // Regression: on Android, `toImageAsync()` goes through CameraX's
+    // `jpegImageToJpegByteArray`, which advances the JPEG plane's `ByteBuffer`
+    // position to `capacity`. The plane buffer is shared across reads (Android's
+    // `ImageReader` caches the same `ByteBuffer` instance), so a subsequent
+    // `saveToTemporaryFileAsync()` that reads `buffer.remaining()` would write a
+    // 0-byte file, and `ExifInterface.saveAttributes()` would then throw
+    // "ExifInterface only supports saving attributes for JPEG, PNG, and WebP
+    // formats" because it cannot sniff the MIME type of an empty file.
+    // See `HybridPhoto.kt#saveToFile`.
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.9,
+      qualityPrioritization: 'balanced',
+    })
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    await session.start()
+
+    const photo = await photoOutput.capturePhoto(
+      { flashMode: 'off', enableShutterSound: false },
+      {},
+    )
+
+    const image = await photo.toImageAsync()
+    expect(image.width).toBeGreaterThan(0)
+    expect(image.height).toBeGreaterThan(0)
+    image.dispose()
+
+    const path = await photo.saveToTemporaryFileAsync()
+    expect(path.length).toBeGreaterThan(0)
+    photo.dispose()
+
+    await session.stop()
+  })
+
   // TODO: Re-enable once VisionCamera exposes a way to query supported photo
   //       container formats upfront (see the TODO in CameraPhotoOutput.nitro.ts
   //       near `TargetPhotoContainerFormat`). Without that API there is no

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
@@ -91,7 +91,12 @@ class HybridPhoto(
         // JPEG Images have a single plane of image data.
         val plane = image.planes.single()
         val buffer = plane.buffer
-        val bytes = ByteArray(buffer.remaining()).also { bytes -> buffer.get(bytes) }
+        // The ByteBuffer is shared and cached by Android's ImageReader, so other readers
+        // (e.g. `image.toBitmap()` via `toImage()`) may have advanced its position to the end.
+        // Rewind so we read all bytes from the start instead of writing an empty file.
+        buffer.rewind()
+        val bytes = ByteArray(buffer.remaining())
+        buffer.get(bytes)
         FileOutputStream(file).use { stream ->
           stream.write(bytes)
         }


### PR DESCRIPTION
Fixes this error:

```diff
- ExifInterface only supports saving attributes for JPEG, PNG, and WebP formats
```

This happened after `ByteBuffer` caret was moved (eg by ImageReader or Camera lib) and we fix it by rewinding.