### PR TITLE
ci(ios): fix harness test for ios (permissions should work now)

### DIFF
--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -63,6 +63,8 @@ env:
   HARNESS_IOS_APP_BUILD_OUTPUT: apps/simple-camera/ios/build/devicefarm/SimpleCamera.ipa
   HARNESS_IOS_DERIVED_DATA_OUTPUT: apps/simple-camera/ios/build/devicefarm/DerivedData
   HARNESS_IOS_IPA_ARTIFACT_NAME: harness-ios-ipa
+  HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME: harness-xctest-agent-ipa
+  HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH: apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentUITests.ipa
   HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT: devicefarm-test-package.zip
   HARNESS_ANDROID_BUNDLE_ID: com.margelo.nitro.camera.example.simple
   HARNESS_ANDROID_DEVICE_ARCH: ${{ github.event.inputs.device_arch || 'arm64-v8a' }}
@@ -405,6 +407,51 @@ jobs:
             zip -qry "$GITHUB_WORKSPACE/$IPA_PATH" Payload
           )
 
+      - name: Build Harness XCTest UI runner IPA
+        run: |
+          set -euo pipefail
+
+          PLATFORM_PACKAGE_JSON="$(node -p "require.resolve('@react-native-harness/platform-apple/package.json')")"
+          PLATFORM_APPLE_ROOT="$(dirname "$PLATFORM_PACKAGE_JSON")"
+
+          DERIVED_DATA="apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentDerivedData"
+          IPA_PATH="apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentUITests.ipa"
+          PROJECT_PATH="$PLATFORM_APPLE_ROOT/xctest-agent/HarnessXCTestAgent.xcodeproj"
+
+          PAYLOAD_ROOT="$(mktemp -d)"
+          PAYLOAD_DIR="$PAYLOAD_ROOT/Payload"
+
+          rm -rf "$DERIVED_DATA" "$IPA_PATH"
+          mkdir -p "$DERIVED_DATA" "$(dirname "$IPA_PATH")" "$PAYLOAD_DIR"
+
+          xcodebuild \
+            -project "$PROJECT_PATH" \
+            -scheme HarnessXCTestAgent \
+            -configuration Debug \
+            -sdk iphoneos \
+            -destination generic/platform=iOS \
+            -derivedDataPath "$DERIVED_DATA" \
+            -showBuildTimingSummary \
+            build-for-testing \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY= \
+            DEVELOPMENT_TEAM= \
+            COMPILER_INDEX_STORE_ENABLE=NO | xcbeautify --renderer github-actions
+
+          RUNNER_APP="$(find "$DERIVED_DATA/Build/Products/Debug-iphoneos" -maxdepth 1 -type d -name '*UITests-Runner.app' -print -quit)"
+          test -n "$RUNNER_APP"
+          test -d "$RUNNER_APP"
+
+          cp -R "$RUNNER_APP" "$PAYLOAD_DIR/"
+
+          (
+            cd "$PAYLOAD_ROOT"
+            zip -qry "$GITHUB_WORKSPACE/$IPA_PATH" Payload
+          )
+
+          test -f "$IPA_PATH"
+
       - name: Save DerivedData cache
         if: steps.cache-deriveddata-restore.outputs.cache-hit != 'true' && success()
         uses: actions/cache/save@v4
@@ -420,6 +467,14 @@ jobs:
         with:
           name: ${{ env.HARNESS_IOS_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload Harness XCTest UI runner IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}
           if-no-files-found: error
           retention-days: 7
 
@@ -463,6 +518,17 @@ jobs:
           content-type: application/octet-stream
           upload-name: simple-camera-${{ github.run_id }}-${{ github.run_attempt }}.ipa
 
+      - name: Upload Harness XCTest UI runner IPA to AWS Device Farm
+        id: upload-xctest-runner
+        uses: ./.github/actions/upload-devicefarm-artifact
+        with:
+          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          file-path: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}
+          upload-type: IOS_APP
+          content-type: application/octet-stream
+          upload-name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}.ipa
+
       - name: Schedule Device Farm iOS Automated Test
         id: run-test
         uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
@@ -473,6 +539,11 @@ jobs:
               "projectArn": "${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}",
               "appArn": "${{ steps.upload-ipa.outputs['upload-arn'] }}",
               "devicePoolArn": "${{ env.HARNESS_DEVICE_FARM_IOS_DEVICE_POOL_ARN }}",
