### PR TITLE
fix: Windows CMake/Ninja paths issue + Gradle 9 bundle/codegen ordering for barcode-scanner

### DIFF
--- a/packages/react-native-vision-camera-barcode-scanner/android/build.gradle
+++ b/packages/react-native-vision-camera-barcode-scanner/android/build.gradle
@@ -35,6 +35,17 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["VisionCameraBarcodeScanner_" + name]).toInteger()
 }
 
+def isWindowsOs() {
+  return System.properties["os.name"].toLowerCase().contains("windows")
+}
+
+// Windows: CMake/Ninja default next to this module (often deep under node_modules), exceeding
+// path limits. Relocate under root android/build (standard Gradle output, already gitignored).
+if (isWindowsOs()) {
+  def safeName = project.name.replace(":", "_")
+  project.buildDir = new File(rootProject.buildDir, "externalNativeModules/${safeName}")
+}
+
 android {
   namespace "com.margelo.nitro.camera.barcodescanner"
 
@@ -67,6 +78,9 @@ android {
   externalNativeBuild {
     cmake {
       path "CMakeLists.txt"
+      if (isWindowsOs()) {
+        buildStagingDirectory = new File(project.buildDir, "cxx")
+      }
     }
   }
 
@@ -150,3 +164,19 @@ dependencies {
   implementation project(":react-native-vision-camera")
 }
 
+// Gradle 9 validates task dependencies: JS bundle tasks read New Architecture codegen
+// outputs from libraries. Wire bundle tasks to this module's codegen when present.
+gradle.projectsEvaluated {
+  def codegenTask = tasks.findByName("generateCodegenArtifactsFromSchema")
+  if (codegenTask != null) {
+    rootProject.subprojects.each { sub ->
+      if (sub.plugins.hasPlugin("com.android.application")) {
+        sub.tasks.matching { t ->
+          t.name.startsWith("createBundle") && t.name.endsWith("JsAndAssets")
+        }.configureEach { t ->
+          t.dependsOn(codegenTask)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION

## Summary

Improves `react-native-vision-camera-barcode-scanner` Android builds on **Windows** and with **Gradle 9** / React Native **New Architecture** by relocating native/Gradle outputs under the host app’s standard **`android/build/`** tree (no extra top-level folders), and by declaring an explicit task ordering between Hermes bundle tasks and this library’s codegen output.

## Problem

1. **Long paths on Windows**  
   The library often resolves under a deep `node_modules/...` tree. Android Gradle Plugin still places **CMake/Ninja** output in a `.cxx` tree derived from the module location, so object file paths can exceed practical **Ninja/CMake** limits. Symptoms include CMake repeatedly re-running and:
   `ninja: error: manifest 'build.ninja' still dirty after 100 tries`.

2. **Gradle 9 configuration validation**  
   With New Architecture enabled, `:app:createBundle*JsAndAssets` can consume outputs from `:react-native-vision-camera-barcode-scanner:generateCodegenArtifactsFromSchema` without an explicit dependency, which Gradle 9 reports as a misconfiguration.

## Solution

- **Windows only** (detected via `os.name`):
  - Set `project.buildDir` to **`android/build/externalNativeModules/<sanitized-project-name>`** (under `rootProject.buildDir`), so library outputs stay in the normal Gradle build output tree.
  - Set `externalNativeBuild.cmake.buildStagingDirectory` to **`${project.buildDir}/cxx`** so CMake/Ninja staging is short and colocated with that module’s relocated `buildDir`.

- **All platforms** (when the React Gradle plugin registers codegen on this project):
  - In `gradle.projectsEvaluated`, find `generateCodegenArtifactsFromSchema` on this project and register `dependsOn` from every application subproject’s `createBundle*JsAndAssets` tasks.

## Notes

- Does **not** add `-DCMAKE_OBJECT_PATH_MAX=...`: Android SDK CMake is often **3.22.x**, while that flag targets **CMake 3.26+**; relocation addresses the root cause without relying on newer CMake.
- Uses **`rootProject.buildDir`** so paths stay correct for the usual React Native layout where the Gradle root is the `android/` project.
