### PR TITLE
docs: Make callable members with args reflect `(...)`

### DIFF
--- a/docs/scripts/typedoc-frontmatter.mts
+++ b/docs/scripts/typedoc-frontmatter.mts
@@ -17,6 +17,7 @@ import {
   orderPlatformLabelsWithOrder,
 } from '../src/lib/shared/platforms-core.ts'
 import { annotateProjectOwnTypeLevelDocumentation } from '../src/lib/typedoc/inherited-type-level-comments.ts'
+import { getMemberCallSuffix } from '../src/lib/typedoc/member-heading.ts'
 import {
   createHybridInterfaceResolver,
   getDirectHybridParentName,
@@ -173,11 +174,10 @@ function getMemberHeadingTitle(
     return null
   }
 
-  const hasSignatures =
-    Array.isArray(reflection.signatures) && reflection.signatures.length > 0
+  const callSuffix = getMemberCallSuffix(reflection)
   const isOptional = reflection.flags?.isOptional === true
 
-  return `${reflection.name}${hasSignatures ? '()' : ''}${isOptional ? '?' : ''}`
+  return `${reflection.name}${callSuffix}${isOptional ? '?' : ''}`
 }
 
 function collectMemberPlatformsByHeading(

--- a/docs/scripts/typedoc-theme.mts
+++ b/docs/scripts/typedoc-theme.mts
@@ -19,6 +19,7 @@ import {
   MarkdownThemeContext,
 } from 'typedoc-plugin-markdown'
 import { shouldSuppressInheritedTypeLevelComment } from '../src/lib/typedoc/inherited-type-level-comments.ts'
+import { getMemberCallSuffix } from '../src/lib/typedoc/member-heading.ts'
 
 type CommentTag = {
   tag: string
@@ -319,8 +320,16 @@ class VisionCameraThemeContext extends MarkdownThemeContext {
       declaration: this.partials.declaration,
       declarationTitle: this.partials.declarationTitle,
       inheritance: this.partials.inheritance,
+      memberTitle: this.partials.memberTitle,
       memberWithGroups: this.partials.memberWithGroups,
       signatureTitle: this.partials.signatureTitle,
+    }
+
+    this.partials.memberTitle = (model) => {
+      const title = originalPartials.memberTitle(model)
+      return getMemberCallSuffix(model) === '(...)'
+        ? title.replace('()', '(...)')
+        : title
     }
 
     this.partials.accessor = (model, options) =>

--- a/docs/scripts/typedoc-theme.mts
+++ b/docs/scripts/typedoc-theme.mts
@@ -325,12 +325,11 @@ class VisionCameraThemeContext extends MarkdownThemeContext {
       signatureTitle: this.partials.signatureTitle,
     }
 
-    this.partials.memberTitle = (model) => {
-      const title = originalPartials.memberTitle(model)
-      return getMemberCallSuffix(model) === '(...)'
-        ? title.replace('()', '(...)')
-        : title
-    }
+    this.partials.memberTitle = (model) =>
+      originalPartials.memberTitle(model).replace(
+        '()',
+        getMemberCallSuffix(model),
+      )
 
     this.partials.accessor = (model, options) =>
       this.renderAccessor(model, options)

--- a/docs/scripts/verify-api-output.mts
+++ b/docs/scripts/verify-api-output.mts
@@ -515,7 +515,7 @@ function main(): void {
   assertFileContains(cameraPhotoOutputPath, '> [!NOTE] Note')
   const saveToFileAsyncSection = getMethodSectionBody(
     photoPageText,
-    'saveToFileAsync()',
+    'saveToFileAsync(...)',
   )
   if (saveToFileAsyncSection == null) {
     throw new Error('Expected Photo.saveToFileAsync() section to be present.')

--- a/docs/src/lib/typedoc/member-heading.ts
+++ b/docs/src/lib/typedoc/member-heading.ts
@@ -1,0 +1,49 @@
+import type { DeclarationReflection, SignatureReflection } from 'typedoc'
+
+function getTypeDeclaration(
+  reflection: DeclarationReflection,
+): DeclarationReflection | undefined {
+  const type = reflection.type
+  if (type == null || typeof type !== 'object' || !('declaration' in type)) {
+    return undefined
+  }
+  return (type as { declaration?: DeclarationReflection }).declaration
+}
+
+function hasCallableSignatures(reflection: DeclarationReflection): boolean {
+  const typeDeclaration = getTypeDeclaration(reflection)
+  if (typeDeclaration?.children?.length) {
+    return false
+  }
+  return (
+    Boolean(reflection.signatures?.length) ||
+    Boolean(typeDeclaration?.signatures?.length)
+  )
+}
+
+function collectSignatures(
+  reflection: DeclarationReflection,
+): SignatureReflection[] {
+  return [
+    ...(reflection.signatures ?? []),
+    ...(getTypeDeclaration(reflection)?.signatures ?? []),
+  ]
+}
+
+/**
+ * Returns the suffix shown after a member name in method-style headings:
+ *   - `''`   for non-callable members
+ *   - `'()'` for callable members that take no arguments
+ *   - `'(...)'` for callable members with one or more parameters in any signature
+ */
+export function getMemberCallSuffix(
+  reflection: DeclarationReflection,
+): '' | '()' | '(...)' {
+  if (!hasCallableSignatures(reflection)) {
+    return ''
+  }
+  const takesArguments = collectSignatures(reflection).some(
+    (signature) => (signature.parameters?.length ?? 0) > 0,
+  )
+  return takesArguments ? '(...)' : '()'
+}


### PR DESCRIPTION
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="100%" alt="Screenshot 2026-05-12 at 11 29 02" src="https://github.com/user-attachments/assets/8feb1633-b73f-4900-b8dc-a173304b5ed9" />
</td>
<td>
<img width="100%" alt="Screenshot 2026-05-12 at 11 29 34" src="https://github.com/user-attachments/assets/3b8ce76d-23fa-4bfb-937a-80f66290231f" />
</td>

</tr>
</table>