+              "configuration": {
+                "auxiliaryApps": [
+                  "${{ steps.upload-xctest-runner.outputs['upload-arn'] }}"
+                ]
+              },
               "test": {
                 "type": "APPIUM_NODE",
                 "testPackageArn": "${{ needs.prepare-devicefarm-assets.outputs.test_package_arn }}",

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -58,16 +58,17 @@ env:
   HARNESS_AWS_REGION: us-west-2
   HARNESS_DEVICE_FARM_PROJECT_ARN: arn:aws:devicefarm:us-west-2:633665345122:project:210b1942-012b-4653-9673-f3ff91c5e649
   HARNESS_XCODE_VERSION: "26.2"
+  HARNESS_PROJECT_ROOT: apps/simple-camera
   HARNESS_ANDROID_APP_BUILD_OUTPUT: apps/simple-camera/android/app/build/outputs/apk/debug/app-debug.apk
   HARNESS_IOS_APP_BUILD_OUTPUT: apps/simple-camera/ios/build/devicefarm/SimpleCamera.ipa
   HARNESS_IOS_DERIVED_DATA_OUTPUT: apps/simple-camera/ios/build/devicefarm/DerivedData
+  HARNESS_IOS_IPA_ARTIFACT_NAME: harness-ios-ipa
   HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT: devicefarm-test-package.zip
   HARNESS_ANDROID_BUNDLE_ID: com.margelo.nitro.camera.example.simple
   HARNESS_ANDROID_DEVICE_ARCH: ${{ github.event.inputs.device_arch || 'arm64-v8a' }}
-  # Name of the device pool on AWS to pick Android devices from.
-  # (iOS pool config lives alongside the `test-ios` job and will be restored
-  # when iOS Device Farm testing is re-enabled — see `build-ios`.)
+  # Name of the device pools on AWS to pick devices from.
   HARNESS_DEVICE_FARM_ANDROID_DEVICE_POOL_ARN: LatestFlagshipsDynamic
+  HARNESS_DEVICE_FARM_IOS_DEVICE_POOL_ARN: iPhonePool
 
 jobs:
   detect-changes:
@@ -127,12 +128,11 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - detect-changes
-    # iOS Device Farm testing is temporarily disabled (see `test-ios`/`build-ios` jobs),
-    # so this only needs to run when Android testing is scheduled.
-    if: ${{ needs.detect-changes.outputs.run_android == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_android == 'true' || needs.detect-changes.outputs.run_ios == 'true' }}
     outputs:
       test_package_arn: ${{ steps.upload-test-package.outputs.upload-arn }}
       android_test_spec_arn: ${{ steps.upload-android-test-spec.outputs.upload-arn }}
+      ios_test_spec_arn: ${{ steps.upload-ios-test-spec.outputs.upload-arn }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -174,6 +174,18 @@ jobs:
           upload-type: APPIUM_NODE_TEST_SPEC
           content-type: application/octet-stream
           upload-name: AwsTestSpecAndroid-${{ github.run_id }}-${{ github.run_attempt }}.yml
+
+      - name: Upload Device Farm iOS test spec
+        if: ${{ needs.detect-changes.outputs.run_ios == 'true' }}
+        id: upload-ios-test-spec
+        uses: ./.github/actions/upload-devicefarm-artifact
+        with:
+          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          file-path: apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+          upload-type: APPIUM_NODE_TEST_SPEC
+          content-type: application/octet-stream
+          upload-name: AwsTestSpecIOS-${{ github.run_id }}-${{ github.run_attempt }}.yml
 
   test-android:
     name: Test Android

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -411,33 +411,19 @@ jobs:
         run: |
           set -euo pipefail
 
-          PLATFORM_PACKAGE_JSON="$(node -p "require.resolve('@react-native-harness/platform-apple/package.json')")"
-          PLATFORM_APPLE_ROOT="$(dirname "$PLATFORM_PACKAGE_JSON")"
-
-          DERIVED_DATA="apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentDerivedData"
+          PROJECT_ROOT="apps/simple-camera"
+          DERIVED_DATA="$PROJECT_ROOT/.harness/xctest-agent/device"
           IPA_PATH="apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentUITests.ipa"
-          PROJECT_PATH="$PLATFORM_APPLE_ROOT/xctest-agent/HarnessXCTestAgent.xcodeproj"
-
           PAYLOAD_ROOT="$(mktemp -d)"
           PAYLOAD_DIR="$PAYLOAD_ROOT/Payload"
 
           rm -rf "$DERIVED_DATA" "$IPA_PATH"
-          mkdir -p "$DERIVED_DATA" "$(dirname "$IPA_PATH")" "$PAYLOAD_DIR"
+          mkdir -p "$(dirname "$IPA_PATH")" "$PAYLOAD_DIR"
 
-          xcodebuild \
-            -project "$PROJECT_PATH" \
-            -scheme HarnessXCTestAgent \
-            -configuration Debug \
-            -sdk iphoneos \
-            -destination generic/platform=iOS \
-            -derivedDataPath "$DERIVED_DATA" \
-            -showBuildTimingSummary \
-            build-for-testing \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY= \
-            DEVELOPMENT_TEAM= \
-            COMPILER_INDEX_STORE_ENABLE=NO | xcbeautify --renderer github-actions
+          (
+            cd "$PROJECT_ROOT"
+            node ../../node_modules/react-native-harness/bin.js xctest build --destination device
+          )
 
           RUNNER_APP="$(find "$DERIVED_DATA/Build/Products/Debug-iphoneos" -maxdepth 1 -type d -name '*UITests-Runner.app' -print -quit)"
           test -n "$RUNNER_APP"

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -62,12 +62,13 @@ env:
   HARNESS_ANDROID_APP_BUILD_OUTPUT: apps/simple-camera/android/app/build/outputs/apk/debug/app-debug.apk
   HARNESS_IOS_APP_BUILD_OUTPUT: apps/simple-camera/ios/build/devicefarm/SimpleCamera.ipa
   HARNESS_IOS_DERIVED_DATA_OUTPUT: apps/simple-camera/ios/build/devicefarm/DerivedData
+  HARNESS_ANDROID_APK_ARTIFACT_NAME: harness-android-apk
   HARNESS_IOS_IPA_ARTIFACT_NAME: harness-ios-ipa
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME: harness-xctest-agent-ipa
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH: apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentUITests.ipa
   HARNESS_IOS_XCTEST_UI_TEST_PACKAGE_OUTPUT: apps/simple-camera/ios/build/devicefarm/HarnessXCTestUITestPackage.zip
   HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME: react-native-vision-camera.zip
-  HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT: devicefarm-test-package.zip
+  HARNESS_ANDROID_DEVICE_FARM_TEST_PACKAGE_OUTPUT: apps/simple-camera/android/build/devicefarm/AndroidTestPackage.zip
   HARNESS_ANDROID_BUNDLE_ID: com.margelo.nitro.camera.example.simple
   HARNESS_ANDROID_DEVICE_ARCH: ${{ github.event.inputs.device_arch || 'arm64-v8a' }}
   # Name of the device pools on AWS to pick devices from.
@@ -127,77 +128,12 @@ jobs:
           echo "run_android=${{ steps.filter.outputs.android == 'true' || steps.filter.outputs.shared == 'true' }}" >> "$GITHUB_OUTPUT"
           echo "run_ios=${{ steps.filter.outputs.ios == 'true' || steps.filter.outputs.shared == 'true' }}" >> "$GITHUB_OUTPUT"
 
-  prepare-devicefarm-assets:
-    name: Prepare Device Farm Assets
-    runs-on: ubuntu-latest
-    needs:
-      - detect-changes
-    if: ${{ needs.detect-changes.outputs.run_android == 'true' || needs.detect-changes.outputs.run_ios == 'true' }}
-    outputs:
-      test_package_arn: ${{ steps.upload-test-package.outputs.upload-arn }}
-      android_test_spec_arn: ${{ steps.upload-android-test-spec.outputs.upload-arn }}
-      ios_test_spec_arn: ${{ steps.upload-ios-test-spec.outputs.upload-arn }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::633665345122:role/GitHubDeviceFarmRole
-          aws-region: ${{ env.HARNESS_AWS_REGION }}
-
-      - name: Create Device Farm test package zip
-        run: |
-          rm -f "${{ env.HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT }}"
-          git archive \
-            --format=zip \
-            --output "${{ env.HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT }}" \
-            HEAD
-          unzip -tq "${{ env.HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT }}"
-
-      - name: Upload Device Farm test package
-        id: upload-test-package
-        uses: ./.github/actions/upload-devicefarm-artifact
-        with:
-          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
-          aws-region: ${{ env.HARNESS_AWS_REGION }}
-          file-path: ${{ env.HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT }}
-          upload-type: APPIUM_NODE_TEST_PACKAGE
-          content-type: application/zip
-          upload-name: DeviceFarmTestPackage-${{ github.run_id }}-${{ github.run_attempt }}.zip
-
-      - name: Upload Device Farm Android test spec
-        id: upload-android-test-spec
-        uses: ./.github/actions/upload-devicefarm-artifact
-        with:
-          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
-          aws-region: ${{ env.HARNESS_AWS_REGION }}
-          file-path: apps/simple-camera/device-farm-tests/AwsTestSpec.yml
-          upload-type: APPIUM_NODE_TEST_SPEC
-          content-type: application/octet-stream
-          upload-name: AwsTestSpecAndroid-${{ github.run_id }}-${{ github.run_attempt }}.yml
-
-      - name: Upload Device Farm iOS test spec
-        if: ${{ needs.detect-changes.outputs.run_ios == 'true' }}
-        id: upload-ios-test-spec
-        uses: ./.github/actions/upload-devicefarm-artifact
-        with:
-          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
-          aws-region: ${{ env.HARNESS_AWS_REGION }}
-          file-path: apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
-          upload-type: XCTEST_UI_TEST_SPEC
-          content-type: application/octet-stream
-          upload-name: AwsTestSpecIOS-${{ github.run_id }}-${{ github.run_attempt }}.yml
-
-  test-android:
-    name: Test Android
+  build-android:
+    name: Build Android
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs:
       - detect-changes
-      - prepare-devicefarm-assets
     if: ${{ needs.detect-changes.outputs.run_android == 'true' }}
     steps:
       - uses: actions/checkout@v6
@@ -233,12 +169,6 @@ jobs:
             ${{ runner.os }}-gradle-${{ env.HARNESS_ANDROID_DEVICE_ARCH }}-
             ${{ runner.os }}-gradle-
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::633665345122:role/GitHubDeviceFarmRole
-          aws-region: ${{ env.HARNESS_AWS_REGION }}
-
       - name: Restore Android app from cache
         id: cache-apk-restore
         uses: actions/cache/restore@v4
@@ -260,6 +190,84 @@ jobs:
 
       - name: Verify Android app artifact
         run: test -f ${{ env.HARNESS_ANDROID_APP_BUILD_OUTPUT }}
+
+      - name: Upload Android app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.HARNESS_ANDROID_APK_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_ANDROID_APP_BUILD_OUTPUT }}
+          if-no-files-found: error
+          retention-days: 7
+
+  test-android:
+    name: Test Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs:
+      - detect-changes
+      - build-android
+    if: ${{ needs.detect-changes.outputs.run_android == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Download Android app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.HARNESS_ANDROID_APK_ARTIFACT_NAME }}
+          path: apps/simple-camera/android/app/build/outputs/apk/debug
+
+      - name: Verify Android app artifact
+        run: test -f ${{ env.HARNESS_ANDROID_APP_BUILD_OUTPUT }}
+
+      - name: Create Android Device Farm test package
+        run: |
+          set -euo pipefail
+
+          PACKAGE_PATH="${{ env.HARNESS_ANDROID_DEVICE_FARM_TEST_PACKAGE_OUTPUT }}"
+          PACKAGE_DIR="$(dirname "$PACKAGE_PATH")"
+
+          rm -f "$PACKAGE_PATH"
+          mkdir -p "$PACKAGE_DIR"
+
+          git archive \
+            --format=zip \
+            --output "$PACKAGE_PATH" \
+            HEAD
+
+          unzip -tq "$PACKAGE_PATH"
+
+      - name: Verify Android Device Farm test package
+        run: test -f ${{ env.HARNESS_ANDROID_DEVICE_FARM_TEST_PACKAGE_OUTPUT }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::633665345122:role/GitHubDeviceFarmRole
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+
+      - name: Upload Android test package to AWS Device Farm
+        id: upload-android-test-package
+        uses: ./.github/actions/upload-devicefarm-artifact
+        with:
+          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          file-path: ${{ env.HARNESS_ANDROID_DEVICE_FARM_TEST_PACKAGE_OUTPUT }}
+          upload-type: APPIUM_NODE_TEST_PACKAGE
+          content-type: application/zip
+          upload-name: AndroidTestPackage-${{ github.run_id }}-${{ github.run_attempt }}.zip
+
+      - name: Upload Android test spec to AWS Device Farm
+        id: upload-android-test-spec
+        uses: ./.github/actions/upload-devicefarm-artifact
+        with:
+          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          file-path: apps/simple-camera/device-farm-tests/AwsTestSpec.yml
+          upload-type: APPIUM_NODE_TEST_SPEC
+          content-type: application/octet-stream
+          upload-name: AwsTestSpecAndroid-${{ github.run_id }}-${{ github.run_attempt }}.yml
 
       - name: Upload APK to AWS Device Farm
         id: upload-apk
@@ -283,8 +291,8 @@ jobs:
               "devicePoolArn": "${{ env.HARNESS_DEVICE_FARM_ANDROID_DEVICE_POOL_ARN }}",
               "test": {
                 "type": "APPIUM_NODE",
-                "testPackageArn": "${{ needs.prepare-devicefarm-assets.outputs.test_package_arn }}",
-                "testSpecArn": "${{ needs.prepare-devicefarm-assets.outputs.android_test_spec_arn }}"
+                "testPackageArn": "${{ steps.upload-android-test-package.outputs['upload-arn'] }}",
+                "testSpecArn": "${{ steps.upload-android-test-spec.outputs['upload-arn'] }}"
               }
             }
           artifact-types: ALL
@@ -476,7 +484,6 @@ jobs:
     timeout-minutes: 45
     needs:
       - detect-changes
-      - prepare-devicefarm-assets
       - build-ios
     if: ${{ needs.detect-changes.outputs.run_ios == 'true' }}
     steps:
@@ -562,9 +569,21 @@ jobs:
           content-type: application/zip
           upload-name: harness-xctest-ui-package-${{ github.run_id }}-${{ github.run_attempt }}.zip
 
+      - name: Upload iOS test spec to AWS Device Farm
+        id: upload-ios-test-spec
+        uses: ./.github/actions/upload-devicefarm-artifact
+        with:
+          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          file-path: apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+          upload-type: XCTEST_UI_TEST_SPEC
+          content-type: application/octet-stream
+          upload-name: AwsTestSpecIOS-${{ github.run_id }}-${{ github.run_attempt }}.yml
+
       - name: Schedule Device Farm iOS Automated Test
         id: run-test
         uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
+        continue-on-error: true
         with:
           run-settings-json: |
             {
@@ -575,7 +594,7 @@ jobs:
               "test": {
                 "type": "XCTEST_UI",
                 "testPackageArn": "${{ steps.upload-xctest-ui-package.outputs['upload-arn'] }}",
-                "testSpecArn": "${{ needs.prepare-devicefarm-assets.outputs.ios_test_spec_arn }}"
+                "testSpecArn": "${{ steps.upload-ios-test-spec.outputs['upload-arn'] }}"
               }
             }
           artifact-types: ALL
@@ -586,3 +605,4 @@ jobs:
         with:
           artifact-folder: ${{ steps.run-test.outputs.artifact-folder }}
           platform: ios
+          test-step-outcome: ${{ steps.run-test.outcome }}

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -402,3 +402,76 @@ jobs:
 
       - name: Verify iOS app artifact
         run: test -f ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
+
+      - name: Upload iOS app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.HARNESS_IOS_IPA_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
+          if-no-files-found: error
+          retention-days: 7
+
+  test-ios:
+    name: Test iOS
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs:
+      - detect-changes
+      - prepare-devicefarm-assets
+      - build-ios
+    if: ${{ needs.detect-changes.outputs.run_ios == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Download iOS app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.HARNESS_IOS_IPA_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm
+
+      - name: Verify iOS app artifact
+        run: test -f ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::633665345122:role/GitHubDeviceFarmRole
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+
+      - name: Upload IPA to AWS Device Farm
+        id: upload-ipa
+        uses: ./.github/actions/upload-devicefarm-artifact
+        with:
+          project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          file-path: ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
+          upload-type: IOS_APP
+          content-type: application/octet-stream
+          upload-name: simple-camera-${{ github.run_id }}-${{ github.run_attempt }}.ipa
+
+      - name: Schedule Device Farm iOS Automated Test
+        id: run-test
+        uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
+        with:
+          run-settings-json: |
+            {
+              "name": "GitHubAction-${{ github.workflow }}-ios_${{ github.run_id }}_${{ github.run_attempt }}",
+              "projectArn": "${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}",
+              "appArn": "${{ steps.upload-ipa.outputs['upload-arn'] }}",
+              "devicePoolArn": "${{ env.HARNESS_DEVICE_FARM_IOS_DEVICE_POOL_ARN }}",
+              "test": {
+                "type": "APPIUM_NODE",
+                "testPackageArn": "${{ needs.prepare-devicefarm-assets.outputs.test_package_arn }}",
+                "testSpecArn": "${{ needs.prepare-devicefarm-assets.outputs.ios_test_spec_arn }}"
+              }
+            }
+          artifact-types: ALL
+
+      - name: Collect iOS Device Farm results
+        if: always()
+        uses: ./.github/actions/collect-devicefarm-results
+        with:
+          artifact-folder: ${{ steps.run-test.outputs.artifact-folder }}
+          platform: ios

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -498,8 +498,17 @@ jobs:
           name: ${{ env.HARNESS_IOS_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm
 
+      - name: Download Harness XCTest UI runner IPA artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm
+
       - name: Verify iOS app artifact
         run: test -f ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
+
+      - name: Verify Harness XCTest UI runner IPA artifact
+        run: test -f ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -65,6 +65,8 @@ env:
   HARNESS_IOS_IPA_ARTIFACT_NAME: harness-ios-ipa
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME: harness-xctest-agent-ipa
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH: apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentUITests.ipa
+  HARNESS_IOS_XCTEST_UI_TEST_PACKAGE_OUTPUT: apps/simple-camera/ios/build/devicefarm/HarnessXCTestUITestPackage.zip
+  HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME: react-native-vision-camera.zip
   HARNESS_DEVICE_FARM_TEST_PACKAGE_OUTPUT: devicefarm-test-package.zip
   HARNESS_ANDROID_BUNDLE_ID: com.margelo.nitro.camera.example.simple
   HARNESS_ANDROID_DEVICE_ARCH: ${{ github.event.inputs.device_arch || 'arm64-v8a' }}
@@ -185,7 +187,7 @@ jobs:
           project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
           aws-region: ${{ env.HARNESS_AWS_REGION }}
           file-path: apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
-          upload-type: APPIUM_NODE_TEST_SPEC
+          upload-type: XCTEST_UI_TEST_SPEC
           content-type: application/octet-stream
           upload-name: AwsTestSpecIOS-${{ github.run_id }}-${{ github.run_attempt }}.yml
 
@@ -295,16 +297,6 @@ jobs:
           platform: android
           test-step-outcome: ${{ steps.run-test.outcome }}
 
-  # iOS testing on AWS Device Farm is temporarily disabled.
-  # Device Farm has no UI operator to tap through runtime permission dialogs
-  # (Camera, Microphone, Location, etc.), so the app hangs on first launch.
-  # Unlike Android, there is no equivalent to `adb shell pm grant` for iOS, so
-  # we depend on an upcoming React Native Harness feature to pre-grant iOS
-  # permissions. Until that ships, we still build the iOS app here as a
-  # compile-only smoke test (and to keep the DerivedData/Pods caches warm), but
-  # we do NOT schedule any Device Farm run.
-  # TODO: Re-enable iOS Device Farm testing once Harness ships iOS permission
-  # pre-granting.
   build-ios:
     name: Build iOS
     runs-on: macos-latest
@@ -510,6 +502,38 @@ jobs:
       - name: Verify Harness XCTest UI runner IPA artifact
         run: test -f ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}
 
+      - name: Create XCTest UI test package
+        run: |
+          set -euo pipefail
+
+          PACKAGE_PATH="${{ env.HARNESS_IOS_XCTEST_UI_TEST_PACKAGE_OUTPUT }}"
+          PACKAGE_ROOT="$(mktemp -d)"
+          REPO_ARCHIVE="$PACKAGE_ROOT/${{ env.HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME }}"
+          RUNNER_IPA="$PACKAGE_ROOT/$(basename "${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}")"
+
+          rm -f "$PACKAGE_PATH"
+          mkdir -p "$(dirname "$PACKAGE_PATH")"
+
+          git archive \
+            --format=zip \
+            --output "$REPO_ARCHIVE" \
+            HEAD
+
+          cp "${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}" "$RUNNER_IPA"
+
+          (
+            cd "$PACKAGE_ROOT"
+            zip -qry "$GITHUB_WORKSPACE/$PACKAGE_PATH" \
+              "$(basename "$RUNNER_IPA")" \
+              "${{ env.HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME }}"
+          )
+
+          unzip -tq "$PACKAGE_PATH"
+          unzip -l "$PACKAGE_PATH"
+
+      - name: Verify XCTest UI test package
+        run: test -f ${{ env.HARNESS_IOS_XCTEST_UI_TEST_PACKAGE_OUTPUT }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -527,16 +551,16 @@ jobs:
           content-type: application/octet-stream
           upload-name: simple-camera-${{ github.run_id }}-${{ github.run_attempt }}.ipa
 
-      - name: Upload Harness XCTest UI runner IPA to AWS Device Farm
-        id: upload-xctest-runner
+      - name: Upload XCTest UI test package to AWS Device Farm
+        id: upload-xctest-ui-package
         uses: ./.github/actions/upload-devicefarm-artifact
         with:
           project-arn: ${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}
           aws-region: ${{ env.HARNESS_AWS_REGION }}
-          file-path: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}
-          upload-type: IOS_APP
-          content-type: application/octet-stream
-          upload-name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}-${{ github.run_id }}-${{ github.run_attempt }}.ipa
+          file-path: ${{ env.HARNESS_IOS_XCTEST_UI_TEST_PACKAGE_OUTPUT }}
+          upload-type: XCTEST_UI_TEST_PACKAGE
+          content-type: application/zip
+          upload-name: harness-xctest-ui-package-${{ github.run_id }}-${{ github.run_attempt }}.zip
 
       - name: Schedule Device Farm iOS Automated Test
         id: run-test
@@ -548,14 +572,9 @@ jobs:
               "projectArn": "${{ env.HARNESS_DEVICE_FARM_PROJECT_ARN }}",
               "appArn": "${{ steps.upload-ipa.outputs['upload-arn'] }}",
               "devicePoolArn": "${{ env.HARNESS_DEVICE_FARM_IOS_DEVICE_POOL_ARN }}",
-              "configuration": {
-                "auxiliaryApps": [
-                  "${{ steps.upload-xctest-runner.outputs['upload-arn'] }}"
-                ]
-              },
               "test": {
-                "type": "APPIUM_NODE",
-                "testPackageArn": "${{ needs.prepare-devicefarm-assets.outputs.test_package_arn }}",
+                "type": "XCTEST_UI",
+                "testPackageArn": "${{ steps.upload-xctest-ui-package.outputs['upload-arn'] }}",
                 "testSpecArn": "${{ needs.prepare-devicefarm-assets.outputs.ios_test_spec_arn }}"
               }
             }

--- a/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
@@ -22,6 +22,7 @@ describe('VisionCamera - Constraints', () => {
   let backDevice: CameraDevice
 
   beforeAll(async () => {
+    await VisionCamera.requestCameraPermission();
     expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
     factory = await VisionCamera.createDeviceFactory()
     const back = factory.getDefaultCamera('back')

--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -10,6 +10,7 @@ describe('VisionCamera - Controller', () => {
   let backDevice: CameraDevice
 
   beforeAll(async () => {
+    await VisionCamera.requestCameraPermission();
     expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
     factory = await VisionCamera.createDeviceFactory()
     const back = factory.getDefaultCamera('back')

--- a/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
@@ -19,6 +19,7 @@ describe('VisionCamera - Frame', () => {
   let backDevice: CameraDevice
 
   beforeAll(async () => {
+    await VisionCamera.requestCameraPermission();
     expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
     factory = await VisionCamera.createDeviceFactory()
     const back = factory.getDefaultCamera('back')

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -21,6 +21,7 @@ describe('VisionCamera - Photo', () => {
   let backDevice: CameraDevice
 
   beforeAll(async () => {
+    await VisionCamera.requestCameraPermission();
     expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
     factory = await VisionCamera.createDeviceFactory()
     const back = factory.getDefaultCamera('back')

--- a/apps/simple-camera/__tests__/visioncamera.session.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.session.harness.ts
@@ -12,6 +12,7 @@ describe('VisionCamera - Session', () => {
   let factory: CameraDeviceFactory
 
   beforeAll(async () => {
+    await VisionCamera.requestCameraPermission();
     expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
     factory = await VisionCamera.createDeviceFactory()
   })

--- a/apps/simple-camera/__tests__/visioncamera.video.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.video.harness.ts
@@ -21,6 +21,8 @@ describe('VisionCamera - Video', () => {
   let backDevice: CameraDevice
 
   beforeAll(async () => {
+    await VisionCamera.requestCameraPermission();
+    await VisionCamera.requestMicrophonePermission();
     expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
     expect(VisionCamera.microphonePermissionStatus).toBe('authorized')
     factory = await VisionCamera.createDeviceFactory()

--- a/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
@@ -14,23 +14,6 @@ phases:
       - adb wait-for-device
       - adb devices -l
 
-      # Grant all runtime permissions we need up-front. AWS Device Farm has no UI
-      # operator to tap through permission dialogs, so any runtime permission
-      # request would hang the test. The APK is already installed by Device Farm
-      # before the test spec runs, so `pm grant` targets the installed package.
-      - |
-        APP_PACKAGE="com.margelo.nitro.camera.example.simple"
-        for PERMISSION in \
-          android.permission.CAMERA \
-          android.permission.RECORD_AUDIO \
-          android.permission.ACCESS_FINE_LOCATION \
-          android.permission.ACCESS_COARSE_LOCATION \
-          android.permission.READ_EXTERNAL_STORAGE \
-          android.permission.WRITE_EXTERNAL_STORAGE; do
-          echo "Granting ${PERMISSION} to ${APP_PACKAGE}"
-          adb shell pm grant "${APP_PACKAGE}" "${PERMISSION}" || echo "Failed to grant ${PERMISSION} (may not be applicable on this API level)"
-        done
-
   test:
     commands:
       - MANUFACTURER="$(adb shell getprop ro.product.manufacturer | tr -d '\r')"

--- a/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
@@ -22,7 +22,7 @@ phases:
       - HARNESS_JUNIT="$WORKING_DIRECTORY/harness-results.junit.xml"
       - HARNESS_LOG="$WORKING_DIRECTORY/harness-output.log"
       - cd apps/simple-camera
-      - set -o pipefail; HARNESS_ANDROID_DEVICE_MANUFACTURER="$MANUFACTURER" HARNESS_ANDROID_DEVICE_MODEL="$MODEL" CI=true JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" ~/.bun/bin/bun run test:harness:android -- --reporters=default --reporters=jest-junit --verbose 2>&1 | tee "$HARNESS_LOG"
+      - set -o pipefail; HARNESS_ANDROID_DEVICE_MANUFACTURER="$MANUFACTURER" HARNESS_ANDROID_DEVICE_MODEL="$MODEL" CI=true FORCE_COLOR=1 JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" ~/.bun/bin/bun run test:harness:android -- --reporters=default --reporters=jest-junit --verbose 2>&1 | tee "$HARNESS_LOG"
 
 artifacts:
   - $WORKING_DIRECTORY

--- a/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
@@ -22,7 +22,7 @@ phases:
       - HARNESS_JUNIT="$WORKING_DIRECTORY/harness-results.junit.xml"
       - HARNESS_LOG="$WORKING_DIRECTORY/harness-output.log"
       - cd apps/simple-camera
-      - set -o pipefail; HARNESS_ANDROID_DEVICE_MANUFACTURER="$MANUFACTURER" HARNESS_ANDROID_DEVICE_MODEL="$MODEL" CI=true JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" ~/.bun/bin/bun run test:harness:android -- --reporters=default --reporters=jest-junit 2>&1 | tee "$HARNESS_LOG"
+      - set -o pipefail; HARNESS_ANDROID_DEVICE_MANUFACTURER="$MANUFACTURER" HARNESS_ANDROID_DEVICE_MODEL="$MODEL" CI=true JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" ~/.bun/bin/bun run test:harness:android -- --reporters=default --reporters=jest-junit --verbose 2>&1 | tee "$HARNESS_LOG"
 
 artifacts:
   - $WORKING_DIRECTORY

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -70,6 +70,7 @@ phases:
           HARNESS_IOS_DEVICE_ID="$DEVICEFARM_DEVICE_UDID" \
           HARNESS_DETECT_NATIVE_CRASHES=false \
           CI=true \
+          FORCE_COLOR=1 \
           JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" \
           ~/.bun/bin/bun run test:harness -- \
             --harnessRunner ios \

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -7,38 +7,115 @@ phases:
     commands:
       - devicefarm-cli use node 20
       - node -v
+      - xcodebuild -version
       - curl -fsSL https://bun.com/install | bash
-      - ~/.bun/bin/bun install
       - xcrun devicectl list devices
+
+      # The XCTEST_UI package contains the Harness XCTest runner IPA and a
+      # repo archive. Unpack the repo so the Node/Bun Harness tests can run.
+      - |
+        set -euo pipefail
+
+        REPO_ARCHIVE="$DEVICEFARM_XCTEST_BUILD_DIRECTORY/react-native-vision-camera.zip"
+        HARNESS_REPO_ROOT="$WORKING_DIRECTORY/react-native-vision-camera"
+
+        test -f "$REPO_ARCHIVE"
+        rm -rf "$HARNESS_REPO_ROOT"
+        mkdir -p "$HARNESS_REPO_ROOT"
+        unzip -q "$REPO_ARCHIVE" -d "$HARNESS_REPO_ROOT"
+
+        cd "$HARNESS_REPO_ROOT"
+        ~/.bun/bin/bun install --frozen-lockfile
 
   test:
     commands:
       - HARNESS_JUNIT="$WORKING_DIRECTORY/harness-results.junit.xml"
       - HARNESS_LOG="$WORKING_DIRECTORY/harness-output.log"
 
-      # Resolve host IPv6 for Metro. On macOS runners ipv4 won't work, as confirmed by AWS support.
-      # AWS specifically recommends using the utun interfaces for this, which is what we do here. 
-      # If we fail to resolve an IP address, we error out, as without this the tests won't be able to connect to Metro at all.
+      # Resolve host IPv6 for Metro. On macOS runners IPv4 won't work, as
+      # confirmed by AWS support. AWS recommends utun interfaces for this.
       - |
+        set -euo pipefail
+
         METRO_HOST_IP="$(ifconfig utun1 2>/dev/null | awk '/inet6 / {ip=$2} END {print ip}')"
         if [ -z "$METRO_HOST_IP" ]; then
           METRO_HOST_IP="$(ifconfig utun0 2>/dev/null | awk '/inet6 / {ip=$2} END {print ip}')"
         fi
+
         METRO_HOST_IP="${METRO_HOST_IP%%%*}"
-        [ -n "$METRO_HOST_IP" ] || { echo "Failed to resolve Metro host IPv6." >&2; exit 1; }
+        if [ -z "$METRO_HOST_IP" ]; then
+          echo "Failed to resolve Metro host IPv6." >&2
+          exit 1
+        fi
+
         echo "Using Metro host IPv6 for iOS harness: ${METRO_HOST_IP}"
         echo "$METRO_HOST_IP" > "$WORKING_DIRECTORY/metro-host-ip.txt"
 
-      # Find the physical device connected to this runner we want to run the test on:
-      - IOS_DEVICE_UDID="${DEVICEFARM_DEVICE_UDID:-${DEVICEFARM_DEVICE_NAME:-}}"
-      - IOS_DEVICES_JSON="$(mktemp)"
-      - xcrun devicectl list devices --json-output "$IOS_DEVICES_JSON"
-      - IOS_DEVICE_NAME="$(node -e "const fs=require('node:fs');const payload=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));const devices=payload?.result?.devices ?? [];const udid=process.env.IOS_DEVICE_UDID || '';const matchedByUdid=devices.find((d)=>d?.identifier===udid);const selected=matchedByUdid ?? devices[0] ?? null;const name=selected?.deviceProperties?.name ?? '';if(!name){process.exit(1)};process.stdout.write(name);" "$IOS_DEVICES_JSON")"
-      - 'echo "Resolved Device Farm iOS device for harness: ${IOS_DEVICE_NAME} (${IOS_DEVICE_UDID:-unknown-udid})"'
+      # Find the physical device connected to this runner.
+      - |
+        set -euo pipefail
 
-      # Actually run the test:
-      - cd apps/simple-camera
-      - set -o pipefail; HARNESS_METRO_BIND_HOST="::" HARNESS_IOS_METRO_HOST="$(cat "$WORKING_DIRECTORY/metro-host-ip.txt")" HARNESS_IOS_DEVICE_NAME="$IOS_DEVICE_NAME" HARNESS_DETECT_NATIVE_CRASHES=false CI=true JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" ~/.bun/bin/bun run test:harness -- --harnessRunner ios --reporters=default --reporters=jest-junit 2>&1 | tee "$HARNESS_LOG"
+        IOS_DEVICE_UDID="${DEVICEFARM_DEVICE_UDID:-${DEVICEFARM_DEVICE_NAME:-}}"
+        IOS_DEVICES_JSON="$(mktemp)"
+        xcrun devicectl list devices --json-output "$IOS_DEVICES_JSON"
+
+        IOS_DEVICE_NAME="$(
+          IOS_DEVICE_UDID="$IOS_DEVICE_UDID" node - "$IOS_DEVICES_JSON" <<'NODE'
+        const fs = require('node:fs')
+
+        const jsonPath = process.argv[2]
+        const rawJson = fs.readFileSync(jsonPath, 'utf8')
+        const payload = JSON.parse(rawJson)
+        const devices = payload.result.devices
+        const udid = process.env.IOS_DEVICE_UDID || ''
+
+        let selected = null
+        for (const device of devices) {
+          if (device.identifier === udid) {
+            selected = device
+            break
+          }
+        }
+
+        if (selected == null && devices.length > 0) {
+          selected = devices[0]
+        }
+
+        if (selected == null) {
+          process.exit(1)
+        }
+
+        const name = selected.deviceProperties.name
+        if (!name) {
+          process.exit(1)
+        }
+
+        process.stdout.write(name)
+        NODE
+        )"
+
+        echo "$IOS_DEVICE_NAME" > "$WORKING_DIRECTORY/ios-device-name.txt"
+        echo "Resolved Device Farm iOS device for harness: ${IOS_DEVICE_NAME} (${IOS_DEVICE_UDID:-unknown-udid})"
+
+      # Actually run the JS Harness tests. Harness owns the XCTest agent
+      # lifecycle, but uses AWS's generated .xctestrun instead of building one.
+      - |
+        set -o pipefail
+
+        cd "$WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera"
+
+        HARNESS_IOS_XCTESTRUN_FILE="$DEVICEFARM_XCUITESTRUN_FILE" \
+          HARNESS_IOS_XCTEST_DERIVED_DATA_PATH="$DEVICEFARM_DERIVED_DATA_PATH" \
+          HARNESS_METRO_BIND_HOST="::" \
+          HARNESS_IOS_METRO_HOST="$(cat "$WORKING_DIRECTORY/metro-host-ip.txt")" \
+          HARNESS_IOS_DEVICE_NAME="$(cat "$WORKING_DIRECTORY/ios-device-name.txt")" \
+          HARNESS_DETECT_NATIVE_CRASHES=false \
+          CI=true \
+          JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" \
+          ~/.bun/bin/bun run test:harness -- \
+            --harnessRunner ios \
+            --reporters=default \
+            --reporters=jest-junit 2>&1 | tee "$HARNESS_LOG"
 
 artifacts:
   - $WORKING_DIRECTORY

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -74,7 +74,8 @@ phases:
           ~/.bun/bin/bun run test:harness -- \
             --harnessRunner ios \
             --reporters=default \
-            --reporters=jest-junit 2>&1 | tee "$HARNESS_LOG"
+            --reporters=jest-junit \
+            --verbose 2>&1 | tee "$HARNESS_LOG"
 
 artifacts:
   - $WORKING_DIRECTORY/harness-artifacts

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -51,56 +51,12 @@ phases:
         echo "Using Metro host IPv6 for iOS harness: ${METRO_HOST_IP}"
         echo "$METRO_HOST_IP" > "$WORKING_DIRECTORY/metro-host-ip.txt"
 
-      # Find the physical device connected to this runner.
-      - |
-        set -euo pipefail
-
-        IOS_DEVICE_UDID="${DEVICEFARM_DEVICE_UDID:-${DEVICEFARM_DEVICE_NAME:-}}"
-        IOS_DEVICES_JSON="$(mktemp)"
-        xcrun devicectl list devices --json-output "$IOS_DEVICES_JSON"
-
-        IOS_DEVICE_NAME="$(
-          IOS_DEVICE_UDID="$IOS_DEVICE_UDID" node - "$IOS_DEVICES_JSON" <<'NODE'
-        const fs = require('node:fs')
-
-        const jsonPath = process.argv[2]
-        const rawJson = fs.readFileSync(jsonPath, 'utf8')
-        const payload = JSON.parse(rawJson)
-        const devices = payload.result.devices
-        const udid = process.env.IOS_DEVICE_UDID || ''
-
-        let selected = null
-        for (const device of devices) {
-          if (device.identifier === udid) {
-            selected = device
-            break
-          }
-        }
-
-        if (selected == null && devices.length > 0) {
-          selected = devices[0]
-        }
-
-        if (selected == null) {
-          process.exit(1)
-        }
-
-        const name = selected.deviceProperties.name
-        if (!name) {
-          process.exit(1)
-        }
-
-        process.stdout.write(name)
-        NODE
-        )"
-
-        echo "$IOS_DEVICE_NAME" > "$WORKING_DIRECTORY/ios-device-name.txt"
-        echo "Resolved Device Farm iOS device for harness: ${IOS_DEVICE_NAME} (${IOS_DEVICE_UDID:-unknown-udid})"
-
       # Actually run the JS Harness tests. Harness owns the XCTest agent
       # lifecycle, but uses AWS's generated .xctestrun instead of building one.
       - |
-        set -o pipefail
+        set -euo pipefail
+
+        : "${DEVICEFARM_DEVICE_UDID:?Missing DEVICEFARM_DEVICE_UDID. Device Farm must provide the physical iOS device UDID.}"
 
         cd "$WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera"
 
@@ -108,7 +64,7 @@ phases:
           HARNESS_IOS_XCTEST_DERIVED_DATA_PATH="$DEVICEFARM_DERIVED_DATA_PATH" \
           HARNESS_METRO_BIND_HOST="::" \
           HARNESS_IOS_METRO_HOST="$(cat "$WORKING_DIRECTORY/metro-host-ip.txt")" \
-          HARNESS_IOS_DEVICE_NAME="$(cat "$WORKING_DIRECTORY/ios-device-name.txt")" \
+          HARNESS_IOS_DEVICE_ID="$DEVICEFARM_DEVICE_UDID" \
           HARNESS_DETECT_NATIVE_CRASHES=false \
           CI=true \
           JEST_JUNIT_OUTPUT_FILE="$HARNESS_JUNIT" \

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -29,8 +29,11 @@ phases:
 
   test:
     commands:
-      - HARNESS_JUNIT="$WORKING_DIRECTORY/harness-results.junit.xml"
-      - HARNESS_LOG="$WORKING_DIRECTORY/harness-output.log"
+      - HARNESS_ARTIFACTS="$WORKING_DIRECTORY/harness-artifacts"
+      - HARNESS_JUNIT="$HARNESS_ARTIFACTS/harness-results.junit.xml"
+      - HARNESS_LOG="$HARNESS_ARTIFACTS/harness-output.log"
+      - HARNESS_METRO_HOST_FILE="$HARNESS_ARTIFACTS/metro-host-ip.txt"
+      - mkdir -p "$HARNESS_ARTIFACTS"
 
       # Resolve host IPv6 for Metro. On macOS runners IPv4 won't work, as
       # confirmed by AWS support. AWS recommends utun interfaces for this.
@@ -49,7 +52,7 @@ phases:
         fi
 
         echo "Using Metro host IPv6 for iOS harness: ${METRO_HOST_IP}"
-        echo "$METRO_HOST_IP" > "$WORKING_DIRECTORY/metro-host-ip.txt"
+        echo "$METRO_HOST_IP" > "$HARNESS_METRO_HOST_FILE"
 
       # Actually run the JS Harness tests. Harness owns the XCTest agent
       # lifecycle, but uses AWS's generated .xctestrun instead of building one.
@@ -63,7 +66,7 @@ phases:
         HARNESS_IOS_XCTESTRUN_FILE="$DEVICEFARM_XCUITESTRUN_FILE" \
           HARNESS_IOS_XCTEST_DERIVED_DATA_PATH="$DEVICEFARM_DERIVED_DATA_PATH" \
           HARNESS_METRO_BIND_HOST="::" \
-          HARNESS_IOS_METRO_HOST="$(cat "$WORKING_DIRECTORY/metro-host-ip.txt")" \
+          HARNESS_IOS_METRO_HOST="$(cat "$HARNESS_METRO_HOST_FILE")" \
           HARNESS_IOS_DEVICE_ID="$DEVICEFARM_DEVICE_UDID" \
           HARNESS_DETECT_NATIVE_CRASHES=false \
           CI=true \
@@ -74,4 +77,4 @@ phases:
             --reporters=jest-junit 2>&1 | tee "$HARNESS_LOG"
 
 artifacts:
-  - $WORKING_DIRECTORY
+  - $WORKING_DIRECTORY/harness-artifacts

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -37,9 +37,9 @@ phases:
       - |
         set -euo pipefail
 
-        METRO_HOST_IP="$(ifconfig utun1 2>/dev/null | awk '/inet6 / {ip=$2} END {print ip}')"
+        METRO_HOST_IP="$(ifconfig utun1 2>/dev/null | awk '/inet6 / {ip=$2} END {print ip}' || true)"
         if [ -z "$METRO_HOST_IP" ]; then
-          METRO_HOST_IP="$(ifconfig utun0 2>/dev/null | awk '/inet6 / {ip=$2} END {print ip}')"
+          METRO_HOST_IP="$(ifconfig utun0 2>/dev/null | awk '/inet6 / {ip=$2} END {print ip}' || true)"
         fi
 
         METRO_HOST_IP="${METRO_HOST_IP%%%*}"

--- a/apps/simple-camera/package.json
+++ b/apps/simple-camera/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@react-native-community/blur": "^4.4.1",
-    "@react-native-harness/platform-apple": "^1.1.0-rc.4",
     "@react-native-menu/menu": "^2.0.0",
     "@react-native-vector-icons/ionicons": "12.4.1",
     "@react-navigation/native": "^7.1.31",
@@ -48,12 +47,13 @@
     "@react-native-community/cli": "20.1.2",
     "@react-native-community/cli-platform-android": "20.1.2",
     "@react-native-community/cli-platform-ios": "20.1.2",
-    "@react-native-harness/platform-android": "1.1.0-rc.4",
+    "@react-native-harness/platform-android": "1.2.0-rc.1",
+    "@react-native-harness/platform-apple": "1.2.0-rc.1",
     "@react-native/babel-preset": "0.84.0",
     "@react-native/metro-config": "0.84.0",
     "@react-native/typescript-config": "0.84.0",
     "@types/react": "19.2.14",
-    "react-native-harness": "1.1.0-rc.4",
+    "react-native-harness": "1.2.0-rc.1",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/apps/simple-camera/rn-harness.config.mjs
+++ b/apps/simple-camera/rn-harness.config.mjs
@@ -32,7 +32,8 @@ const iosBundleId =
   process.env.HARNESS_IOS_BUNDLE_ID ?? 'com.margelo.nitro.camera.example.simple'
 const iosSimulatorName = process.env.HARNESS_IOS_SIMULATOR ?? 'iPhone 16 Pro'
 const iosSimulatorVersion = process.env.HARNESS_IOS_SIMULATOR_VERSION ?? '18.5'
-const iosPhysicalDeviceName = process.env.HARNESS_IOS_DEVICE_NAME ?? 'iPhone'
+const iosPhysicalDeviceIdentifier =
+  process.env.HARNESS_IOS_DEVICE_ID?.trim() || 'iPhone'
 const iosMetroHostInput = process.env.HARNESS_IOS_METRO_HOST?.trim() ?? ''
 const iosMetroPort = process.env.HARNESS_IOS_METRO_PORT ?? '8081'
 
@@ -88,11 +89,11 @@ const androidDevice = useEmulator
   : physicalAndroidDevice(androidPhysicalManufacturer, androidPhysicalModel)
 
 const iosDevice = isCI
-  ? applePhysicalDevice(iosPhysicalDeviceName, {
-    codeSign: {
-      teamId: 'LC6XSNN25D'
-    }
-  })
+  ? applePhysicalDevice(iosPhysicalDeviceIdentifier, {
+      codeSign: {
+        teamId: 'TheTeamHereDoesntMatterOnCiButWeHaveToPassItStillIthink',
+      },
+    })
   : appleSimulator(iosSimulatorName, iosSimulatorVersion)
 
 const config = {

--- a/apps/simple-camera/rn-harness.config.mjs
+++ b/apps/simple-camera/rn-harness.config.mjs
@@ -90,7 +90,7 @@ const androidDevice = useEmulator
 const iosDevice = isCI
   ? applePhysicalDevice(iosPhysicalDeviceName, {
     codeSign: {
-      teamId: 'idislikethisrightnow'
+      teamId: 'LC6XSNN25D'
     }
   })
   : appleSimulator(iosSimulatorName, iosSimulatorVersion)

--- a/apps/simple-camera/rn-harness.config.mjs
+++ b/apps/simple-camera/rn-harness.config.mjs
@@ -31,7 +31,7 @@ const androidDeviceMode =
 const iosBundleId =
   process.env.HARNESS_IOS_BUNDLE_ID ?? 'com.margelo.nitro.camera.example.simple'
 const iosSimulatorName = process.env.HARNESS_IOS_SIMULATOR ?? 'iPhone 16 Pro'
-const iosSimulatorVersion = process.env.HARNESS_IOS_SIMULATOR_VERSION ?? '18.0'
+const iosSimulatorVersion = process.env.HARNESS_IOS_SIMULATOR_VERSION ?? '18.5'
 const iosPhysicalDeviceName = process.env.HARNESS_IOS_DEVICE_NAME ?? 'iPhone'
 const iosMetroHostInput = process.env.HARNESS_IOS_METRO_HOST?.trim() ?? ''
 const iosMetroPort = process.env.HARNESS_IOS_METRO_PORT ?? '8081'

--- a/apps/simple-camera/rn-harness.config.mjs
+++ b/apps/simple-camera/rn-harness.config.mjs
@@ -88,7 +88,11 @@ const androidDevice = useEmulator
   : physicalAndroidDevice(androidPhysicalManufacturer, androidPhysicalModel)
 
 const iosDevice = isCI
-  ? applePhysicalDevice(iosPhysicalDeviceName)
+  ? applePhysicalDevice(iosPhysicalDeviceName, {
+    codeSign: {
+      teamId: 'idislikethisrightnow'
+    }
+  })
   : appleSimulator(iosSimulatorName, iosSimulatorVersion)
 
 const config = {
@@ -115,6 +119,7 @@ const config = {
   detectNativeCrashes,
   resetEnvironmentBetweenTestFiles: true,
   forwardClientLogs: true,
+  permissions: true
 }
 
 export default config

--- a/bun.lock
+++ b/bun.lock
@@ -227,6 +227,7 @@
   ],
   "patchedDependencies": {
     "react-native@0.84.0": "patches/react-native@0.84.0.patch",
+    "@react-native-harness/platform-apple@1.2.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/bun.lock
+++ b/bun.lock
@@ -227,6 +227,7 @@
   ],
   "patchedDependencies": {
     "react-native@0.84.0": "patches/react-native@0.84.0.patch",
+    "@react-native-harness/cli@1.2.0-rc.1": "patches/@react-native-harness%2Fcli@1.2.0-rc.1.patch",
     "@react-native-harness/platform-apple@1.2.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch",
   },
   "packages": {

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,6 @@
       "version": "5.0.9",
       "dependencies": {
         "@react-native-community/blur": "^4.4.1",
-        "@react-native-harness/platform-apple": "^1.1.0-rc.4",
         "@react-native-menu/menu": "^2.0.0",
         "@react-native-vector-icons/ionicons": "12.4.1",
         "@react-navigation/native": "^7.1.31",
@@ -55,12 +54,13 @@
         "@react-native-community/cli": "20.1.2",
         "@react-native-community/cli-platform-android": "20.1.2",
         "@react-native-community/cli-platform-ios": "20.1.2",
-        "@react-native-harness/platform-android": "1.1.0-rc.4",
+        "@react-native-harness/platform-android": "1.2.0-rc.1",
+        "@react-native-harness/platform-apple": "1.2.0-rc.1",
         "@react-native/babel-preset": "0.84.0",
         "@react-native/metro-config": "0.84.0",
         "@react-native/typescript-config": "0.84.0",
         "@types/react": "19.2.14",
-        "react-native-harness": "1.1.0-rc.4",
+        "react-native-harness": "1.2.0-rc.1",
         "typescript": "5.9.3",
       },
     },
@@ -917,31 +917,31 @@
 
     "@react-native-community/cli-types": ["@react-native-community/cli-types@20.1.2", "", { "dependencies": { "joi": "^17.2.1" } }, "sha512-WYK98VdcJE+lRuyRzigE/GQAbaJZOKkjpaLwhmMMItXVTqMmIccfGu9b4pRoQOVfs1aLq87DuwUOi9sxz6OG1g=="],
 
-    "@react-native-harness/babel-preset": ["@react-native-harness/babel-preset@1.1.0-rc.4", "", { "dependencies": { "@babel/plugin-transform-class-static-block": "^7.27.1", "babel-plugin-istanbul": "^7.0.1" }, "peerDependencies": { "@babel/core": "^7.22.0", "@babel/plugin-transform-react-jsx": "*" } }, "sha512-+oJC6EZh8wAzk35r+MEKmYuJXM5fLxaO5I0UOtWDdyQXAj+yL5mafAnfX1Bj/TjnnDMn9HprYhNVD9NuVXvKIQ=="],
+    "@react-native-harness/babel-preset": ["@react-native-harness/babel-preset@1.2.0-rc.1", "", { "dependencies": { "@babel/plugin-transform-class-static-block": "^7.27.1", "babel-plugin-istanbul": "^7.0.1" }, "peerDependencies": { "@babel/core": "^7.22.0", "@babel/plugin-transform-react-jsx": "*" } }, "sha512-Ci+l7QU5l6Ra9CBgc2ft+qSVUfoscTIsVMEDMZcFUyRNd3tzs23zRoxhAf+8YaKVLf7wkzRHi6uO0Ax5ufZu/g=="],
 
-    "@react-native-harness/bridge": ["@react-native-harness/bridge@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/platforms": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "birpc": "^2.4.0", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "ssim.js": "^3.5.0", "tslib": "^2.3.0", "ws": "^8.18.2" } }, "sha512-lJg/GbzhLyLc0YXClkc6/wg8JRGNp687UPh2dr2+JAreX78HYGZy5ggfWVVIdGRRL8p9DqD0hknWrNafwp4tog=="],
+    "@react-native-harness/bridge": ["@react-native-harness/bridge@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/platforms": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "birpc": "^2.4.0", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "ssim.js": "^3.5.0", "tslib": "^2.3.0", "ws": "^8.18.2" } }, "sha512-tanlyu9XBqcsSLDMoRBLa/xiuD5FmF3uV8prxesI7VAI9gvM+V7JhzYeH8gOirOFDM/w/35+oJqMIdHNo5gRAQ=="],
 
-    "@react-native-harness/bundler-metro": ["@react-native-harness/bundler-metro@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/babel-preset": "1.1.0-rc.4", "@react-native-harness/config": "1.1.0-rc.4", "@react-native-harness/runtime": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "@react-native/metro-config": "*", "connect": "^3.7.0", "nocache": "^4.0.0", "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*", "metro-cache": "*", "metro-config": "*", "metro-resolver": "*" } }, "sha512-p46NTxdvw7nq+yaDk6T1JExBKlrm3rFQzLI57Gc98CI/hiH8FHBStSezeyY26M+Pnw9tiaWUyBNwfEIMPDICkw=="],
+    "@react-native-harness/bundler-metro": ["@react-native-harness/bundler-metro@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/babel-preset": "1.2.0-rc.1", "@react-native-harness/config": "1.2.0-rc.1", "@react-native-harness/runtime": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "@react-native/metro-config": "*", "connect": "^3.7.0", "nocache": "^4.0.0", "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*", "metro-cache": "*", "metro-config": "*", "metro-resolver": "*" } }, "sha512-b58/UDDaBIzGusHXU/PUX1N4FTtCEAX0ZEp7Jrmh1wwxmyeK41Q9dOwWFgPn9LeIbLuVKDyBrBXtMNH3nvBtJg=="],
 
-    "@react-native-harness/cli": ["@react-native-harness/cli@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/bridge": "1.1.0-rc.4", "@react-native-harness/config": "1.1.0-rc.4", "@react-native-harness/platforms": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "tslib": "^2.3.0" }, "peerDependencies": { "jest-cli": "*" } }, "sha512-DaQWESoVNiyxQbfBU4LudY5E0pZx6Ndw/z/gbqQrp0mCt7US53qsI6KOqm1K2jWgcQmrlgcgEOpS6zVroVMzvw=="],
+    "@react-native-harness/cli": ["@react-native-harness/cli@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/bridge": "1.2.0-rc.1", "@react-native-harness/config": "1.2.0-rc.1", "@react-native-harness/platforms": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "tslib": "^2.3.0" }, "peerDependencies": { "jest-cli": "*" } }, "sha512-9GH+J53kDUP6vGxOqr8SkYZJJzEivMNsYJJrEN5OW4EPHzEhUa3q8PC9DR3zImfaQS6qaslC6Dd5fT0erEfarA=="],
 
-    "@react-native-harness/config": ["@react-native-harness/config@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/plugins": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-BWOp/1R5M6mBs9gDy9NK9nPyCamZlavjyNYYZCD5qV9hHOerW5NUraB1csg9VdGoMQR7FWrBeO9wUVWvqAPEXw=="],
+    "@react-native-harness/config": ["@react-native-harness/config@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/plugins": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-kIPdQG2MAHRN5pIYbKgHJU+cUcIJJWP/zZXDGhOCmHmbJq2gym8fnKnG9BnWcLOmH9vu8F//qrGx/dXEPxsM8Q=="],
 
-    "@react-native-harness/jest": ["@react-native-harness/jest@1.1.0-rc.4", "", { "dependencies": { "@jest/test-result": "^30.2.0", "@react-native-harness/bridge": "1.1.0-rc.4", "@react-native-harness/bundler-metro": "1.1.0-rc.4", "@react-native-harness/config": "1.1.0-rc.4", "@react-native-harness/platforms": "1.1.0-rc.4", "@react-native-harness/plugins": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "chalk": "^4.1.2", "jest-message-util": "^30.2.0", "jest-util": "^30.2.0", "p-limit": "^7.1.1", "tslib": "^2.3.0", "yargs": "^17.7.2" } }, "sha512-Cw+UThQ1iIXKzxci9dkL5nb/XEBEBf3+Ro2cJV1pIfTHEopcq/XwPsiRpLt5zc+jHM00xZgoIfG23KnKlGCzZg=="],
+    "@react-native-harness/jest": ["@react-native-harness/jest@1.2.0-rc.1", "", { "dependencies": { "@jest/test-result": "^30.2.0", "@react-native-harness/bridge": "1.2.0-rc.1", "@react-native-harness/bundler-metro": "1.2.0-rc.1", "@react-native-harness/config": "1.2.0-rc.1", "@react-native-harness/platforms": "1.2.0-rc.1", "@react-native-harness/plugins": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "chalk": "^4.1.2", "jest-message-util": "^30.2.0", "jest-util": "^30.2.0", "p-limit": "^7.1.1", "tslib": "^2.3.0", "yargs": "^17.7.2" } }, "sha512-dSnykZboYeypGCo7LRWcOcpV69hHuvGIKmJOUvtCMhMAW4xdax3RuoeNIdq7z6nyp2dsbrJzrPL83Gu00kWx9Q=="],
 
-    "@react-native-harness/metro": ["@react-native-harness/metro@1.1.0-rc.4", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*" } }, "sha512-hYHH12jzr3VVNpiTHgkXYoJmJvVmj5s5TzW+gL3QIagE5y1x+YjHOtU2MTQoCsqq8Gkr/GSC3gLr1VnWZ4YFVA=="],
+    "@react-native-harness/metro": ["@react-native-harness/metro@1.2.0-rc.1", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*" } }, "sha512-vsydKaxcQTuLsBy6l3i12D1ieLxAP6bqr3v/JJtZR8mMxRWUWrf/RopIEoi0jlNCqaXxO0w9AzOUWk2lc91AIg=="],
 
-    "@react-native-harness/platform-android": ["@react-native-harness/platform-android@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/config": "1.1.0-rc.4", "@react-native-harness/platforms": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-lNWxPfehU6H0xLMDBCV6raebdzORcheDdHO2zY8V2NgjrrFZsRa86TBXVSgI7pHJgrIRMcRGK2tHOX/mNwP5Jw=="],
+    "@react-native-harness/platform-android": ["@react-native-harness/platform-android@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/config": "1.2.0-rc.1", "@react-native-harness/platforms": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-zYL1WRMuzn7IfqghthYQv6JkE+tRLbXMrtYkdmR2gL/6NGXq4IvqS0CTu8yWPiMMN66TPicsYrobMIReDyX1yw=="],
 
-    "@react-native-harness/platform-apple": ["@react-native-harness/platform-apple@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/config": "1.1.0-rc.4", "@react-native-harness/platforms": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-V8yW6oY7CKyw8d32BBmjSADCwZK7f/EzursRemWiI7mvjs+PQHyKX2hvOCC/Ulo7wpbKh3LfY7/b0Jh8IX4DlA=="],
+    "@react-native-harness/platform-apple": ["@react-native-harness/platform-apple@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/config": "1.2.0-rc.1", "@react-native-harness/platforms": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-7xyqx2yhNwzwA//aFfGHlKHKlmK0p6NwPh9UpNMsgZixbpTv2eW3vk9AgF0BJ66FFNucZIS108jko/RHVdpXcg=="],
 
-    "@react-native-harness/platforms": ["@react-native-harness/platforms@1.1.0-rc.4", "", { "dependencies": { "tslib": "^2.3.0" } }, "sha512-EJyzYVbse+CBACvNnTF/fcZSn5bJ+43GI9A4ETAR5FlKdZjMHZUE52PTFhexqPs5+83f17g99kubVERtAicJqQ=="],
+    "@react-native-harness/platforms": ["@react-native-harness/platforms@1.2.0-rc.1", "", { "dependencies": { "tslib": "^2.3.0" } }, "sha512-3c+Ij8S0CcnsXMa9aSQiO/37jvNUD0fvBZiYJoyROe7Hibwiyos1d0P80CRmDK12UJ8FnHE0wtWDkGIgRx4x7A=="],
 
-    "@react-native-harness/plugins": ["@react-native-harness/plugins@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/bridge": "1.1.0-rc.4", "@react-native-harness/platforms": "1.1.0-rc.4", "@react-native-harness/tools": "1.1.0-rc.4", "hookable": "^6.1.0", "tslib": "^2.3.0" } }, "sha512-tOlKtnZiSndJAYC9yX/V4vMnZQqw1qdS+ohVoU3u4rQce1s6dti2zjw7DtfXeRl4dKojA1coV9sY6h6rvlHrNA=="],
+    "@react-native-harness/plugins": ["@react-native-harness/plugins@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/bridge": "1.2.0-rc.1", "@react-native-harness/platforms": "1.2.0-rc.1", "@react-native-harness/tools": "1.2.0-rc.1", "hookable": "^6.1.0", "tslib": "^2.3.0" } }, "sha512-RfR6j1jt90mNFwST6OVB55W1q6wWe8Qq2IldhUTbXhCkdaO+u/qcugP5BAFp6Q7yclDN7yZADIm916XIrN6MYQ=="],
 
-    "@react-native-harness/runtime": ["@react-native-harness/runtime@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/bridge": "1.1.0-rc.4", "@vitest/expect": "4.0.16", "@vitest/spy": "4.0.16", "chai": "^6.2.2", "event-target-shim": "^6.0.2", "react-native-url-polyfill": "^3.0.0", "use-sync-external-store": "^1.6.0", "zustand": "^5.0.5" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-IBMsZrbyMY9Eqj23jGjac8FWgR/lZH7ZTbpFZ5zkaumamC97SQ8YL0RZwYR2euZEmPhKxyyhrAS7HPhtow4dow=="],
+    "@react-native-harness/runtime": ["@react-native-harness/runtime@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/bridge": "1.2.0-rc.1", "@vitest/expect": "4.0.16", "@vitest/spy": "4.0.16", "chai": "^6.2.2", "event-target-shim": "^6.0.2", "react-native-url-polyfill": "^3.0.0", "use-sync-external-store": "^1.6.0", "zustand": "^5.0.5" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-LwPEV3b5dQANj10gOundjOJ2IAlRxt34Y35xM9+7L12XXhtMiwK0WR/VZJrJsNWqgJuBrgNUdfzDeuGzDgwPIw=="],
 
-    "@react-native-harness/tools": ["@react-native-harness/tools@1.1.0-rc.4", "", { "dependencies": { "@clack/prompts": "1.0.0-alpha.9", "nano-spawn": "^1.0.2", "picocolors": "^1.1.1", "tslib": "^2.3.0" }, "peerDependencies": { "react-native": "*" } }, "sha512-ttrq/h/V4B2JVjxIjJMMvRY/SkNJWqJ9Wge4HjRhwE/d1ZuBjX/ayLycR/50yu+237Je/e5QFJ8QAznZa4VekQ=="],
+    "@react-native-harness/tools": ["@react-native-harness/tools@1.2.0-rc.1", "", { "dependencies": { "@clack/prompts": "1.0.0-alpha.9", "nano-spawn": "^1.0.2", "picocolors": "^1.1.1", "tslib": "^2.3.0" }, "peerDependencies": { "react-native": "*" } }, "sha512-2swhF7WCzKQhna5KE9xNeJ/08Rl0gUbHyWGuZSxDsNkm0jBPZ2/MBzqJvxXQaFovx5VGfO8/ksbmOW0Ck3HiKQ=="],
 
     "@react-native-menu/menu": ["@react-native-menu/menu@2.0.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-hb8Mirw6aKPGONhgo52IiNpwHtISVrgCT3rMdFX1qS7eOFNzOcQh8d2UDnaH5zVpxN+QuvWtaaiRMGFpIjzdtA=="],
 
@@ -2349,7 +2349,7 @@
 
     "react-native-gesture-handler": ["react-native-gesture-handler@2.30.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA=="],
 
-    "react-native-harness": ["react-native-harness@1.1.0-rc.4", "", { "dependencies": { "@react-native-harness/babel-preset": "1.1.0-rc.4", "@react-native-harness/cli": "1.1.0-rc.4", "@react-native-harness/jest": "1.1.0-rc.4", "@react-native-harness/metro": "1.1.0-rc.4", "@react-native-harness/runtime": "1.1.0-rc.4", "tslib": "^2.3.0" }, "bin": { "react-native-harness": "bin.js", "harness": "bin.js" } }, "sha512-DfNDXvBPfmiNvdtlSgpep/IA4saoli9aaU4B3ZSO9bQ4QXjvgCg9oBASc403noeItVe54V4oHf6NnZ3QP/ZeHg=="],
+    "react-native-harness": ["react-native-harness@1.2.0-rc.1", "", { "dependencies": { "@react-native-harness/babel-preset": "1.2.0-rc.1", "@react-native-harness/cli": "1.2.0-rc.1", "@react-native-harness/jest": "1.2.0-rc.1", "@react-native-harness/metro": "1.2.0-rc.1", "@react-native-harness/runtime": "1.2.0-rc.1", "tslib": "^2.3.0" }, "bin": { "react-native-harness": "bin.js", "harness": "bin.js" } }, "sha512-G1do6XswGPVQc1xaWiSeYyiCAyOGD0sh7XejIwhbXjw3lFSpD6G8m5KfIpR1Kkk7aas3NQIBuTa9PWve4sSsQQ=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA=="],
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
     }
   },
   "patchedDependencies": {
-    "react-native@0.84.0": "patches/react-native@0.84.0.patch"
+    "react-native@0.84.0": "patches/react-native@0.84.0.patch",
+    "@react-native-harness/platform-apple@1.2.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch"
   },
   "version": "5.0.9"
 }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
   },
   "patchedDependencies": {
     "react-native@0.84.0": "patches/react-native@0.84.0.patch",
-    "@react-native-harness/platform-apple@1.2.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch"
+    "@react-native-harness/platform-apple@1.2.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch",
+    "@react-native-harness/cli@1.2.0-rc.1": "patches/@react-native-harness%2Fcli@1.2.0-rc.1.patch"
   },
   "version": "5.0.9"
 }

--- a/patches/@react-native-harness%2Fcli@1.2.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fcli@1.2.0-rc.1.patch
@@ -1,0 +1,465 @@
+diff --git a/dist/index.js b/dist/index.js
+index 048172d0d582ea7d5aef83c42ddb68afd00ef3aa..5cc9510a4e925aaf63198e8d23acd811f3aa33a1 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,6 +1,7 @@
+ import { run, yargsOptions } from 'jest-cli';
+ import { getConfig } from '@react-native-harness/config';
+ import { runInitWizard } from './wizard/index.js';
++import { getErrorMessage, runXCTestCommand } from './xctest-command.js';
+ import fs from 'node:fs';
+ import path from 'node:path';
+ const JEST_CONFIG_EXTENSIONS = ['.mjs', '.js', '.cjs'];
+@@ -62,7 +63,14 @@ const patchYargsOptions = () => {
+     delete yargsOptions.coverageProvider;
+     delete yargsOptions.logHeapUsage;
+ };
+-if (process.argv.includes('init')) {
++if (process.argv[2] === 'xctest') {
++    runXCTestCommand().catch((error) => {
++        const message = getErrorMessage(error);
++        console.error(message);
++        process.exit(1);
++    });
++}
++else if (process.argv.includes('init')) {
+     runInitWizard();
+ }
+ else {
+diff --git a/node_modules/@react-native-harness/cli/dist/xctest-command.d.ts b/dist/xctest-command.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..cbd5371f13b211d26179902e82b50ef80cd3854d
+--- /dev/null
++++ b/dist/xctest-command.d.ts
+@@ -0,0 +1,34 @@
++export type XCTestBuildDestination = 'simulator' | 'device';
++export type XCTestBuildArgs = {
++    destination: XCTestBuildDestination;
++    provisioningProfile?: string;
++    signingIdentity?: string;
++    teamId?: string;
++};
++type XCTestBuildResult = {
++    destination: XCTestBuildDestination;
++    derivedDataPath: string;
++    reused: boolean;
++    xctestrunPath?: string;
++};
++type XCTestBuildSigning = {
++    provisioningProfile?: string;
++    signingIdentity?: string;
++    teamId?: string;
++};
++export type PlatformAppleXCTestModule = {
++    buildXCTestAgent: (options: {
++        destination: XCTestBuildDestination;
++        projectRoot: string;
++        signing?: XCTestBuildSigning;
++    }) => Promise<XCTestBuildResult>;
++};
++export declare const getErrorMessage: (error: unknown) => string;
++export declare const parseXCTestBuildArgs: (args: string[]) => XCTestBuildArgs;
++export declare const runXCTestBuildCommand: (options: {
++    args: string[];
++    cwd: string;
++    platformApple: PlatformAppleXCTestModule;
++}) => Promise<void>;
++export declare const runXCTestCommand: () => Promise<void>;
++export {};
+diff --git a/node_modules/@react-native-harness/cli/dist/xctest-command.js b/dist/xctest-command.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..20b99a052b5ac52f8a29aaebda196b17e08b2f68
+--- /dev/null
++++ b/dist/xctest-command.js
+@@ -0,0 +1,132 @@
++import yargs from 'yargs';
++import { hideBin } from 'yargs/helpers';
++export const getErrorMessage = (error) => {
++    if (error instanceof Error) {
++        return error.message;
++    }
++    return String(error);
++};
++const createXCTestYargs = (args) => {
++    return yargs(args)
++        .scriptName('harness xctest')
++        .command('build', 'Build the bundled iOS XCTest agent', (command) => {
++        return command
++            .option('destination', {
++            choices: ['simulator', 'device'],
++            demandOption: true,
++            describe: 'Build destination',
++            type: 'string',
++        })
++            .option('teamId', {
++            describe: 'Apple development team ID for signed device builds',
++            type: 'string',
++        })
++            .option('signingIdentity', {
++            describe: 'Code signing identity for signed device builds',
++            type: 'string',
++        })
++            .option('provisioningProfile', {
++            describe: 'Provisioning profile specifier for signed device builds',
++            type: 'string',
++        })
++            .example('$0 build --destination simulator', 'Build unsigned simulator artifacts')
++            .example('$0 build --destination device', 'Build unsigned device artifacts')
++            .example('$0 build --destination device --teamId BAJL5U28HC', 'Build signed device artifacts');
++    }, () => undefined)
++        .demandCommand(1, 'Missing xctest command.')
++        .strict()
++        .help()
++        .version(false)
++        .exitProcess(false)
++        .fail((message, error) => {
++        throw error ?? new Error(message);
++    });
++};
++const getParsedXCTestBuildArgv = (args) => {
++    const parser = createXCTestYargs(['build', ...args]);
++    const argv = parser.parseSync();
++    const destination = argv.destination;
++    const provisioningProfile = argv.provisioningProfile;
++    const signingIdentity = argv.signingIdentity;
++    const teamId = argv.teamId;
++    return {
++        destination: destination,
++        provisioningProfile: typeof provisioningProfile === 'string' ? provisioningProfile : undefined,
++        signingIdentity: typeof signingIdentity === 'string' ? signingIdentity : undefined,
++        teamId: typeof teamId === 'string' ? teamId : undefined,
++    };
++};
++export const parseXCTestBuildArgs = (args) => {
++    const argv = getParsedXCTestBuildArgv(args);
++    return {
++        destination: argv.destination,
++        provisioningProfile: argv.provisioningProfile,
++        signingIdentity: argv.signingIdentity,
++        teamId: argv.teamId,
++    };
++};
++export const runXCTestBuildCommand = async (options) => {
++    const buildArgs = parseXCTestBuildArgs(options.args);
++    const signing = {
++        provisioningProfile: buildArgs.provisioningProfile,
++        signingIdentity: buildArgs.signingIdentity,
++        teamId: buildArgs.teamId,
++    };
++    const hasSigning = signing.provisioningProfile !== undefined ||
++        signing.signingIdentity !== undefined ||
++        signing.teamId !== undefined;
++    const buildOptions = {
++        destination: buildArgs.destination,
++        projectRoot: options.cwd,
++        signing: undefined,
++    };
++    if (hasSigning) {
++        buildOptions.signing = signing;
++    }
++    const result = await options.platformApple.buildXCTestAgent(buildOptions);
++    console.log('Built XCTest agent');
++    console.log(`Destination: ${result.destination}`);
++    console.log(`DerivedData: ${result.derivedDataPath}`);
++    if (result.xctestrunPath) {
++        console.log(`XCTestRun: ${result.xctestrunPath}`);
++    }
++    let reusedLabel = 'no';
++    if (result.reused) {
++        reusedLabel = 'yes';
++    }
++    console.log(`Reused: ${reusedLabel}`);
++};
++export const runXCTestCommand = async () => {
++    const args = hideBin(process.argv).slice(1);
++    const parser = createXCTestYargs(args);
++    const argv = parser.parseSync();
++    const commandName = String(argv._[0] ?? '');
++    if (args.includes('--help') || args.includes('-h')) {
++        return;
++    }
++    if (commandName !== 'build') {
++        return;
++    }
++    let platformApple;
++    try {
++        const importedPlatformApple = await import('@react-native-harness/platform-apple');
++        const unknownPlatformApple = importedPlatformApple;
++        platformApple = unknownPlatformApple;
++    }
++    catch (error) {
++        console.error(getErrorMessage(error));
++        process.exit(1);
++    }
++    try {
++        await runXCTestBuildCommand({
++            args: args.slice(1),
++            cwd: process.cwd(),
++            platformApple,
++        });
++    }
++    catch (error) {
++        console.error(getErrorMessage(error));
++        parser.showHelp();
++        process.exit(1);
++    }
++};
+diff --git a/package.json b/package.json
+index 2a9aca69898d576aa70ee256101176e296fc405e..15c5ab807a75a86870e643e3b1891061aa3fd1e7 100644
+--- a/package.json
++++ b/package.json
+@@ -25,12 +25,14 @@
+     "@react-native-harness/tools": "1.2.0-rc.1",
+     "@react-native-harness/bridge": "1.2.0-rc.1",
+     "@react-native-harness/config": "1.2.0-rc.1",
+-    "@react-native-harness/platforms": "1.2.0-rc.1"
++    "@react-native-harness/platform-apple": "1.2.0-rc.1",
++    "@react-native-harness/platforms": "1.2.0-rc.1",
++    "yargs": "^17.7.2"
+   },
+   "devDependencies": {
++    "@types/yargs": "^17.0.32",
+     "jest-cli": "^30.2.0",
+     "@react-native-harness/platform-android": "1.2.0-rc.1",
+-    "@react-native-harness/platform-apple": "1.2.0-rc.1",
+     "@react-native-harness/platform-web": "1.2.0-rc.1"
+   },
+   "peerDependencies": {
+diff --git a/src/index.ts b/src/index.ts
+index 9522515414bbe50ffa9c3d4c37978647ba29b680..73481eadcc46ad77ce80b351788ebff61d8c1b95 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,6 +1,7 @@
+ import { run, yargsOptions } from 'jest-cli';
+ import { getConfig } from '@react-native-harness/config';
+ import { runInitWizard } from './wizard/index.js';
++import { getErrorMessage, runXCTestCommand } from './xctest-command.js';
+ import fs from 'node:fs';
+ import path from 'node:path';
+ 
+@@ -73,7 +74,13 @@ const patchYargsOptions = () => {
+   delete yargsOptions.logHeapUsage;
+ };
+ 
+-if (process.argv.includes('init')) {
++if (process.argv[2] === 'xctest') {
++  runXCTestCommand().catch((error) => {
++    const message = getErrorMessage(error);
++    console.error(message);
++    process.exit(1);
++  });
++} else if (process.argv.includes('init')) {
+   runInitWizard();
+ } else {
+   patchYargsOptions();
+diff --git a/node_modules/@react-native-harness/cli/src/xctest-command.ts b/src/xctest-command.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..cd2afecf879adfa58352ff399cae326d72866916
+--- /dev/null
++++ b/src/xctest-command.ts
+@@ -0,0 +1,205 @@
++import yargs from 'yargs';
++import { hideBin } from 'yargs/helpers';
++
++export type XCTestBuildDestination = 'simulator' | 'device';
++
++export type XCTestBuildArgs = {
++  destination: XCTestBuildDestination;
++  provisioningProfile?: string;
++  signingIdentity?: string;
++  teamId?: string;
++};
++
++type XCTestBuildResult = {
++  destination: XCTestBuildDestination;
++  derivedDataPath: string;
++  reused: boolean;
++  xctestrunPath?: string;
++};
++
++type XCTestBuildSigning = {
++  provisioningProfile?: string;
++  signingIdentity?: string;
++  teamId?: string;
++};
++
++export type PlatformAppleXCTestModule = {
++  buildXCTestAgent: (options: {
++    destination: XCTestBuildDestination;
++    projectRoot: string;
++    signing?: XCTestBuildSigning;
++  }) => Promise<XCTestBuildResult>;
++};
++
++export const getErrorMessage = (error: unknown): string => {
++  if (error instanceof Error) {
++    return error.message;
++  }
++
++  return String(error);
++};
++
++const createXCTestYargs = (args: string[]) => {
++  return yargs(args)
++    .scriptName('harness xctest')
++    .command(
++      'build',
++      'Build the bundled iOS XCTest agent',
++      (command) => {
++        return command
++          .option('destination', {
++            choices: ['simulator', 'device'] as const,
++            demandOption: true,
++            describe: 'Build destination',
++            type: 'string',
++          })
++          .option('teamId', {
++            describe: 'Apple development team ID for signed device builds',
++            type: 'string',
++          })
++          .option('signingIdentity', {
++            describe: 'Code signing identity for signed device builds',
++            type: 'string',
++          })
++          .option('provisioningProfile', {
++            describe:
++              'Provisioning profile specifier for signed device builds',
++            type: 'string',
++          })
++          .example(
++            '$0 build --destination simulator',
++            'Build unsigned simulator artifacts'
++          )
++          .example(
++            '$0 build --destination device',
++            'Build unsigned device artifacts'
++          )
++          .example(
++            '$0 build --destination device --teamId BAJL5U28HC',
++            'Build signed device artifacts'
++          );
++      },
++      () => undefined
++    )
++    .demandCommand(1, 'Missing xctest command.')
++    .strict()
++    .help()
++    .version(false)
++    .exitProcess(false)
++    .fail((message, error) => {
++      throw error ?? new Error(message);
++    });
++};
++
++const getParsedXCTestBuildArgv = (args: string[]) => {
++  const parser = createXCTestYargs(['build', ...args]);
++  const argv = parser.parseSync();
++  const destination = argv.destination;
++  const provisioningProfile = argv.provisioningProfile;
++  const signingIdentity = argv.signingIdentity;
++  const teamId = argv.teamId;
++
++  return {
++    destination: destination as XCTestBuildDestination,
++    provisioningProfile:
++      typeof provisioningProfile === 'string' ? provisioningProfile : undefined,
++    signingIdentity:
++      typeof signingIdentity === 'string' ? signingIdentity : undefined,
++    teamId: typeof teamId === 'string' ? teamId : undefined,
++  };
++};
++
++export const parseXCTestBuildArgs = (args: string[]): XCTestBuildArgs => {
++  const argv = getParsedXCTestBuildArgv(args);
++
++  return {
++    destination: argv.destination,
++    provisioningProfile: argv.provisioningProfile,
++    signingIdentity: argv.signingIdentity,
++    teamId: argv.teamId,
++  };
++};
++
++export const runXCTestBuildCommand = async (options: {
++  args: string[];
++  cwd: string;
++  platformApple: PlatformAppleXCTestModule;
++}) => {
++  const buildArgs = parseXCTestBuildArgs(options.args);
++  const signing = {
++    provisioningProfile: buildArgs.provisioningProfile,
++    signingIdentity: buildArgs.signingIdentity,
++    teamId: buildArgs.teamId,
++  };
++  const hasSigning =
++    signing.provisioningProfile !== undefined ||
++    signing.signingIdentity !== undefined ||
++    signing.teamId !== undefined;
++  const buildOptions = {
++    destination: buildArgs.destination,
++    projectRoot: options.cwd,
++    signing: undefined as XCTestBuildSigning | undefined,
++  };
++
++  if (hasSigning) {
++    buildOptions.signing = signing;
++  }
++
++  const result = await options.platformApple.buildXCTestAgent(buildOptions);
++
++  console.log('Built XCTest agent');
++  console.log(`Destination: ${result.destination}`);
++  console.log(`DerivedData: ${result.derivedDataPath}`);
++
++  if (result.xctestrunPath) {
++    console.log(`XCTestRun: ${result.xctestrunPath}`);
++  }
++
++  let reusedLabel = 'no';
++
++  if (result.reused) {
++    reusedLabel = 'yes';
++  }
++
++  console.log(`Reused: ${reusedLabel}`);
++};
++
++export const runXCTestCommand = async () => {
++  const args = hideBin(process.argv).slice(1);
++  const parser = createXCTestYargs(args);
++  const argv = parser.parseSync();
++  const commandName = String(argv._[0] ?? '');
++
++  if (args.includes('--help') || args.includes('-h')) {
++    return;
++  }
++
++  if (commandName !== 'build') {
++    return;
++  }
++
++  let platformApple: PlatformAppleXCTestModule;
++
++  try {
++    const importedPlatformApple = await import(
++      '@react-native-harness/platform-apple'
++    );
++    const unknownPlatformApple = importedPlatformApple as unknown;
++    platformApple = unknownPlatformApple as PlatformAppleXCTestModule;
++  } catch (error) {
++    console.error(getErrorMessage(error));
++    process.exit(1);
++  }
++
++  try {
++    await runXCTestBuildCommand({
++      args: args.slice(1),
++      cwd: process.cwd(),
++      platformApple,
++    });
++  } catch (error) {
++    console.error(getErrorMessage(error));
++    parser.showHelp();
++    process.exit(1);
++  }
++};

--- a/patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch
@@ -1,3 +1,71 @@
+diff --git a/README.md b/README.md
+index 4046b69619f5770d26353894eeb02b15bd8baedc..497e8d97982c3b4391e4d8ecfa6b4bb382ba371c 100644
+--- a/README.md
++++ b/README.md
+@@ -68,13 +68,15 @@ Creates an iOS simulator device configuration.
+ - `deviceName` - Name of the iOS simulator (e.g., 'iPhone 16 Pro Max')
+ - `osVersion` - iOS version (e.g., '18.0')
+ 
+-### `applePhysicalDevice(deviceName)`
++### `applePhysicalDevice(deviceNameOrId)`
+ 
+ Creates a physical Apple device configuration.
+ 
+ **Parameters:**
+ 
+-- `deviceName` - Name of the physical device (e.g., 'iPhone (Your Name)')
++- `deviceNameOrId` - Name, CoreDevice identifier, or hardware UDID of the
++  physical device (e.g., 'iPhone (Your Name)' or
++  '6954F636-D116-52FA-9D00-8298BBB63705')
+ 
+ ## Requirements
+ 
+diff --git a/dist/xcrun/devicectl.d.ts b/dist/xcrun/devicectl.d.ts
+index 14a80c74f1dc73972db8a75325bb3883760f667e..140217054d1744ce725da5a3986752ad2e7824bf 100644
+--- a/dist/xcrun/devicectl.d.ts
++++ b/dist/xcrun/devicectl.d.ts
+@@ -62,8 +62,9 @@ export declare const copyFileFrom: (identifier: string, options: {
+     domainType: "systemCrashLogs";
+ }) => Promise<void>;
+ export declare const stopApp: (identifier: string, bundleId: string) => Promise<void>;
+-export declare const getDevice: (name: string) => Promise<AppleDeviceInfo | null>;
+-export declare const getDeviceId: (name: string) => Promise<string | null>;
++export declare const isMatchingDevice: (device: AppleDeviceInfo, identifier: string) => boolean;
++export declare const getDevice: (identifier: string) => Promise<AppleDeviceInfo | null>;
++export declare const getDeviceId: (identifier: string) => Promise<string | null>;
+ export declare const isAppRunning: (identifier: string, bundleId: string) => Promise<boolean>;
+ export {};
+ //# sourceMappingURL=devicectl.d.ts.map
+\ No newline at end of file
+diff --git a/dist/xcrun/devicectl.js b/dist/xcrun/devicectl.js
+index afe05044f103f10ecdb057ee0ec58f9425f96981..34d4cefc4d43a8433a235a3bee7eabfac70a3738 100644
+--- a/dist/xcrun/devicectl.js
++++ b/dist/xcrun/devicectl.js
+@@ -172,12 +172,20 @@ export const stopApp = async (identifier, bundleId) => {
+         process.processIdentifier.toString(),
+     ]);
+ };
+-export const getDevice = async (name) => {
++export const isMatchingDevice = (device, identifier) => {
++    return (device.deviceProperties.name === identifier ||
++        device.identifier === identifier ||
++        device.hardwareProperties.udid === identifier);
++};
++export const getDevice = async (identifier) => {
+     const devices = await listDevices();
+-    return (devices.find((device) => device.deviceProperties.name === name) ?? null);
++    const matchingDevice = devices.find((device) => {
++        return isMatchingDevice(device, identifier);
++    });
++    return matchingDevice ?? null;
+ };
+-export const getDeviceId = async (name) => {
+-    const device = await getDevice(name);
++export const getDeviceId = async (identifier) => {
++    const device = await getDevice(identifier);
+     return device?.identifier ?? null;
+ };
+ export const isAppRunning = async (identifier, bundleId) => {
 diff --git a/dist/xctest-agent.js b/dist/xctest-agent.js
 index 837e6a141ddedeadff87b2c5b7e891d248323019..e28ac2bb10281b560a846d588a98525a93e31d8f 100644
 --- a/dist/xctest-agent.js
@@ -82,6 +150,93 @@ index 837e6a141ddedeadff87b2c5b7e891d248323019..e28ac2bb10281b560a846d588a98525a
              '-destination',
              getXCTestAgentRunDestination(target),
              '-parallel-testing-enabled',
+diff --git a/src/__tests__/launch-options.test.ts b/src/__tests__/launch-options.test.ts
+index 1e4e058385e227ea9c7ef9f19de7d0e737e2c4bc..b5bc63c862fe360f4599485df4b4dcf5b1611564 100644
+--- a/src/__tests__/launch-options.test.ts
++++ b/src/__tests__/launch-options.test.ts
+@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
+ import {
+   getDeviceConnectionHost,
+   getDeviceCtlLaunchArgs,
++  isMatchingDevice,
+ } from '../xcrun/devicectl.js';
+ import { getSimctlChildEnvironment } from '../xcrun/simctl.js';
+ 
+@@ -62,4 +63,31 @@ describe('Apple app launch options', () => {
+       })
+     ).toBe('fd12:3456:789a::1');
+   });
++
++  it('matches physical devices by name, CoreDevice identifier, or hardware UDID', () => {
++    const device = {
++      identifier: '6954F636-D116-52FA-9D00-8298BBB63705',
++      deviceProperties: {
++        name: 'G22RJQXC3V',
++        osVersionNumber: '26.0',
++      },
++      hardwareProperties: {
++        marketingName: 'iPhone',
++        productType: 'iPhone17,1',
++        udid: '00008140-001600222422201C',
++      },
++    };
++    const matchesName = isMatchingDevice(device, 'G22RJQXC3V');
++    const matchesIdentifier = isMatchingDevice(
++      device,
++      '6954F636-D116-52FA-9D00-8298BBB63705'
++    );
++    const matchesUdid = isMatchingDevice(device, '00008140-001600222422201C');
++    const matchesUnknownName = isMatchingDevice(device, 'Unknown iPhone');
++
++    expect(matchesName).toBe(true);
++    expect(matchesIdentifier).toBe(true);
++    expect(matchesUdid).toBe(true);
++    expect(matchesUnknownName).toBe(false);
++  });
+ });
+diff --git a/src/xcrun/devicectl.ts b/src/xcrun/devicectl.ts
+index 6269a237e15f83ea9bb574255cec99fd6ce09d0c..521951e5aa376f5ffeb6ae7f992f0e76df540313 100644
+--- a/src/xcrun/devicectl.ts
++++ b/src/xcrun/devicectl.ts
+@@ -331,17 +331,32 @@ export const stopApp = async (
+   ]);
+ };
+ 
++export const isMatchingDevice = (
++  device: AppleDeviceInfo,
++  identifier: string
++): boolean => {
++  return (
++    device.deviceProperties.name === identifier ||
++    device.identifier === identifier ||
++    device.hardwareProperties.udid === identifier
++  );
++};
++
+ export const getDevice = async (
+-  name: string
++  identifier: string
+ ): Promise<AppleDeviceInfo | null> => {
+   const devices = await listDevices();
+-  return (
+-    devices.find((device) => device.deviceProperties.name === name) ?? null
+-  );
++  const matchingDevice = devices.find((device) => {
++    return isMatchingDevice(device, identifier);
++  });
++
++  return matchingDevice ?? null;
+ };
+ 
+-export const getDeviceId = async (name: string): Promise<string | null> => {
+-  const device = await getDevice(name);
++export const getDeviceId = async (
++  identifier: string
++): Promise<string | null> => {
++  const device = await getDevice(identifier);
+   return device?.identifier ?? null;
+ };
+ 
 diff --git a/src/xctest-agent.ts b/src/xctest-agent.ts
 index cdbb3187bcfc07ac812dd7d5990e9d23220dfdf6..9716c1beb6d210b9ca39b2139ce5b1d53e0f6f3a 100644
 --- a/src/xctest-agent.ts

--- a/patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch
@@ -20,6 +20,26 @@ index 4046b69619f5770d26353894eeb02b15bd8baedc..497e8d97982c3b4391e4d8ecfa6b4bb3
  
  ## Requirements
  
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index d5402fc12d1030cd10673c27895bc0c383feee18..88b16036be8e173bc089cd01fd1adea375c4e6ca 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -2,4 +2,6 @@ export { applePlatform, appleSimulator, applePhysicalDevice, } from './factory.j
+ export type { ApplePlatformConfig } from './config.js';
+ export { HarnessAppPathError } from './errors.js';
+ export { getRunTargets } from './targets.js';
++export { buildXCTestAgent } from './xctest-agent.js';
++export type { BuildXCTestAgentOptions, BuildXCTestAgentResult, XCTestAgentBuildDestination, XCTestAgentBuildSigning, } from './xctest-agent.js';
+ //# sourceMappingURL=index.d.ts.map
+diff --git a/dist/index.js b/dist/index.js
+index d955e2022f9f13e40a2c62ec69ff61958f22ed5c..032abeb70c36b98dfcb6e8417d69682c66a74489 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,3 +1,4 @@
+ export { applePlatform, appleSimulator, applePhysicalDevice, } from './factory.js';
+ export { HarnessAppPathError } from './errors.js';
+ export { getRunTargets } from './targets.js';
++export { buildXCTestAgent } from './xctest-agent.js';
 diff --git a/dist/xcrun/devicectl.d.ts b/dist/xcrun/devicectl.d.ts
 index 14a80c74f1dc73972db8a75325bb3883760f667e..140217054d1744ce725da5a3986752ad2e7824bf 100644
 --- a/dist/xcrun/devicectl.d.ts
@@ -66,11 +86,62 @@ index afe05044f103f10ecdb057ee0ec58f9425f96981..34d4cefc4d43a8433a235a3bee7eabfa
      return device?.identifier ?? null;
  };
  export const isAppRunning = async (identifier, bundleId) => {
+diff --git a/dist/xctest-agent.d.ts b/dist/xctest-agent.d.ts
+index 7b16536de02ed36e5abd2b1ede9c9f0be79943b3..fee1ef58549a0b86ca0ce88af822bfcf3b4a06e4 100644
+--- a/dist/xctest-agent.d.ts
++++ b/dist/xctest-agent.d.ts
+@@ -1,12 +1,28 @@
+ import { type XCTestAgentPermissionsConfiguration } from './xctest-agent-client.js';
+-import type { ApplePhysicalDeviceCodeSign } from './config.js';
++export type XCTestAgentBuildDestination = 'simulator' | 'device';
++export type XCTestAgentBuildSigning = {
++    teamId?: string;
++    signingIdentity?: string;
++    provisioningProfile?: string;
++};
++export type BuildXCTestAgentOptions = {
++    destination: XCTestAgentBuildDestination;
++    signing?: XCTestAgentBuildSigning;
++    projectRoot?: string;
++};
++export type BuildXCTestAgentResult = {
++    destination: XCTestAgentBuildDestination;
++    derivedDataPath: string;
++    reused: boolean;
++    xctestrunPath?: string;
++};
+ type XCTestAgentTarget = {
+     kind: 'simulator';
+     id: string;
+ } | {
+     kind: 'device';
+     id: string;
+-    codeSign: ApplePhysicalDeviceCodeSign;
++    codeSign?: XCTestAgentBuildSigning;
+ };
+ export type XCTestAgentCapability = {
+     getLaunchEnvironment?: () => Record<string, string>;
+@@ -21,6 +37,7 @@ export type XCTestAgentController = {
+     stop: () => Promise<void>;
+     dispose: () => Promise<void>;
+ };
++export declare const buildXCTestAgent: (options: BuildXCTestAgentOptions) => Promise<BuildXCTestAgentResult>;
+ export declare const createXCTestAgentController: (options: {
+     appBundleId?: string;
+     target: XCTestAgentTarget;
 diff --git a/dist/xctest-agent.js b/dist/xctest-agent.js
-index 837e6a141ddedeadff87b2c5b7e891d248323019..e28ac2bb10281b560a846d588a98525a93e31d8f 100644
+index 837e6a141ddedeadff87b2c5b7e891d248323019..0eef970e41bcc0f949bc037d3363c7df7476b72c 100644
 --- a/dist/xctest-agent.js
 +++ b/dist/xctest-agent.js
-@@ -14,6 +14,8 @@ const XCTEST_AGENT_PROJECT_NAME = 'HarnessXCTestAgent';
+@@ -6,7 +6,6 @@ import { promisify } from 'node:util';
+ import path from 'node:path';
+ import { fileURLToPath } from 'node:url';
+ import { createXCTestAgentClient, } from './xctest-agent-client.js';
+-import { getSimulators } from './xcrun/simctl.js';
+ import { createDeviceXCTestAgentTransport } from './xctest-agent-transport-device.js';
+ import { createSimulatorXCTestAgentTransport } from './xctest-agent-transport-simulator.js';
+ const xctestAgentLogger = logger.child('ios-xctest-agent');
+@@ -14,6 +13,8 @@ const XCTEST_AGENT_PROJECT_NAME = 'HarnessXCTestAgent';
  const XCTEST_AGENT_SCHEME_NAME = 'HarnessXCTestAgent';
  const XCTEST_AGENT_PORT_ENV = 'HARNESS_XCTEST_AGENT_PORT';
  const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV = 'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID';
@@ -79,10 +150,26 @@ index 837e6a141ddedeadff87b2c5b7e891d248323019..e28ac2bb10281b560a846d588a98525a
  const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
  const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
  const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
-@@ -44,6 +46,25 @@ const getXCTestAgentCacheRoot = () => {
- const getXCTestAgentDerivedDataPath = (target) => {
-     return path.join(getXCTestAgentBuildRoot(), target.kind);
+@@ -35,29 +36,51 @@ const assertXCTestAgentProjectExists = () => {
+     }
+     throw new Error(`Missing checked-in XCTest agent project at ${projectFilePath}. Include the checked-in project in the package artifact.`);
  };
+-const getXCTestAgentBuildRoot = () => {
+-    return path.join(process.cwd(), HARNESS_DIRNAME, XCTEST_AGENT_BUILD_DIRNAME);
++const getXCTestAgentBuildRoot = (projectRoot = process.cwd()) => {
++    return path.join(projectRoot, HARNESS_DIRNAME, XCTEST_AGENT_BUILD_DIRNAME);
+ };
+-const getXCTestAgentCacheRoot = () => {
+-    return getHarnessCacheRootPath();
++const getXCTestAgentCacheRoot = (projectRoot = process.cwd()) => {
++    return getHarnessCacheRootPath(projectRoot);
+ };
+-const getXCTestAgentDerivedDataPath = (target) => {
+-    return path.join(getXCTestAgentBuildRoot(), target.kind);
++const getXCTestAgentDerivedDataPath = (destination, projectRoot = process.cwd()) => {
++    const buildRoot = getXCTestAgentBuildRoot(projectRoot);
++    return path.join(buildRoot, destination);
++};
 +const getEnvironmentPath = (name) => {
 +    const value = process.env[name]?.trim();
 +    if (!value) {
@@ -101,29 +188,402 @@ index 837e6a141ddedeadff87b2c5b7e891d248323019..e28ac2bb10281b560a846d588a98525a
 +        return;
 +    }
 +    throw new Error(`Missing external XCTest run file at ${filePath}. Check ${XCTEST_AGENT_XCTESTRUN_FILE_ENV}.`);
-+};
+ };
  const getXCTestAgentBuildManifestPath = (derivedDataPath) => path.join(derivedDataPath, 'build-manifest.json');
  const getXCTestAgentCacheManifestPath = (derivedDataPath) => path.join(derivedDataPath, 'cache.json');
- const getXCTestAgentBuildDestination = (target) => {
-@@ -427,6 +448,17 @@ export const createXCTestAgentController = (options) => {
+-const getXCTestAgentBuildDestination = (target) => {
+-    return target.kind === 'simulator'
+-        ? `platform=iOS Simulator,id=${target.id}`
+-        : `generic/platform=iOS`;
++const getXCTestAgentBuildDestination = (destination) => {
++    if (destination === 'simulator') {
++        return 'generic/platform=iOS Simulator';
++    }
++    return 'generic/platform=iOS';
+ };
+ const getXCTestAgentRunDestination = (target) => {
+-    return target.kind === 'simulator'
+-        ? `platform=iOS Simulator,id=${target.id}`
+-        : `platform=iOS,id=${target.id}`;
+-};
+-const getXCTestAgentBuildSigningArgs = (target) => {
+     if (target.kind === 'simulator') {
++        return `platform=iOS Simulator,id=${target.id}`;
++    }
++    return `platform=iOS,id=${target.id}`;
++};
++const getXCTestAgentBuildSigningArgs = (destination, signing) => {
++    if (destination === 'simulator') {
+         return [
+             'CODE_SIGNING_ALLOWED=NO',
+             'CODE_SIGNING_REQUIRED=NO',
+@@ -65,14 +88,25 @@ const getXCTestAgentBuildSigningArgs = (target) => {
+             'DEVELOPMENT_TEAM=',
+         ];
+     }
+-    const { teamId, signingIdentity, provisioningProfile } = target.codeSign;
+-    const args = [
+-        'CODE_SIGN_STYLE=Automatic',
+-        `DEVELOPMENT_TEAM=${teamId}`,
+-        `CODE_SIGN_IDENTITY=${signingIdentity ?? 'Apple Development'}`,
+-    ];
+-    if (provisioningProfile) {
+-        args.push(`PROVISIONING_PROFILE_SPECIFIER=${provisioningProfile}`);
++    if (!signing) {
++        return ['CODE_SIGNING_ALLOWED=NO', 'CODE_SIGNING_REQUIRED=NO'];
++    }
++    const args = [];
++    if (signing.teamId) {
++        args.push('CODE_SIGN_STYLE=Automatic');
++        args.push(`DEVELOPMENT_TEAM=${signing.teamId}`);
++        if (signing.signingIdentity) {
++            args.push(`CODE_SIGN_IDENTITY=${signing.signingIdentity}`);
++        }
++        else {
++            args.push('CODE_SIGN_IDENTITY=Apple Development');
++        }
++    }
++    else if (signing.signingIdentity) {
++        args.push(`CODE_SIGN_IDENTITY=${signing.signingIdentity}`);
++    }
++    if (signing.provisioningProfile) {
++        args.push(`PROVISIONING_PROFILE_SPECIFIER=${signing.provisioningProfile}`);
+     }
+     return args;
+ };
+@@ -80,16 +114,16 @@ const getXCTestAgentBuildProductsPath = (derivedDataPath) => path.join(derivedDa
+ const getXCTestAgentSourceFilePath = () => {
+     return fileURLToPath(import.meta.url);
+ };
+-const readBuildManifest = (target) => {
+-    const manifestPath = getXCTestAgentBuildManifestPath(getXCTestAgentDerivedDataPath(target));
++const readBuildManifest = (derivedDataPath) => {
++    const manifestPath = getXCTestAgentBuildManifestPath(derivedDataPath);
+     if (!fs.existsSync(manifestPath)) {
+         return null;
+     }
+     return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+ };
+-const writeBuildManifest = (target, manifest) => {
+-    fs.mkdirSync(getXCTestAgentDerivedDataPath(target), { recursive: true });
+-    fs.writeFileSync(getXCTestAgentBuildManifestPath(getXCTestAgentDerivedDataPath(target)), JSON.stringify(manifest, null, 2));
++const writeBuildManifest = (derivedDataPath, manifest) => {
++    fs.mkdirSync(derivedDataPath, { recursive: true });
++    fs.writeFileSync(getXCTestAgentBuildManifestPath(derivedDataPath), JSON.stringify(manifest, null, 2));
+ };
+ const getProjectInputFilePaths = (root) => {
+     const entries = fs.readdirSync(root, { withFileTypes: true });
+@@ -143,7 +177,6 @@ const readSimulatorBuildManifest = (derivedDataPath) => {
+         manifest.destinationKind !== 'simulator' ||
+         typeof manifest.buildInputsHash !== 'string' ||
+         typeof manifest.hostArchitecture !== 'string' ||
+-        typeof manifest.simulatorRuntime !== 'string' ||
+         typeof manifest.simulatorSdkVersion !== 'string' ||
+         typeof manifest.xcodeVersion !== 'string' ||
+         typeof manifest.xctestrunRelativePath !== 'string') {
+@@ -165,8 +198,6 @@ const getSimulatorCacheDirectoryName = (context) => {
+     hash.update('\0');
+     hash.update(context.hostArchitecture);
+     hash.update('\0');
+-    hash.update(context.simulatorRuntime);
+-    hash.update('\0');
+     hash.update(context.simulatorSdkVersion);
+     hash.update('\0');
+     hash.update(context.xcodeVersion);
+@@ -174,11 +205,12 @@ const getSimulatorCacheDirectoryName = (context) => {
+         .digest('hex')
+         .slice(0, 12)}`;
+ };
+-const getSimulatorCacheDerivedDataPath = (context) => {
+-    return path.join(getXCTestAgentCacheRoot(), getSimulatorCacheDirectoryName(context));
++const getSimulatorCacheDerivedDataPath = (context, projectRoot = process.cwd()) => {
++    const cacheRoot = getXCTestAgentCacheRoot(projectRoot);
++    return path.join(cacheRoot, getSimulatorCacheDirectoryName(context));
+ };
+-const getHarnessCacheDirectories = () => {
+-    const cacheRoot = getXCTestAgentCacheRoot();
++const getHarnessCacheDirectories = (projectRoot = process.cwd()) => {
++    const cacheRoot = getXCTestAgentCacheRoot(projectRoot);
+     if (!fs.existsSync(cacheRoot)) {
+         return [];
+     }
+@@ -191,12 +223,11 @@ const getHarnessCacheDirectories = () => {
+ const isCompatibleSimulatorBuildManifest = (manifest, context) => {
+     return (manifest.buildInputsHash === context.buildInputsHash &&
+         manifest.hostArchitecture === context.hostArchitecture &&
+-        manifest.simulatorRuntime === context.simulatorRuntime &&
+         manifest.simulatorSdkVersion === context.simulatorSdkVersion &&
+         manifest.xcodeVersion === context.xcodeVersion);
+ };
+-const findReusableSimulatorBuildArtifacts = (context) => {
+-    for (const derivedDataPath of getHarnessCacheDirectories()) {
++const findReusableSimulatorBuildArtifacts = (context, projectRoot = process.cwd()) => {
++    for (const derivedDataPath of getHarnessCacheDirectories(projectRoot)) {
+         const manifest = readSimulatorBuildManifest(derivedDataPath);
+         if (!manifest || !isCompatibleSimulatorBuildManifest(manifest, context)) {
+             continue;
+@@ -222,49 +253,145 @@ const getCurrentSimulatorSdkVersion = async () => {
+     ]);
+     return stdout.trim();
+ };
+-const getCurrentSimulatorRuntime = async (simulatorId) => {
+-    const simulators = await getSimulators();
+-    const simulator = simulators.find((candidate) => candidate.udid === simulatorId);
+-    if (!simulator) {
+-        throw new Error(`Simulator with UDID ${simulatorId} not found`);
+-    }
+-    return simulator.runtime;
+-};
+-const getSimulatorCacheContext = async (target, buildInputsHash) => {
+-    const [xcodeVersion, simulatorSdkVersion, simulatorRuntime] = await Promise.all([
++const getSimulatorCacheContext = async (buildInputsHash) => {
++    const [xcodeVersion, simulatorSdkVersion] = await Promise.all([
+         getCurrentXcodeVersion(),
+         getCurrentSimulatorSdkVersion(),
+-        getCurrentSimulatorRuntime(target.id),
+     ]);
+     return {
+         buildInputsHash,
+         hostArchitecture: process.arch,
+-        simulatorRuntime,
+         simulatorSdkVersion,
+         xcodeVersion,
+     };
+ };
+-const shouldReuseBuildArtifacts = (target, buildInputsHash) => {
+-    if (target.kind === 'simulator') {
++const shouldReuseBuildArtifacts = (options) => {
++    if (options.destination === 'simulator') {
+         throw new Error('Simulator build reuse must be validated with cache compatibility metadata');
+     }
+-    const manifest = readBuildManifest(target);
++    const manifest = readBuildManifest(options.derivedDataPath);
+     if (!manifest) {
+         return false;
+     }
+-    if (manifest.buildInputsHash !== buildInputsHash ||
+-        manifest.destinationKind !== target.kind) {
++    if (manifest.buildInputsHash !== options.buildInputsHash ||
++        manifest.destinationKind !== options.destination) {
++        return false;
++    }
++    if (manifest.signing?.teamId !== options.signing?.teamId ||
++        manifest.signing?.signingIdentity !== options.signing?.signingIdentity ||
++        manifest.signing?.provisioningProfile !==
++            options.signing?.provisioningProfile) {
+         return false;
+     }
+-    if (target.kind === 'device') {
+-        if (manifest.codeSign?.teamId !== target.codeSign.teamId ||
+-            manifest.codeSign?.signingIdentity !== target.codeSign.signingIdentity ||
+-            manifest.codeSign?.provisioningProfile !==
+-                target.codeSign.provisioningProfile) {
+-            return false;
++    const buildProductsPath = getXCTestAgentBuildProductsPath(options.derivedDataPath);
++    return fs.existsSync(buildProductsPath);
++};
++const getXCTestRunPath = (derivedDataPath) => {
++    const xctestrunRelativePath = getXCTestRunRelativePath(derivedDataPath);
++    if (!xctestrunRelativePath) {
++        return undefined;
++    }
++    const buildProductsPath = getXCTestAgentBuildProductsPath(derivedDataPath);
++    return path.join(buildProductsPath, xctestrunRelativePath);
++};
++export const buildXCTestAgent = async (options) => {
++    const projectRoot = options.projectRoot ?? process.cwd();
++    const buildInputsHash = getProjectInputsHash();
++    let derivedDataPath = getXCTestAgentDerivedDataPath(options.destination, projectRoot);
++    let simulatorCacheContext;
++    xctestAgentLogger.debug('verifying checked-in XCTest agent project for %s', options.destination);
++    xctestAgentLogger.info('Using checked-in XCTest agent project for %s target', options.destination);
++    assertXCTestAgentProjectExists();
++    if (options.destination === 'simulator') {
++        simulatorCacheContext = await getSimulatorCacheContext(buildInputsHash);
++        const reusableDerivedDataPath = findReusableSimulatorBuildArtifacts(simulatorCacheContext, projectRoot);
++        if (reusableDerivedDataPath) {
++            xctestAgentLogger.info('Reusing cached XCTest agent build for %s target', options.destination);
++            xctestAgentLogger.debug('reusing cached XCTest agent build for %s', options.destination);
++            return {
++                destination: options.destination,
++                derivedDataPath: reusableDerivedDataPath,
++                reused: true,
++                xctestrunPath: getXCTestRunPath(reusableDerivedDataPath),
++            };
++        }
++        derivedDataPath = getSimulatorCacheDerivedDataPath(simulatorCacheContext, projectRoot);
++    }
++    else {
++        const canReuseBuild = shouldReuseBuildArtifacts({
++            buildInputsHash,
++            derivedDataPath,
++            destination: options.destination,
++            signing: options.signing,
++        });
++        if (canReuseBuild) {
++            xctestAgentLogger.info('Reusing cached XCTest agent build for %s target', options.destination);
++            xctestAgentLogger.debug('reusing cached XCTest agent build for %s', options.destination);
++            return {
++                destination: options.destination,
++                derivedDataPath,
++                reused: true,
++                xctestrunPath: getXCTestRunPath(derivedDataPath),
++            };
+         }
+     }
+-    return fs.existsSync(getXCTestAgentBuildProductsPath(getXCTestAgentDerivedDataPath(target)));
++    fs.mkdirSync(derivedDataPath, { recursive: true });
++    xctestAgentLogger.debug('building XCTest agent for %s', options.destination);
++    xctestAgentLogger.info('Building XCTest agent for %s target', options.destination);
++    const signingArgs = getXCTestAgentBuildSigningArgs(options.destination, options.signing);
++    const provisioningArgs = [];
++    if (options.destination === 'device' && options.signing?.teamId) {
++        provisioningArgs.push('-allowProvisioningUpdates');
++    }
++    const buildArgs = [
++        'build-for-testing',
++        '-project',
++        getXCTestAgentProjectFilePath(),
++        '-scheme',
++        XCTEST_AGENT_SCHEME_NAME,
++        '-destination',
++        getXCTestAgentBuildDestination(options.destination),
++        '-derivedDataPath',
++        derivedDataPath,
++        ...provisioningArgs,
++        ...signingArgs,
++    ];
++    await spawn('xcodebuild', buildArgs);
++    const xctestrunRelativePath = getXCTestRunRelativePath(derivedDataPath);
++    if (!xctestrunRelativePath) {
++        const buildProductsPath = getXCTestAgentBuildProductsPath(derivedDataPath);
++        throw new Error(`Missing generated .xctestrun file in ${buildProductsPath}`);
++    }
++    if (options.destination === 'simulator') {
++        if (!simulatorCacheContext) {
++            throw new Error('Missing simulator cache context for XCTest agent build');
++        }
++        writeSimulatorBuildManifest(derivedDataPath, {
++            artifactName: XCTEST_AGENT_SIMULATOR_CACHE_ARTIFACT,
++            buildInputsHash,
++            destinationKind: 'simulator',
++            hostArchitecture: simulatorCacheContext.hostArchitecture,
++            schemaVersion: XCTEST_AGENT_SIMULATOR_CACHE_SCHEMA_VERSION,
++            simulatorSdkVersion: simulatorCacheContext.simulatorSdkVersion,
++            xcodeVersion: simulatorCacheContext.xcodeVersion,
++            xctestrunRelativePath,
++        });
++    }
++    else {
++        writeBuildManifest(derivedDataPath, {
++            buildInputsHash,
++            destinationKind: options.destination,
++            signing: options.signing,
++        });
++    }
++    xctestAgentLogger.info('Built XCTest agent for %s target', options.destination);
++    const buildProductsPath = getXCTestAgentBuildProductsPath(derivedDataPath);
++    return {
++        destination: options.destination,
++        derivedDataPath,
++        reused: false,
++        xctestrunPath: path.join(buildProductsPath, xctestrunRelativePath),
++    };
+ };
+ const getDefaultRuntimeConfiguration = () => {
+     return {
+@@ -402,7 +529,7 @@ export const createXCTestAgentController = (options) => {
+         runnerName: `xctest-agent-${target.kind}`,
+     });
+     const xcodebuildLogPath = path.join(logArtifacts.directoryPath, 'xcodebuild.log');
+-    let preparedDerivedDataPath = getXCTestAgentDerivedDataPath(target);
++    let preparedDerivedDataPath = getXCTestAgentDerivedDataPath(target.kind);
+     let prepared = false;
+     let agentProcess = null;
+     let agentClient = null;
+@@ -427,66 +554,26 @@ export const createXCTestAgentController = (options) => {
          if (prepared) {
              return;
          }
+-        const buildInputsHash = getProjectInputsHash();
+-        xctestAgentLogger.debug('verifying checked-in XCTest agent project for %s', target.kind);
+-        xctestAgentLogger.info('Using checked-in XCTest agent project for %s target', target.kind);
+-        assertXCTestAgentProjectExists();
+-        if (target.kind === 'simulator') {
+-            const cacheContext = await getSimulatorCacheContext(target, buildInputsHash);
+-            const reusableDerivedDataPath = findReusableSimulatorBuildArtifacts(cacheContext);
+-            if (reusableDerivedDataPath) {
+-                preparedDerivedDataPath = reusableDerivedDataPath;
+-                prepared = true;
+-                xctestAgentLogger.info('Reusing cached XCTest agent build for %s target', target.kind);
+-                xctestAgentLogger.debug('reusing cached XCTest agent build for %s', target.kind);
+-                return;
 +        const externalXCTestRunFilePath = getExternalXCTestRunFilePath();
 +        if (externalXCTestRunFilePath) {
 +            assertExternalXCTestRunFileExists(externalXCTestRunFilePath);
 +            const externalDerivedDataPath = getExternalDerivedDataPath();
 +            if (externalDerivedDataPath) {
 +                preparedDerivedDataPath = externalDerivedDataPath;
-+            }
-+            prepared = true;
+             }
+-            preparedDerivedDataPath = getSimulatorCacheDerivedDataPath(cacheContext);
+-        }
+-        else if (shouldReuseBuildArtifacts(target, buildInputsHash)) {
+             prepared = true;
+-            xctestAgentLogger.info('Reusing cached XCTest agent build for %s target', target.kind);
+-            xctestAgentLogger.debug('reusing cached XCTest agent build for %s', target.kind);
 +            xctestAgentLogger.info('Using external XCTest run file for %s target: %s', target.kind, externalXCTestRunFilePath);
-+            return;
-+        }
-         const buildInputsHash = getProjectInputsHash();
-         xctestAgentLogger.debug('verifying checked-in XCTest agent project for %s', target.kind);
-         xctestAgentLogger.info('Using checked-in XCTest agent project for %s target', target.kind);
-@@ -499,12 +531,22 @@ export const createXCTestAgentController = (options) => {
+             return;
+         }
+-        fs.mkdirSync(preparedDerivedDataPath, { recursive: true });
+-        xctestAgentLogger.debug('building XCTest agent for %s', target.kind);
+-        xctestAgentLogger.info('Building XCTest agent for %s target', target.kind);
+-        await spawn('xcodebuild', [
+-            'build-for-testing',
+-            '-project',
+-            getXCTestAgentProjectFilePath(),
+-            '-scheme',
+-            XCTEST_AGENT_SCHEME_NAME,
+-            '-destination',
+-            getXCTestAgentBuildDestination(target),
+-            '-derivedDataPath',
+-            preparedDerivedDataPath,
+-            ...(target.kind === 'device' ? ['-allowProvisioningUpdates'] : []),
+-            ...getXCTestAgentBuildSigningArgs(target),
+-        ]);
+-        if (target.kind === 'simulator') {
+-            const cacheContext = await getSimulatorCacheContext(target, buildInputsHash);
+-            const xctestrunRelativePath = getXCTestRunRelativePath(preparedDerivedDataPath);
+-            if (!xctestrunRelativePath) {
+-                throw new Error(`Missing generated .xctestrun file in ${getXCTestAgentBuildProductsPath(preparedDerivedDataPath)}`);
+-            }
+-            writeSimulatorBuildManifest(preparedDerivedDataPath, {
+-                artifactName: XCTEST_AGENT_SIMULATOR_CACHE_ARTIFACT,
+-                destinationKind: 'simulator',
+-                schemaVersion: XCTEST_AGENT_SIMULATOR_CACHE_SCHEMA_VERSION,
+-                xctestrunRelativePath,
+-                ...cacheContext,
+-            });
++        let signing;
++        if (target.kind === 'device') {
++            signing = target.codeSign;
+         }
+-        else {
+-            writeBuildManifest(target, {
+-                buildInputsHash,
+-                destinationKind: target.kind,
+-                codeSign: target.codeSign,
+-            });
+-        }
+-        xctestAgentLogger.info('Built XCTest agent for %s target', target.kind);
++        const buildResult = await buildXCTestAgent({
++            destination: target.kind,
++            signing,
++        });
++        preparedDerivedDataPath = buildResult.derivedDataPath;
+         prepared = true;
+     };
+     const ensureStarted = async () => {
+@@ -499,12 +586,22 @@ export const createXCTestAgentController = (options) => {
          xctestAgentLogger.debug('starting XCTest agent for %s', target.kind);
          xctestAgentLogger.info('Starting XCTest agent session for %s target', target.kind);
          xctestAgentLogger.debug('Using XCTest agent port %d', port);
@@ -194,6 +654,21 @@ index 1e4e058385e227ea9c7ef9f19de7d0e737e2c4bc..b5bc63c862fe360f4599485df4b4dcf5
 +    expect(matchesUnknownName).toBe(false);
 +  });
  });
+diff --git a/src/index.ts b/src/index.ts
+index 555b3e0048af5dad1440c9dd11da8b190b1cfce5..6f35f792ff3a02ee17673026d804e973e23bed03 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -6,3 +6,10 @@ export {
+ export type { ApplePlatformConfig } from './config.js';
+ export { HarnessAppPathError } from './errors.js';
+ export { getRunTargets } from './targets.js';
++export { buildXCTestAgent } from './xctest-agent.js';
++export type {
++  BuildXCTestAgentOptions,
++  BuildXCTestAgentResult,
++  XCTestAgentBuildDestination,
++  XCTestAgentBuildSigning,
++} from './xctest-agent.js';
 diff --git a/src/xcrun/devicectl.ts b/src/xcrun/devicectl.ts
 index 6269a237e15f83ea9bb574255cec99fd6ce09d0c..521951e5aa376f5ffeb6ae7f992f0e76df540313 100644
 --- a/src/xcrun/devicectl.ts
@@ -238,10 +713,19 @@ index 6269a237e15f83ea9bb574255cec99fd6ce09d0c..521951e5aa376f5ffeb6ae7f992f0e76
  };
  
 diff --git a/src/xctest-agent.ts b/src/xctest-agent.ts
-index cdbb3187bcfc07ac812dd7d5990e9d23220dfdf6..9716c1beb6d210b9ca39b2139ce5b1d53e0f6f3a 100644
+index cdbb3187bcfc07ac812dd7d5990e9d23220dfdf6..3e3ce41289df8feb6e8f38a44bf49f3338c0691a 100644
 --- a/src/xctest-agent.ts
 +++ b/src/xctest-agent.ts
-@@ -29,6 +29,9 @@ const XCTEST_AGENT_SCHEME_NAME = 'HarnessXCTestAgent';
+@@ -16,8 +16,6 @@ import {
+   createXCTestAgentClient,
+   type XCTestAgentPermissionsConfiguration,
+ } from './xctest-agent-client.js';
+-import type { ApplePhysicalDeviceCodeSign } from './config.js';
+-import { getSimulators } from './xcrun/simctl.js';
+ import type { XCTestAgentTransport } from './xctest-agent-transport.js';
+ import { createDeviceXCTestAgentTransport } from './xctest-agent-transport-device.js';
+ import { createSimulatorXCTestAgentTransport } from './xctest-agent-transport-simulator.js';
+@@ -29,6 +27,9 @@ const XCTEST_AGENT_SCHEME_NAME = 'HarnessXCTestAgent';
  const XCTEST_AGENT_PORT_ENV = 'HARNESS_XCTEST_AGENT_PORT';
  const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV =
    'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID';
@@ -251,10 +735,88 @@ index cdbb3187bcfc07ac812dd7d5990e9d23220dfdf6..9716c1beb6d210b9ca39b2139ce5b1d5
  const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
  const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
  const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
-@@ -125,6 +128,34 @@ const getXCTestAgentDerivedDataPath = (target: XCTestAgentTarget): string => {
-   return path.join(getXCTestAgentBuildRoot(), target.kind);
+@@ -38,6 +39,27 @@ const XCTEST_AGENT_SIMULATOR_CACHE_ARTIFACT = 'xctest-agent-simulator';
+ const XCTEST_AGENT_SIMULATOR_CACHE_SCHEMA_VERSION = 1;
+ const pipelineAsync = promisify(pipeline);
+ 
++export type XCTestAgentBuildDestination = 'simulator' | 'device';
++
++export type XCTestAgentBuildSigning = {
++  teamId?: string;
++  signingIdentity?: string;
++  provisioningProfile?: string;
++};
++
++export type BuildXCTestAgentOptions = {
++  destination: XCTestAgentBuildDestination;
++  signing?: XCTestAgentBuildSigning;
++  projectRoot?: string;
++};
++
++export type BuildXCTestAgentResult = {
++  destination: XCTestAgentBuildDestination;
++  derivedDataPath: string;
++  reused: boolean;
++  xctestrunPath?: string;
++};
++
+ type XCTestAgentTarget =
+   | {
+       kind: 'simulator';
+@@ -46,7 +68,7 @@ type XCTestAgentTarget =
+   | {
+       kind: 'device';
+       id: string;
+-      codeSign: ApplePhysicalDeviceCodeSign;
++      codeSign?: XCTestAgentBuildSigning;
+     };
+ 
+ export type XCTestAgentCapability = {
+@@ -62,8 +84,8 @@ export type XCTestAgentRuntimeConfiguration = {
+ 
+ type XCTestAgentBuildManifest = {
+   buildInputsHash: string;
+-  destinationKind: XCTestAgentTarget['kind'];
+-  codeSign?: ApplePhysicalDeviceCodeSign;
++  destinationKind: XCTestAgentBuildDestination;
++  signing?: XCTestAgentBuildSigning;
  };
  
+ type SimulatorXCTestAgentCacheManifest = {
+@@ -72,7 +94,6 @@ type SimulatorXCTestAgentCacheManifest = {
+   destinationKind: 'simulator';
+   hostArchitecture: string;
+   schemaVersion: typeof XCTEST_AGENT_SIMULATOR_CACHE_SCHEMA_VERSION;
+-  simulatorRuntime: string;
+   simulatorSdkVersion: string;
+   xcodeVersion: string;
+   xctestrunRelativePath: string;
+@@ -113,16 +134,48 @@ const assertXCTestAgentProjectExists = () => {
+   );
+ };
+ 
+-const getXCTestAgentBuildRoot = (): string => {
+-  return path.join(process.cwd(), HARNESS_DIRNAME, XCTEST_AGENT_BUILD_DIRNAME);
++const getXCTestAgentBuildRoot = (projectRoot = process.cwd()): string => {
++  return path.join(projectRoot, HARNESS_DIRNAME, XCTEST_AGENT_BUILD_DIRNAME);
+ };
+ 
+-const getXCTestAgentCacheRoot = (): string => {
+-  return getHarnessCacheRootPath();
++const getXCTestAgentCacheRoot = (projectRoot = process.cwd()): string => {
++  return getHarnessCacheRootPath(projectRoot);
+ };
+ 
+-const getXCTestAgentDerivedDataPath = (target: XCTestAgentTarget): string => {
+-  return path.join(getXCTestAgentBuildRoot(), target.kind);
++const getXCTestAgentDerivedDataPath = (
++  destination: XCTestAgentBuildDestination,
++  projectRoot = process.cwd()
++): string => {
++  const buildRoot = getXCTestAgentBuildRoot(projectRoot);
++  return path.join(buildRoot, destination);
++};
++
 +const getEnvironmentPath = (name: string): string | null => {
 +  const value = process.env[name]?.trim();
 +
@@ -281,37 +843,580 @@ index cdbb3187bcfc07ac812dd7d5990e9d23220dfdf6..9716c1beb6d210b9ca39b2139ce5b1d5
 +  throw new Error(
 +    `Missing external XCTest run file at ${filePath}. Check ${XCTEST_AGENT_XCTESTRUN_FILE_ENV}.`
 +  );
+ };
+ 
+ const getXCTestAgentBuildManifestPath = (derivedDataPath: string): string =>
+@@ -131,22 +184,29 @@ const getXCTestAgentBuildManifestPath = (derivedDataPath: string): string =>
+ const getXCTestAgentCacheManifestPath = (derivedDataPath: string): string =>
+   path.join(derivedDataPath, 'cache.json');
+ 
+-const getXCTestAgentBuildDestination = (target: XCTestAgentTarget): string => {
+-  return target.kind === 'simulator'
+-    ? `platform=iOS Simulator,id=${target.id}`
+-    : `generic/platform=iOS`;
++const getXCTestAgentBuildDestination = (
++  destination: XCTestAgentBuildDestination
++): string => {
++  if (destination === 'simulator') {
++    return 'generic/platform=iOS Simulator';
++  }
++
++  return 'generic/platform=iOS';
+ };
+ 
+ const getXCTestAgentRunDestination = (target: XCTestAgentTarget): string => {
+-  return target.kind === 'simulator'
+-    ? `platform=iOS Simulator,id=${target.id}`
+-    : `platform=iOS,id=${target.id}`;
++  if (target.kind === 'simulator') {
++    return `platform=iOS Simulator,id=${target.id}`;
++  }
++
++  return `platform=iOS,id=${target.id}`;
+ };
+ 
+ const getXCTestAgentBuildSigningArgs = (
+-  target: XCTestAgentTarget
++  destination: XCTestAgentBuildDestination,
++  signing?: XCTestAgentBuildSigning
+ ): string[] => {
+-  if (target.kind === 'simulator') {
++  if (destination === 'simulator') {
+     return [
+       'CODE_SIGNING_ALLOWED=NO',
+       'CODE_SIGNING_REQUIRED=NO',
+@@ -155,15 +215,29 @@ const getXCTestAgentBuildSigningArgs = (
+     ];
+   }
+ 
+-  const { teamId, signingIdentity, provisioningProfile } = target.codeSign;
+-  const args = [
+-    'CODE_SIGN_STYLE=Automatic',
+-    `DEVELOPMENT_TEAM=${teamId}`,
+-    `CODE_SIGN_IDENTITY=${signingIdentity ?? 'Apple Development'}`,
+-  ];
++  if (!signing) {
++    return ['CODE_SIGNING_ALLOWED=NO', 'CODE_SIGNING_REQUIRED=NO'];
++  }
++
++  const args: string[] = [];
++
++  if (signing.teamId) {
++    args.push('CODE_SIGN_STYLE=Automatic');
++    args.push(`DEVELOPMENT_TEAM=${signing.teamId}`);
+ 
+-  if (provisioningProfile) {
+-    args.push(`PROVISIONING_PROFILE_SPECIFIER=${provisioningProfile}`);
++    if (signing.signingIdentity) {
++      args.push(`CODE_SIGN_IDENTITY=${signing.signingIdentity}`);
++    } else {
++      args.push('CODE_SIGN_IDENTITY=Apple Development');
++    }
++  } else if (signing.signingIdentity) {
++    args.push(`CODE_SIGN_IDENTITY=${signing.signingIdentity}`);
++  }
++
++  if (signing.provisioningProfile) {
++    args.push(
++      `PROVISIONING_PROFILE_SPECIFIER=${signing.provisioningProfile}`
++    );
+   }
+ 
+   return args;
+@@ -177,11 +251,9 @@ const getXCTestAgentSourceFilePath = (): string => {
+ };
+ 
+ const readBuildManifest = (
+-  target: XCTestAgentTarget
++  derivedDataPath: string
+ ): XCTestAgentBuildManifest | null => {
+-  const manifestPath = getXCTestAgentBuildManifestPath(
+-    getXCTestAgentDerivedDataPath(target)
+-  );
++  const manifestPath = getXCTestAgentBuildManifestPath(derivedDataPath);
+ 
+   if (!fs.existsSync(manifestPath)) {
+     return null;
+@@ -193,12 +265,12 @@ const readBuildManifest = (
+ };
+ 
+ const writeBuildManifest = (
+-  target: XCTestAgentTarget,
++  derivedDataPath: string,
+   manifest: XCTestAgentBuildManifest
+ ) => {
+-  fs.mkdirSync(getXCTestAgentDerivedDataPath(target), { recursive: true });
++  fs.mkdirSync(derivedDataPath, { recursive: true });
+   fs.writeFileSync(
+-    getXCTestAgentBuildManifestPath(getXCTestAgentDerivedDataPath(target)),
++    getXCTestAgentBuildManifestPath(derivedDataPath),
+     JSON.stringify(manifest, null, 2)
+   );
+ };
+@@ -279,7 +351,6 @@ const readSimulatorBuildManifest = (
+     manifest.destinationKind !== 'simulator' ||
+     typeof manifest.buildInputsHash !== 'string' ||
+     typeof manifest.hostArchitecture !== 'string' ||
+-    typeof manifest.simulatorRuntime !== 'string' ||
+     typeof manifest.simulatorSdkVersion !== 'string' ||
+     typeof manifest.xcodeVersion !== 'string' ||
+     typeof manifest.xctestrunRelativePath !== 'string'
+@@ -313,8 +384,6 @@ const getSimulatorCacheDirectoryName = (
+   hash.update('\0');
+   hash.update(context.hostArchitecture);
+   hash.update('\0');
+-  hash.update(context.simulatorRuntime);
+-  hash.update('\0');
+   hash.update(context.simulatorSdkVersion);
+   hash.update('\0');
+   hash.update(context.xcodeVersion);
+@@ -325,16 +394,19 @@ const getSimulatorCacheDirectoryName = (
+ };
+ 
+ const getSimulatorCacheDerivedDataPath = (
+-  context: SimulatorXCTestAgentCacheContext
++  context: SimulatorXCTestAgentCacheContext,
++  projectRoot = process.cwd()
+ ): string => {
++  const cacheRoot = getXCTestAgentCacheRoot(projectRoot);
++
+   return path.join(
+-    getXCTestAgentCacheRoot(),
++    cacheRoot,
+     getSimulatorCacheDirectoryName(context)
+   );
+ };
+ 
+-const getHarnessCacheDirectories = (): string[] => {
+-  const cacheRoot = getXCTestAgentCacheRoot();
++const getHarnessCacheDirectories = (projectRoot = process.cwd()): string[] => {
++  const cacheRoot = getXCTestAgentCacheRoot(projectRoot);
+ 
+   if (!fs.existsSync(cacheRoot)) {
+     return [];
+@@ -354,16 +426,16 @@ const isCompatibleSimulatorBuildManifest = (
+   return (
+     manifest.buildInputsHash === context.buildInputsHash &&
+     manifest.hostArchitecture === context.hostArchitecture &&
+-    manifest.simulatorRuntime === context.simulatorRuntime &&
+     manifest.simulatorSdkVersion === context.simulatorSdkVersion &&
+     manifest.xcodeVersion === context.xcodeVersion
+   );
+ };
+ 
+ const findReusableSimulatorBuildArtifacts = (
+-  context: SimulatorXCTestAgentCacheContext
++  context: SimulatorXCTestAgentCacheContext,
++  projectRoot = process.cwd()
+ ): string | null => {
+-  for (const derivedDataPath of getHarnessCacheDirectories()) {
++  for (const derivedDataPath of getHarnessCacheDirectories(projectRoot)) {
+     const manifest = readSimulatorBuildManifest(derivedDataPath);
+ 
+     if (!manifest || !isCompatibleSimulatorBuildManifest(manifest, context)) {
+@@ -400,78 +472,228 @@ const getCurrentSimulatorSdkVersion = async (): Promise<string> => {
+   return stdout.trim();
+ };
+ 
+-const getCurrentSimulatorRuntime = async (
+-  simulatorId: string
+-): Promise<string> => {
+-  const simulators = await getSimulators();
+-  const simulator = simulators.find(
+-    (candidate) => candidate.udid === simulatorId
+-  );
+-
+-  if (!simulator) {
+-    throw new Error(`Simulator with UDID ${simulatorId} not found`);
+-  }
+-
+-  return simulator.runtime;
+-};
+-
+ const getSimulatorCacheContext = async (
+-  target: Extract<XCTestAgentTarget, { kind: 'simulator' }>,
+   buildInputsHash: string
+ ): Promise<SimulatorXCTestAgentCacheContext> => {
+-  const [xcodeVersion, simulatorSdkVersion, simulatorRuntime] =
+-    await Promise.all([
+-      getCurrentXcodeVersion(),
+-      getCurrentSimulatorSdkVersion(),
+-      getCurrentSimulatorRuntime(target.id),
+-    ]);
++  const [xcodeVersion, simulatorSdkVersion] = await Promise.all([
++    getCurrentXcodeVersion(),
++    getCurrentSimulatorSdkVersion(),
++  ]);
+ 
+   return {
+     buildInputsHash,
+     hostArchitecture: process.arch,
+-    simulatorRuntime,
+     simulatorSdkVersion,
+     xcodeVersion,
+   };
+ };
+ 
+-const shouldReuseBuildArtifacts = (
+-  target: XCTestAgentTarget,
+-  buildInputsHash: string
+-): boolean => {
+-  if (target.kind === 'simulator') {
++const shouldReuseBuildArtifacts = (options: {
++  buildInputsHash: string;
++  derivedDataPath: string;
++  destination: XCTestAgentBuildDestination;
++  signing?: XCTestAgentBuildSigning;
++}): boolean => {
++  if (options.destination === 'simulator') {
+     throw new Error(
+       'Simulator build reuse must be validated with cache compatibility metadata'
+     );
+   }
+ 
+-  const manifest = readBuildManifest(target);
++  const manifest = readBuildManifest(options.derivedDataPath);
+ 
+   if (!manifest) {
+     return false;
+   }
+ 
+   if (
+-    manifest.buildInputsHash !== buildInputsHash ||
+-    manifest.destinationKind !== target.kind
++    manifest.buildInputsHash !== options.buildInputsHash ||
++    manifest.destinationKind !== options.destination
+   ) {
+     return false;
+   }
+ 
+-  if (target.kind === 'device') {
+-    if (
+-      manifest.codeSign?.teamId !== target.codeSign.teamId ||
+-      manifest.codeSign?.signingIdentity !== target.codeSign.signingIdentity ||
+-      manifest.codeSign?.provisioningProfile !==
+-        target.codeSign.provisioningProfile
+-    ) {
+-      return false;
++  if (
++    manifest.signing?.teamId !== options.signing?.teamId ||
++    manifest.signing?.signingIdentity !== options.signing?.signingIdentity ||
++    manifest.signing?.provisioningProfile !==
++      options.signing?.provisioningProfile
++  ) {
++    return false;
++  }
++
++  const buildProductsPath = getXCTestAgentBuildProductsPath(
++    options.derivedDataPath
++  );
++
++  return fs.existsSync(buildProductsPath);
 +};
 +
- const getXCTestAgentBuildManifestPath = (derivedDataPath: string): string =>
-   path.join(derivedDataPath, 'build-manifest.json');
++const getXCTestRunPath = (derivedDataPath: string): string | undefined => {
++  const xctestrunRelativePath = getXCTestRunRelativePath(derivedDataPath);
++
++  if (!xctestrunRelativePath) {
++    return undefined;
++  }
++
++  const buildProductsPath = getXCTestAgentBuildProductsPath(derivedDataPath);
++  return path.join(buildProductsPath, xctestrunRelativePath);
++};
++
++export const buildXCTestAgent = async (
++  options: BuildXCTestAgentOptions
++): Promise<BuildXCTestAgentResult> => {
++  const projectRoot = options.projectRoot ?? process.cwd();
++  const buildInputsHash = getProjectInputsHash();
++  let derivedDataPath = getXCTestAgentDerivedDataPath(
++    options.destination,
++    projectRoot
++  );
++  let simulatorCacheContext: SimulatorXCTestAgentCacheContext | undefined;
++
++  xctestAgentLogger.debug(
++    'verifying checked-in XCTest agent project for %s',
++    options.destination
++  );
++  xctestAgentLogger.info(
++    'Using checked-in XCTest agent project for %s target',
++    options.destination
++  );
++  assertXCTestAgentProjectExists();
++
++  if (options.destination === 'simulator') {
++    simulatorCacheContext = await getSimulatorCacheContext(buildInputsHash);
++    const reusableDerivedDataPath = findReusableSimulatorBuildArtifacts(
++      simulatorCacheContext,
++      projectRoot
++    );
++
++    if (reusableDerivedDataPath) {
++      xctestAgentLogger.info(
++        'Reusing cached XCTest agent build for %s target',
++        options.destination
++      );
++      xctestAgentLogger.debug(
++        'reusing cached XCTest agent build for %s',
++        options.destination
++      );
++
++      return {
++        destination: options.destination,
++        derivedDataPath: reusableDerivedDataPath,
++        reused: true,
++        xctestrunPath: getXCTestRunPath(reusableDerivedDataPath),
++      };
++    }
++
++    derivedDataPath = getSimulatorCacheDerivedDataPath(
++      simulatorCacheContext,
++      projectRoot
++    );
++  } else {
++    const canReuseBuild = shouldReuseBuildArtifacts({
++      buildInputsHash,
++      derivedDataPath,
++      destination: options.destination,
++      signing: options.signing,
++    });
++
++    if (canReuseBuild) {
++      xctestAgentLogger.info(
++        'Reusing cached XCTest agent build for %s target',
++        options.destination
++      );
++      xctestAgentLogger.debug(
++        'reusing cached XCTest agent build for %s',
++        options.destination
++      );
++
++      return {
++        destination: options.destination,
++        derivedDataPath,
++        reused: true,
++        xctestrunPath: getXCTestRunPath(derivedDataPath),
++      };
++    }
++  }
++
++  fs.mkdirSync(derivedDataPath, { recursive: true });
++
++  xctestAgentLogger.debug('building XCTest agent for %s', options.destination);
++  xctestAgentLogger.info(
++    'Building XCTest agent for %s target',
++    options.destination
++  );
++
++  const signingArgs = getXCTestAgentBuildSigningArgs(
++    options.destination,
++    options.signing
++  );
++  const provisioningArgs: string[] = [];
++
++  if (options.destination === 'device' && options.signing?.teamId) {
++    provisioningArgs.push('-allowProvisioningUpdates');
++  }
++
++  const buildArgs = [
++    'build-for-testing',
++    '-project',
++    getXCTestAgentProjectFilePath(),
++    '-scheme',
++    XCTEST_AGENT_SCHEME_NAME,
++    '-destination',
++    getXCTestAgentBuildDestination(options.destination),
++    '-derivedDataPath',
++    derivedDataPath,
++    ...provisioningArgs,
++    ...signingArgs,
++  ];
++
++  await spawn('xcodebuild', buildArgs);
++
++  const xctestrunRelativePath = getXCTestRunRelativePath(derivedDataPath);
++
++  if (!xctestrunRelativePath) {
++    const buildProductsPath = getXCTestAgentBuildProductsPath(derivedDataPath);
++    throw new Error(`Missing generated .xctestrun file in ${buildProductsPath}`);
++  }
++
++  if (options.destination === 'simulator') {
++    if (!simulatorCacheContext) {
++      throw new Error('Missing simulator cache context for XCTest agent build');
+     }
++
++    writeSimulatorBuildManifest(derivedDataPath, {
++      artifactName: XCTEST_AGENT_SIMULATOR_CACHE_ARTIFACT,
++      buildInputsHash,
++      destinationKind: 'simulator',
++      hostArchitecture: simulatorCacheContext.hostArchitecture,
++      schemaVersion: XCTEST_AGENT_SIMULATOR_CACHE_SCHEMA_VERSION,
++      simulatorSdkVersion: simulatorCacheContext.simulatorSdkVersion,
++      xcodeVersion: simulatorCacheContext.xcodeVersion,
++      xctestrunRelativePath,
++    });
++  } else {
++    writeBuildManifest(derivedDataPath, {
++      buildInputsHash,
++      destinationKind: options.destination,
++      signing: options.signing,
++    });
+   }
  
-@@ -724,6 +755,24 @@ export const createXCTestAgentController = (options: {
+-  return fs.existsSync(
+-    getXCTestAgentBuildProductsPath(getXCTestAgentDerivedDataPath(target))
++  xctestAgentLogger.info(
++    'Built XCTest agent for %s target',
++    options.destination
+   );
++
++  const buildProductsPath = getXCTestAgentBuildProductsPath(derivedDataPath);
++
++  return {
++    destination: options.destination,
++    derivedDataPath,
++    reused: false,
++    xctestrunPath: path.join(buildProductsPath, xctestrunRelativePath),
++  };
+ };
+ 
+ const getDefaultRuntimeConfiguration = (): XCTestAgentRuntimeConfiguration => {
+@@ -688,7 +910,7 @@ export const createXCTestAgentController = (options: {
+     logArtifacts.directoryPath,
+     'xcodebuild.log'
+   );
+-  let preparedDerivedDataPath = getXCTestAgentDerivedDataPath(target);
++  let preparedDerivedDataPath = getXCTestAgentDerivedDataPath(target.kind);
+   let prepared = false;
+   let agentProcess: Subprocess | null = null;
+   let agentClient: ReturnType<typeof createXCTestAgentClient> | null = null;
+@@ -724,104 +946,35 @@ export const createXCTestAgentController = (options: {
        return;
      }
  
+-    const buildInputsHash = getProjectInputsHash();
+-
+-    xctestAgentLogger.debug(
+-      'verifying checked-in XCTest agent project for %s',
+-      target.kind
+-    );
+-    xctestAgentLogger.info(
+-      'Using checked-in XCTest agent project for %s target',
+-      target.kind
+-    );
+-    assertXCTestAgentProjectExists();
 +    const externalXCTestRunFilePath = getExternalXCTestRunFilePath();
 +    if (externalXCTestRunFilePath) {
 +      assertExternalXCTestRunFileExists(externalXCTestRunFilePath);
-+
+ 
+-    if (target.kind === 'simulator') {
+-      const cacheContext = await getSimulatorCacheContext(
+-        target,
+-        buildInputsHash
+-      );
+-      const reusableDerivedDataPath =
+-        findReusableSimulatorBuildArtifacts(cacheContext);
+-
+-      if (reusableDerivedDataPath) {
+-        preparedDerivedDataPath = reusableDerivedDataPath;
+-        prepared = true;
+-        xctestAgentLogger.info(
+-          'Reusing cached XCTest agent build for %s target',
+-          target.kind
+-        );
+-        xctestAgentLogger.debug(
+-          'reusing cached XCTest agent build for %s',
+-          target.kind
+-        );
+-        return;
 +      const externalDerivedDataPath = getExternalDerivedDataPath();
 +      if (externalDerivedDataPath) {
 +        preparedDerivedDataPath = externalDerivedDataPath;
-+      }
-+
-+      prepared = true;
-+      xctestAgentLogger.info(
+       }
+ 
+-      preparedDerivedDataPath = getSimulatorCacheDerivedDataPath(cacheContext);
+-    } else if (shouldReuseBuildArtifacts(target, buildInputsHash)) {
+       prepared = true;
+       xctestAgentLogger.info(
+-        'Reusing cached XCTest agent build for %s target',
+-        target.kind
+-      );
+-      xctestAgentLogger.debug(
+-        'reusing cached XCTest agent build for %s',
+-        target.kind
 +        'Using external XCTest run file for %s target: %s',
 +        target.kind,
 +        externalXCTestRunFilePath
-+      );
-+      return;
-+    }
-+
-     const buildInputsHash = getProjectInputsHash();
+       );
+       return;
+     }
  
-     xctestAgentLogger.debug(
-@@ -841,12 +890,23 @@ export const createXCTestAgentController = (options: {
+-    fs.mkdirSync(preparedDerivedDataPath, { recursive: true });
+-
+-    xctestAgentLogger.debug('building XCTest agent for %s', target.kind);
+-    xctestAgentLogger.info('Building XCTest agent for %s target', target.kind);
+-    await spawn('xcodebuild', [
+-      'build-for-testing',
+-      '-project',
+-      getXCTestAgentProjectFilePath(),
+-      '-scheme',
+-      XCTEST_AGENT_SCHEME_NAME,
+-      '-destination',
+-      getXCTestAgentBuildDestination(target),
+-      '-derivedDataPath',
+-      preparedDerivedDataPath,
+-      ...(target.kind === 'device' ? ['-allowProvisioningUpdates'] : []),
+-      ...getXCTestAgentBuildSigningArgs(target),
+-    ]);
+-
+-    if (target.kind === 'simulator') {
+-      const cacheContext = await getSimulatorCacheContext(
+-        target,
+-        buildInputsHash
+-      );
+-      const xctestrunRelativePath = getXCTestRunRelativePath(
+-        preparedDerivedDataPath
+-      );
++    let signing: XCTestAgentBuildSigning | undefined;
++    if (target.kind === 'device') {
++      signing = target.codeSign;
++    }
+ 
+-      if (!xctestrunRelativePath) {
+-        throw new Error(
+-          `Missing generated .xctestrun file in ${getXCTestAgentBuildProductsPath(
+-            preparedDerivedDataPath
+-          )}`
+-        );
+-      }
++    const buildResult = await buildXCTestAgent({
++      destination: target.kind,
++      signing,
++    });
+ 
+-      writeSimulatorBuildManifest(preparedDerivedDataPath, {
+-        artifactName: XCTEST_AGENT_SIMULATOR_CACHE_ARTIFACT,
+-        destinationKind: 'simulator',
+-        schemaVersion: XCTEST_AGENT_SIMULATOR_CACHE_SCHEMA_VERSION,
+-        xctestrunRelativePath,
+-        ...cacheContext,
+-      });
+-    } else {
+-      writeBuildManifest(target, {
+-        buildInputsHash,
+-        destinationKind: target.kind,
+-        codeSign: target.codeSign,
+-      });
+-    }
+-    xctestAgentLogger.info('Built XCTest agent for %s target', target.kind);
++    preparedDerivedDataPath = buildResult.derivedDataPath;
+     prepared = true;
+   };
+ 
+@@ -841,12 +994,23 @@ export const createXCTestAgentController = (options: {
        target.kind
      );
      xctestAgentLogger.debug('Using XCTest agent port %d', port);

--- a/patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fplatform-apple@1.2.0-rc.1.patch
@@ -1,0 +1,186 @@
+diff --git a/dist/xctest-agent.js b/dist/xctest-agent.js
+index 837e6a141ddedeadff87b2c5b7e891d248323019..e28ac2bb10281b560a846d588a98525a93e31d8f 100644
+--- a/dist/xctest-agent.js
++++ b/dist/xctest-agent.js
+@@ -14,6 +14,8 @@ const XCTEST_AGENT_PROJECT_NAME = 'HarnessXCTestAgent';
+ const XCTEST_AGENT_SCHEME_NAME = 'HarnessXCTestAgent';
+ const XCTEST_AGENT_PORT_ENV = 'HARNESS_XCTEST_AGENT_PORT';
+ const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV = 'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID';
++const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
++const XCTEST_AGENT_DERIVED_DATA_PATH_ENV = 'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+ const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+@@ -44,6 +46,25 @@ const getXCTestAgentCacheRoot = () => {
+ const getXCTestAgentDerivedDataPath = (target) => {
+     return path.join(getXCTestAgentBuildRoot(), target.kind);
+ };
++const getEnvironmentPath = (name) => {
++    const value = process.env[name]?.trim();
++    if (!value) {
++        return null;
++    }
++    return value;
++};
++const getExternalXCTestRunFilePath = () => {
++    return getEnvironmentPath(XCTEST_AGENT_XCTESTRUN_FILE_ENV);
++};
++const getExternalDerivedDataPath = () => {
++    return getEnvironmentPath(XCTEST_AGENT_DERIVED_DATA_PATH_ENV);
++};
++const assertExternalXCTestRunFileExists = (filePath) => {
++    if (fs.existsSync(filePath)) {
++        return;
++    }
++    throw new Error(`Missing external XCTest run file at ${filePath}. Check ${XCTEST_AGENT_XCTESTRUN_FILE_ENV}.`);
++};
+ const getXCTestAgentBuildManifestPath = (derivedDataPath) => path.join(derivedDataPath, 'build-manifest.json');
+ const getXCTestAgentCacheManifestPath = (derivedDataPath) => path.join(derivedDataPath, 'cache.json');
+ const getXCTestAgentBuildDestination = (target) => {
+@@ -427,6 +448,17 @@ export const createXCTestAgentController = (options) => {
+         if (prepared) {
+             return;
+         }
++        const externalXCTestRunFilePath = getExternalXCTestRunFilePath();
++        if (externalXCTestRunFilePath) {
++            assertExternalXCTestRunFileExists(externalXCTestRunFilePath);
++            const externalDerivedDataPath = getExternalDerivedDataPath();
++            if (externalDerivedDataPath) {
++                preparedDerivedDataPath = externalDerivedDataPath;
++            }
++            prepared = true;
++            xctestAgentLogger.info('Using external XCTest run file for %s target: %s', target.kind, externalXCTestRunFilePath);
++            return;
++        }
+         const buildInputsHash = getProjectInputsHash();
+         xctestAgentLogger.debug('verifying checked-in XCTest agent project for %s', target.kind);
+         xctestAgentLogger.info('Using checked-in XCTest agent project for %s target', target.kind);
+@@ -499,12 +531,22 @@ export const createXCTestAgentController = (options) => {
+         xctestAgentLogger.debug('starting XCTest agent for %s', target.kind);
+         xctestAgentLogger.info('Starting XCTest agent session for %s target', target.kind);
+         xctestAgentLogger.debug('Using XCTest agent port %d', port);
++        const externalXCTestRunFilePath = getExternalXCTestRunFilePath();
++        let xcodebuildRunInputArgs;
++        if (externalXCTestRunFilePath) {
++            xcodebuildRunInputArgs = ['-xctestrun', externalXCTestRunFilePath];
++        }
++        else {
++            xcodebuildRunInputArgs = [
++                '-project',
++                getXCTestAgentProjectFilePath(),
++                '-scheme',
++                XCTEST_AGENT_SCHEME_NAME,
++            ];
++        }
+         const xcodebuildArgs = [
+             'test-without-building',
+-            '-project',
+-            getXCTestAgentProjectFilePath(),
+-            '-scheme',
+-            XCTEST_AGENT_SCHEME_NAME,
++            ...xcodebuildRunInputArgs,
+             '-destination',
+             getXCTestAgentRunDestination(target),
+             '-parallel-testing-enabled',
+diff --git a/src/xctest-agent.ts b/src/xctest-agent.ts
+index cdbb3187bcfc07ac812dd7d5990e9d23220dfdf6..9716c1beb6d210b9ca39b2139ce5b1d53e0f6f3a 100644
+--- a/src/xctest-agent.ts
++++ b/src/xctest-agent.ts
+@@ -29,6 +29,9 @@ const XCTEST_AGENT_SCHEME_NAME = 'HarnessXCTestAgent';
+ const XCTEST_AGENT_PORT_ENV = 'HARNESS_XCTEST_AGENT_PORT';
+ const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV =
+   'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID';
++const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
++const XCTEST_AGENT_DERIVED_DATA_PATH_ENV =
++  'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+ const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+@@ -125,6 +128,34 @@ const getXCTestAgentDerivedDataPath = (target: XCTestAgentTarget): string => {
+   return path.join(getXCTestAgentBuildRoot(), target.kind);
+ };
+ 
++const getEnvironmentPath = (name: string): string | null => {
++  const value = process.env[name]?.trim();
++
++  if (!value) {
++    return null;
++  }
++
++  return value;
++};
++
++const getExternalXCTestRunFilePath = (): string | null => {
++  return getEnvironmentPath(XCTEST_AGENT_XCTESTRUN_FILE_ENV);
++};
++
++const getExternalDerivedDataPath = (): string | null => {
++  return getEnvironmentPath(XCTEST_AGENT_DERIVED_DATA_PATH_ENV);
++};
++
++const assertExternalXCTestRunFileExists = (filePath: string) => {
++  if (fs.existsSync(filePath)) {
++    return;
++  }
++
++  throw new Error(
++    `Missing external XCTest run file at ${filePath}. Check ${XCTEST_AGENT_XCTESTRUN_FILE_ENV}.`
++  );
++};
++
+ const getXCTestAgentBuildManifestPath = (derivedDataPath: string): string =>
+   path.join(derivedDataPath, 'build-manifest.json');
+ 
+@@ -724,6 +755,24 @@ export const createXCTestAgentController = (options: {
+       return;
+     }
+ 
++    const externalXCTestRunFilePath = getExternalXCTestRunFilePath();
++    if (externalXCTestRunFilePath) {
++      assertExternalXCTestRunFileExists(externalXCTestRunFilePath);
++
++      const externalDerivedDataPath = getExternalDerivedDataPath();
++      if (externalDerivedDataPath) {
++        preparedDerivedDataPath = externalDerivedDataPath;
++      }
++
++      prepared = true;
++      xctestAgentLogger.info(
++        'Using external XCTest run file for %s target: %s',
++        target.kind,
++        externalXCTestRunFilePath
++      );
++      return;
++    }
++
+     const buildInputsHash = getProjectInputsHash();
+ 
+     xctestAgentLogger.debug(
+@@ -841,12 +890,23 @@ export const createXCTestAgentController = (options: {
+       target.kind
+     );
+     xctestAgentLogger.debug('Using XCTest agent port %d', port);
++    const externalXCTestRunFilePath = getExternalXCTestRunFilePath();
++    let xcodebuildRunInputArgs: string[];
++
++    if (externalXCTestRunFilePath) {
++      xcodebuildRunInputArgs = ['-xctestrun', externalXCTestRunFilePath];
++    } else {
++      xcodebuildRunInputArgs = [
++        '-project',
++        getXCTestAgentProjectFilePath(),
++        '-scheme',
++        XCTEST_AGENT_SCHEME_NAME,
++      ];
++    }
++
+     const xcodebuildArgs = [
+       'test-without-building',
+-      '-project',
+-      getXCTestAgentProjectFilePath(),
+-      '-scheme',
+-      XCTEST_AGENT_SCHEME_NAME,
++      ...xcodebuildRunInputArgs,
+       '-destination',
+       getXCTestAgentRunDestination(target),
+       '-parallel-testing-enabled',


### PR DESCRIPTION
The new pipeline looks like this: 

<img width="1034" height="248" alt="Screenshot 2026-05-12 at 14 02 20" src="https://github.com/user-attachments/assets/f112fd52-f0c1-4aab-b0e4-7643768efe85" />

Android and iOS now work differently in terms of test execution on AWS, which also means that there is no shared test package between the two platforms (as it was before).

For iOS we now have to build a unsigned XCTest artifact. To AWS we now upload:
- our native app, ipa, unsigned
- the XCTest ipa, unsigned
- Our node project containing the harness tests

On upload AWS will sign the ipa artifacts for us so that they can be installed on AWS's iPhones.
In order to upload and sign an XCTest artifact we had to switch the AWS test type for iOS to `XCTEST_UI`. Luckily though, that changes nothing about the connected host runner so we can still run our nodeJS stuff for harness!

For harness we applied the following PRs as patches:

- PR for building XCTest standalone:
  - https://github.com/callstackincubator/react-native-harness/pull/117
- PR for injecting an external XCTest artifact:
  - https://github.com/callstackincubator/react-native-harness/pull/116