### PR TITLE
feat: Add `supportsTorchStrength`, `minTorchStrength`, `maxTorchStrength` and `enableTorchWithStrength(...)`

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -150,7 +150,9 @@ describe('VisionCamera - Controller', () => {
       return
     }
     if (!backDevice.supportsTorchStrength) {
-      console.log('[SKIP] torch strength: device does not support custom strength')
+      console.log(
+        '[SKIP] torch strength: device does not support custom strength',
+      )
       return
     }
     const session = await VisionCamera.createCameraSession(false)

--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -134,10 +134,51 @@ describe('VisionCamera - Controller', () => {
     await session.start()
 
     try {
-      // TODO: Add setTorchMode('on', STRENGTH) test when we expose something like
-      //       CameraDevice.supportsTorchStrength - currently this might throw on
-      //       some phones without a way to check upfront if it supports setting strength!
       await controller.setTorchMode('on')
+      expect(controller.torchMode).toBe('on')
+
+      await controller.setTorchMode('off')
+      expect(controller.torchMode).toBe('off')
+    } finally {
+      await session.stop()
+    }
+  })
+
+  it('enables torch at min/max strength when the device supports it', async () => {
+    if (!backDevice.hasTorch) {
+      console.log('[SKIP] torch strength: device has no torch')
+      return
+    }
+    if (!backDevice.supportsTorchStrength) {
+      console.log('[SKIP] torch strength: device does not support custom strength')
+      return
+    }
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const [controller] = await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    if (controller == null) throw new Error('no controller')
+    await session.start()
+
+    try {
+      // Min strength (dimmest level the device supports)
+      await controller.enableTorchWithStrength(0.0)
+      expect(controller.torchMode).toBe('on')
+
+      // Max strength — the case that catches the off-by-one in CameraX's
+      // strength mapping (a naive `1 + strength * maxLevel` overshoots to
+      // `maxLevel + 1` and `setTorchStrengthLevel` throws IllegalArgumentException).
+      await controller.enableTorchWithStrength(1.0)
       expect(controller.torchMode).toBe('on')
 
       await controller.setTorchMode('off')

--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -174,17 +174,22 @@ describe('VisionCamera - Controller', () => {
 
     try {
       // Min strength (dimmest level the device supports)
-      await controller.enableTorchWithStrength(0.0)
+      await controller.enableTorchWithStrength(backDevice.minTorchStrength)
       expect(controller.torchMode).toBe('on')
 
-      // Max strength — the case that catches the off-by-one in CameraX's
-      // strength mapping (a naive `1 + strength * maxLevel` overshoots to
-      // `maxLevel + 1` and `setTorchStrengthLevel` throws IllegalArgumentException).
-      await controller.enableTorchWithStrength(1.0)
+      // Max strength — the case that caught the off-by-one in the original
+      // CameraX strength mapping (a naive `1 + strength * maxLevel`
+      // overshoots to `maxLevel + 1` and `setTorchStrengthLevel` throws
+      // IllegalArgumentException). Must round-trip without throwing.
+      await controller.enableTorchWithStrength(backDevice.maxTorchStrength)
       expect(controller.torchMode).toBe('on')
+      expect(controller.torchStrength).toBe(backDevice.maxTorchStrength)
 
       await controller.setTorchMode('off')
       expect(controller.torchMode).toBe('off')
+      // When the torch is physically off, strength must report 0 on both
+      // platforms (the value should not stay at the previously-configured level).
+      expect(controller.torchStrength).toBe(0.0)
     } finally {
       await session.stop()
     }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -215,23 +215,17 @@ class HybridCameraController(
 
   override fun enableTorchWithStrength(strength: Double): Promise<Unit> {
     return Promise.async {
-      // 1. Validate strength
       require(strength in 0.0..1.0) {
         "Torch `strength` is not within 0.0 to 1.0 range! (Received: $strength)"
       }
 
-      // 2. CameraX's setTorchStrengthLevel accepts a level in [1, getMaxTorchStrengthLevel()] —
-      //    anything outside that range fails with IllegalArgumentException, and any value at all
-      //    fails with UnsupportedOperationException on devices that don't support strength control.
-      //    Map our [0.0, 1.0] strength onto [1, maxLevel] linearly. (A naive `1 + strength * maxLevel`
-      //    overshoots to `maxLevel + 1` at the top of the range.)
+      // Extrapolate `[0, 1]` to `[1, maxTorchStrengthLevel]`
       val maxLevel = camera.cameraInfo.maxTorchStrengthLevel
       require(maxLevel > 0) {
         "Cannot configure torch strength - this CameraDevice does not support it!"
       }
       val normalizedStrength = (strength * (maxLevel - 1) + 1).toInt().coerceIn(1, maxLevel)
 
-      // 3. Apply level + enable torch.
       camera.cameraControl
         .setTorchStrengthLevel(normalizedStrength)
         .await()

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -69,9 +69,13 @@ class HybridCameraController(
     get() = zoom * camera.cameraInfo.intrinsicZoomRatio
 
   override val torchStrength: Double
-    get() =
-      camera.cameraInfo.torchStrengthLevel.value
+    get() {
+      // If the torch is off, we must return `0`.
+      // The `torchStrengthLevel` uses a cached value, so it never goes to `0`.
+      if (camera.cameraInfo.torchState.value != TorchState.ON) return 0.0
+      return camera.cameraInfo.torchStrengthLevel.value
         ?.toDouble() ?: 0.0
+    }
 
   override val torchMode: TorchMode
     get() = TorchMode.fromTorchState(camera.cameraInfo.torchState.value ?: TorchState.OFF)

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -196,10 +196,7 @@ class HybridCameraController(
     }
   }
 
-  override fun setTorchMode(
-    mode: TorchMode,
-    strength: Double?,
-  ): Promise<Unit> {
+  override fun setTorchMode(mode: TorchMode): Promise<Unit> {
     return Promise.async {
       when (mode) {
         TorchMode.OFF -> {
@@ -208,24 +205,39 @@ class HybridCameraController(
             .await()
         }
         TorchMode.ON -> {
-          if (strength != null) {
-            require(strength in 0.0..1.0) {
-              "Torch `strength` is not within 0.0 to 1.0 range! (Received: $strength)"
-            }
-            val normalizedStrength = 1 + (strength * camera.cameraInfo.maxTorchStrengthLevel)
-            camera.cameraControl
-              .setTorchStrengthLevel(normalizedStrength.toInt())
-              .await()
-            camera.cameraControl
-              .enableTorch(true)
-              .await()
-          } else {
-            camera.cameraControl
-              .enableTorch(true)
-              .await()
-          }
+          camera.cameraControl
+            .enableTorch(true)
+            .await()
         }
       }
+    }
+  }
+
+  override fun enableTorchWithStrength(strength: Double): Promise<Unit> {
+    return Promise.async {
+      // 1. Validate strength
+      require(strength in 0.0..1.0) {
+        "Torch `strength` is not within 0.0 to 1.0 range! (Received: $strength)"
+      }
+
+      // 2. CameraX's setTorchStrengthLevel accepts a level in [1, getMaxTorchStrengthLevel()] —
+      //    anything outside that range fails with IllegalArgumentException, and any value at all
+      //    fails with UnsupportedOperationException on devices that don't support strength control.
+      //    Map our [0.0, 1.0] strength onto [1, maxLevel] linearly. (A naive `1 + strength * maxLevel`
+      //    overshoots to `maxLevel + 1` at the top of the range.)
+      val maxLevel = camera.cameraInfo.maxTorchStrengthLevel
+      require(maxLevel > 0) {
+        "Cannot configure torch strength - this CameraDevice does not support it!"
+      }
+      val normalizedStrength = (strength * (maxLevel - 1) + 1).toInt().coerceIn(1, maxLevel)
+
+      // 3. Apply level + enable torch.
+      camera.cameraControl
+        .setTorchStrengthLevel(normalizedStrength)
+        .await()
+      camera.cameraControl
+        .enableTorch(true)
+        .await()
     }
   }
 

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -71,7 +71,8 @@ class HybridCameraController(
   override val torchStrength: Double
     get() =
       camera.cameraInfo.torchStrengthLevel.value
-        ?.toDouble() ?: 1.0
+        ?.toDouble() ?: 0.0
+
   override val torchMode: TorchMode
     get() = TorchMode.fromTorchState(camera.cameraInfo.torchState.value ?: TorchState.OFF)
 
@@ -215,19 +216,8 @@ class HybridCameraController(
 
   override fun enableTorchWithStrength(strength: Double): Promise<Unit> {
     return Promise.async {
-      require(strength in 0.0..1.0) {
-        "Torch `strength` is not within 0.0 to 1.0 range! (Received: $strength)"
-      }
-
-      // Extrapolate `[0, 1]` to `[1, maxTorchStrengthLevel]`
-      val maxLevel = camera.cameraInfo.maxTorchStrengthLevel
-      require(maxLevel > 0) {
-        "Cannot configure torch strength - this CameraDevice does not support it!"
-      }
-      val normalizedStrength = (strength * (maxLevel - 1) + 1).toInt().coerceIn(1, maxLevel)
-
       camera.cameraControl
-        .setTorchStrengthLevel(normalizedStrength)
+        .setTorchStrengthLevel(strength.toInt())
         .await()
       camera.cameraControl
         .enableTorch(true)

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
@@ -169,6 +169,9 @@ class HybridCameraDevice(
   override val hasTorch: Boolean
     get() = cameraInfo.hasFlashUnit()
 
+  override val supportsTorchStrength: Boolean
+    get() = cameraInfo.isTorchStrengthSupported
+
   override val supportsLowLightBoost: Boolean
     get() = cameraInfo.isLowLightBoostSupported
 

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridCameraDevice.kt
@@ -172,6 +172,19 @@ class HybridCameraDevice(
   override val supportsTorchStrength: Boolean
     get() = cameraInfo.isTorchStrengthSupported
 
+  override val minTorchStrength: Double
+    get() {
+      if (!supportsTorchStrength) return 0.0
+      // Torch Strength ranges [1, maxTorchStrengthLevel]
+      return 1.0
+    }
+
+  override val maxTorchStrength: Double
+    get() {
+      if (!supportsTorchStrength) return 0.0
+      return cameraInfo.maxTorchStrengthLevel.toDouble()
+    }
+
   override val supportsLowLightBoost: Boolean
     get() = cameraInfo.isLowLightBoostSupported
 

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridPhysicalCameraDevice.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/inputs/HybridPhysicalCameraDevice.kt
@@ -90,6 +90,9 @@ class HybridPhysicalCameraDevice(
   override val maxWhiteBalanceGain: Double = 0.0
   override val hasFlash: Boolean = false
   override val hasTorch: Boolean = false
+  override val supportsTorchStrength: Boolean = false
+  override val minTorchStrength: Double = 0.0
+  override val maxTorchStrength: Double = 0.0
   override val supportsLowLightBoost: Boolean = false
   override val minZoom: Double = 0.0
   override val maxZoom: Double = 0.0

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+maxTorchStrength.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+maxTorchStrength.swift
@@ -1,0 +1,18 @@
+///
+/// AVCaptureDevice+maxTorchStrength.swift
+/// VisionCamera
+/// Copyright © 2026 Marc Rousavy @ Margelo
+///
+
+import AVFoundation
+import Foundation
+
+extension AVCaptureDevice {
+  /// The maximum supported torch strength level for this device.
+  ///
+  /// `AVCaptureDevice.setTorchModeOn(level:)` accepts values up to
+  /// `AVCaptureMaxAvailableTorchLevel`, which is always `1.0`.
+  var maxTorchStrength: Float {
+    return 1.0
+  }
+}

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+maxTorchStrength.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+maxTorchStrength.swift
@@ -12,7 +12,7 @@ extension AVCaptureDevice {
   ///
   /// `AVCaptureDevice.setTorchModeOn(level:)` accepts values up to
   /// `AVCaptureMaxAvailableTorchLevel`, which is always `1.0`.
-  var maxTorchStrength: Float {
+  var maxTorchStrength: Double {
     return 1.0
   }
 }

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+minTorchStrength.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+minTorchStrength.swift
@@ -1,0 +1,21 @@
+///
+/// AVCaptureDevice+minTorchStrength.swift
+/// VisionCamera
+/// Copyright © 2026 Marc Rousavy @ Margelo
+///
+
+import AVFoundation
+import Foundation
+
+extension AVCaptureDevice {
+  /// The minimum supported torch strength level for this device.
+  ///
+  /// Apple's `setTorchModeOn(level:)` accepts `(0, AVCaptureMaxAvailableTorchLevel]`
+  /// and rejects exactly `0` with an uncatchable `NSInvalidArgumentException`, so the
+  /// lowest usable brightness is just above `0`. We expose a small positive floor
+  /// rather than `0` so that callers can pass this value directly to
+  /// `setTorchModeOn(level:)` without tripping that exception.
+  var minTorchStrength: Float {
+    return 0.001
+  }
+}

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+minTorchStrength.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureDevice+minTorchStrength.swift
@@ -15,7 +15,7 @@ extension AVCaptureDevice {
   /// lowest usable brightness is just above `0`. We expose a small positive floor
   /// rather than `0` so that callers can pass this value directly to
   /// `setTorchModeOn(level:)` without tripping that exception.
-  var minTorchStrength: Float {
+  var minTorchStrength: Double {
     return 0.001
   }
 }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -301,9 +301,9 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
 
   func enableTorchWithStrength(strength: Double) -> Promise<Void> {
     return captureDevice.withLock(queue) {
-      guard self.captureDevice.hasTorch else {
+      guard self.device.supportsTorchStrength else {
         throw RuntimeError.error(
-          withMessage: "Cannot enable torch - this CameraDevice does not have a `torch`!"
+          withMessage: "Cannot enable torch - this CameraDevice does not support setting torch strength! (See `device.supportsTorchStrength`)"
         )
       }
       let minStrength = self.captureDevice.minTorchStrength

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -301,14 +301,11 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
 
   func enableTorchWithStrength(strength: Double) -> Promise<Void> {
     return captureDevice.withLock(queue) {
-      // 1. Ensure we have a torch
       guard self.captureDevice.hasTorch else {
         throw RuntimeError.error(
           withMessage: "Cannot enable torch - this CameraDevice does not have a `torch`!"
         )
       }
-
-      // 2. Ensure strength is within range
       guard strength >= 0 && strength <= 1 else {
         throw RuntimeError.error(
           withMessage:
@@ -316,9 +313,8 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
         )
       }
 
-      // 3. Apply level. AVCaptureDevice.setTorchModeOn(level:) accepts (0, AVCaptureMaxAvailableTorchLevel]
-      //    and throws NSInvalidArgumentException (uncatchable from Swift) for level == 0.
-      //    Floor strength=0 at a tiny positive value so JS callers can request "minimum brightness".
+      // `setTorchModeOn(level:)`` accepts (0, AVCaptureMaxAvailableTorchLevel],
+      // but throws if we pass `0` - so we use at least `0.001`.
       let level = max(Float(strength), 0.001)
       try self.captureDevice.setTorchModeOn(level: level)
     }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -308,7 +308,7 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
       }
       let minStrength = self.captureDevice.minTorchStrength
       let maxStrength = self.captureDevice.maxTorchStrength
-      guard strength >= Double(minStrength) && strength <= Double(maxStrength) else {
+      guard strength >= minStrength && strength <= maxStrength else {
         throw RuntimeError(
           "`strength` is not within the device's `minTorchStrength` and `maxTorchStrength` range! (Received: \(strength), `device.minTorchStrength`: \(minStrength), `device.maxTorchStrength`: \(maxStrength)"
         )

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -306,11 +306,11 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
           withMessage: "Cannot enable torch - this CameraDevice does not have a `torch`!"
         )
       }
-      // On iOS, `strength` has to be greater than 0 (>= 0.001),
-      // and smaller than or equal to `1.0`.
-      guard strength > 0 && strength <= 1.0 else {
+      let minStrength = self.captureDevice.minTorchStrength
+      let maxStrength = self.captureDevice.maxTorchStrength
+      guard strength >= Double(minStrength) && strength <= Double(maxStrength) else {
         throw RuntimeError(
-          "`strength` is not within the device's `minTorchStrength` and `maxTorchStrength` range! (Received: \(strength), `device.minTorchStrength`: 0.001, `device.maxTorchStrength`: 1.0"
+          "`strength` is not within the device's `minTorchStrength` and `maxTorchStrength` range! (Received: \(strength), `device.minTorchStrength`: \(minStrength), `device.maxTorchStrength`: \(maxStrength)"
         )
       }
       try self.captureDevice.setTorchModeOn(level: Float(strength))

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -275,7 +275,7 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
       onSubjectAreaDidChange: onSubjectAreaChanged)
   }
 
-  func setTorchMode(mode: TorchMode, strength: Double?) -> Promise<Void> {
+  func setTorchMode(mode: TorchMode) -> Promise<Void> {
     return captureDevice.withLock(queue) {
       // 1. Ensure we have a torch
       if !self.captureDevice.hasTorch {
@@ -294,18 +294,33 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
       case .off:
         self.captureDevice.torchMode = .off
       case .on:
-        if let strength {
-          // 3. We have a custom strength level too! Set that
-          guard strength >= 0 && strength <= 1 else {
-            throw RuntimeError.error(
-              withMessage:
-                "Torch `strength` is not within 0.0 to 1.0 range! (Received: \(strength))")
-          }
-          try self.captureDevice.setTorchModeOn(level: Float(strength))
-        } else {
-          self.captureDevice.torchMode = .on
-        }
+        self.captureDevice.torchMode = .on
       }
+    }
+  }
+
+  func enableTorchWithStrength(strength: Double) -> Promise<Void> {
+    return captureDevice.withLock(queue) {
+      // 1. Ensure we have a torch
+      guard self.captureDevice.hasTorch else {
+        throw RuntimeError.error(
+          withMessage: "Cannot enable torch - this CameraDevice does not have a `torch`!"
+        )
+      }
+
+      // 2. Ensure strength is within range
+      guard strength >= 0 && strength <= 1 else {
+        throw RuntimeError.error(
+          withMessage:
+            "Torch `strength` is not within 0.0 to 1.0 range! (Received: \(strength))"
+        )
+      }
+
+      // 3. Apply level. AVCaptureDevice.setTorchModeOn(level:) accepts (0, AVCaptureMaxAvailableTorchLevel]
+      //    and throws NSInvalidArgumentException (uncatchable from Swift) for level == 0.
+      //    Floor strength=0 at a tiny positive value so JS callers can request "minimum brightness".
+      let level = max(Float(strength), 0.001)
+      try self.captureDevice.setTorchModeOn(level: level)
     }
   }
 

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -306,17 +306,14 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
           withMessage: "Cannot enable torch - this CameraDevice does not have a `torch`!"
         )
       }
-      guard strength >= 0 && strength <= 1 else {
-        throw RuntimeError.error(
-          withMessage:
-            "Torch `strength` is not within 0.0 to 1.0 range! (Received: \(strength))"
+      // On iOS, `strength` has to be greater than 0 (>= 0.001),
+      // and smaller than or equal to `1.0`.
+      guard strength > 0 && strength <= 1.0 else {
+        throw RuntimeError(
+          "`strength` is not within the device's `minTorchStrength` and `maxTorchStrength` range! (Received: \(strength), `device.minTorchStrength`: 0.001, `device.maxTorchStrength`: 1.0"
         )
       }
-
-      // `setTorchModeOn(level:)`` accepts (0, AVCaptureMaxAvailableTorchLevel],
-      // but throws if we pass `0` - so we use at least `0.001`.
-      let level = max(Float(strength), 0.001)
-      try self.captureDevice.setTorchModeOn(level: level)
+      try self.captureDevice.setTorchModeOn(level: Float(strength))
     }
   }
 
@@ -347,11 +344,9 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
       // 1. Ensure exposureBias is within range
       let device = self.captureDevice
       let exposure = Float(exposure)
-      guard exposure >= device.minExposureTargetBias && exposure <= device.maxExposureTargetBias
-      else {
-        throw RuntimeError.error(
-          withMessage:
-            "`exposure` is not within the device's `minExposureBias` and `maxExposureBias` range! (Received: \(exposure), `device.minExposureBias`: \(device.minExposureTargetBias), `device.maxExposureBias`: \(device.maxExposureTargetBias)"
+      guard exposure >= device.minExposureTargetBias && exposure <= device.maxExposureTargetBias else {
+        throw RuntimeError(
+          "`exposure` is not within the device's `minExposureBias` and `maxExposureBias` range! (Received: \(exposure), `device.minExposureBias`: \(device.minExposureTargetBias), `device.maxExposureBias`: \(device.maxExposureTargetBias)"
         )
       }
 

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
@@ -197,8 +197,7 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
   }
 
   var supportsTorchStrength: Bool {
-    // On iOS any device with a torch also accepts a custom brightness level
-    // via AVCaptureDevice.setTorchModeOn(level:), so this mirrors `hasTorch`.
+    // On iOS any device with a torch also supports custom torch level/strength
     return device.hasTorch
   }
 

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
@@ -196,6 +196,12 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
     return device.hasTorch
   }
 
+  var supportsTorchStrength: Bool {
+    // On iOS any device with a torch also accepts a custom brightness level
+    // via AVCaptureDevice.setTorchModeOn(level:), so this mirrors `hasTorch`.
+    return device.hasTorch
+  }
+
   var supportsLowLightBoost: Bool {
     return device.isLowLightBoostSupported
   }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
@@ -202,12 +202,11 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
   }
 
   var minTorchStrength: Double {
-    // We use a tiny value larger than 0, because 0 is not a valid torch level, it'd be "off".
-    return 0.001
+    return Double(device.minTorchStrength)
   }
 
   var maxTorchStrength: Double {
-    return 1.0
+    return Double(device.maxTorchStrength)
   }
 
   var supportsLowLightBoost: Bool {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
@@ -202,11 +202,11 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
   }
 
   var minTorchStrength: Double {
-    return Double(device.minTorchStrength)
+    return device.minTorchStrength
   }
 
   var maxTorchStrength: Double {
-    return Double(device.maxTorchStrength)
+    return device.maxTorchStrength
   }
 
   var supportsLowLightBoost: Bool {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Inputs/HybridCameraDevice.swift
@@ -201,6 +201,15 @@ final class HybridCameraDevice: HybridCameraDeviceSpec, NativeCameraDevice {
     return device.hasTorch
   }
 
+  var minTorchStrength: Double {
+    // We use a tiny value larger than 0, because 0 is not a valid torch level, it'd be "off".
+    return 0.001
+  }
+
+  var maxTorchStrength: Double {
+    return 1.0
+  }
+
   var supportsLowLightBoost: Bool {
     return device.isLowLightBoostSupported
   }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.cpp
@@ -330,9 +330,24 @@ namespace margelo::nitro::camera {
       return __promise;
     }();
   }
-  std::shared_ptr<Promise<void>> JHybridCameraControllerSpec::setTorchMode(TorchMode mode, std::optional<double> strength) {
-    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JTorchMode> /* mode */, jni::alias_ref<jni::JDouble> /* strength */)>("setTorchMode");
-    auto __result = method(_javaPart, JTorchMode::fromCpp(mode), strength.has_value() ? jni::JDouble::valueOf(strength.value()) : nullptr);
+  std::shared_ptr<Promise<void>> JHybridCameraControllerSpec::setTorchMode(TorchMode mode) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JTorchMode> /* mode */)>("setTorchMode");
+    auto __result = method(_javaPart, JTorchMode::fromCpp(mode));
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
+  }
+  std::shared_ptr<Promise<void>> JHybridCameraControllerSpec::enableTorchWithStrength(double strength) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(double /* strength */)>("enableTorchWithStrength");
+    auto __result = method(_javaPart, strength);
     return [&]() {
       auto __promise = Promise<void>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraControllerSpec.hpp
@@ -85,7 +85,8 @@ namespace margelo::nitro::camera {
     std::shared_ptr<Promise<void>> setZoom(double zoom) override;
     std::shared_ptr<Promise<void>> startZoomAnimation(double zoom, double rate) override;
     std::shared_ptr<Promise<void>> cancelZoomAnimation() override;
-    std::shared_ptr<Promise<void>> setTorchMode(TorchMode mode, std::optional<double> strength) override;
+    std::shared_ptr<Promise<void>> setTorchMode(TorchMode mode) override;
+    std::shared_ptr<Promise<void>> enableTorchWithStrength(double strength) override;
     std::shared_ptr<Promise<void>> setExposureBias(double exposure) override;
     std::shared_ptr<Promise<void>> setFocusLocked(double lensPosition) override;
     std::shared_ptr<Promise<void>> lockCurrentFocus() override;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
@@ -308,6 +308,11 @@ namespace margelo::nitro::camera {
     auto __result = method(_javaPart);
     return static_cast<bool>(__result);
   }
+  bool JHybridCameraDeviceSpec::getSupportsTorchStrength() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getSupportsTorchStrength");
+    auto __result = method(_javaPart);
+    return static_cast<bool>(__result);
+  }
   bool JHybridCameraDeviceSpec::getSupportsLowLightBoost() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getSupportsLowLightBoost");
     auto __result = method(_javaPart);

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.cpp
@@ -313,6 +313,16 @@ namespace margelo::nitro::camera {
     auto __result = method(_javaPart);
     return static_cast<bool>(__result);
   }
+  double JHybridCameraDeviceSpec::getMinTorchStrength() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getMinTorchStrength");
+    auto __result = method(_javaPart);
+    return __result;
+  }
+  double JHybridCameraDeviceSpec::getMaxTorchStrength() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getMaxTorchStrength");
+    auto __result = method(_javaPart);
+    return __result;
+  }
   bool JHybridCameraDeviceSpec::getSupportsLowLightBoost() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getSupportsLowLightBoost");
     auto __result = method(_javaPart);

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
@@ -82,6 +82,7 @@ namespace margelo::nitro::camera {
     bool getSupportsWhiteBalanceLocking() override;
     bool getHasFlash() override;
     bool getHasTorch() override;
+    bool getSupportsTorchStrength() override;
     bool getSupportsLowLightBoost() override;
     double getMinZoom() override;
     double getMaxZoom() override;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridCameraDeviceSpec.hpp
@@ -83,6 +83,8 @@ namespace margelo::nitro::camera {
     bool getHasFlash() override;
     bool getHasTorch() override;
     bool getSupportsTorchStrength() override;
+    double getMinTorchStrength() override;
+    double getMaxTorchStrength() override;
     bool getSupportsLowLightBoost() override;
     double getMinZoom() override;
     double getMaxZoom() override;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraControllerSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraControllerSpec.kt
@@ -162,7 +162,11 @@ abstract class HybridCameraControllerSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun setTorchMode(mode: TorchMode, strength: Double?): Promise<Unit>
+  abstract fun setTorchMode(mode: TorchMode): Promise<Unit>
+  
+  @DoNotStrip
+  @Keep
+  abstract fun enableTorchWithStrength(strength: Double): Promise<Unit>
   
   @DoNotStrip
   @Keep

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
@@ -159,6 +159,14 @@ abstract class HybridCameraDeviceSpec: HybridObject() {
   
   @get:DoNotStrip
   @get:Keep
+  abstract val minTorchStrength: Double
+  
+  @get:DoNotStrip
+  @get:Keep
+  abstract val maxTorchStrength: Double
+  
+  @get:DoNotStrip
+  @get:Keep
   abstract val supportsLowLightBoost: Boolean
   
   @get:DoNotStrip

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridCameraDeviceSpec.kt
@@ -155,6 +155,10 @@ abstract class HybridCameraDeviceSpec: HybridObject() {
   
   @get:DoNotStrip
   @get:Keep
+  abstract val supportsTorchStrength: Boolean
+  
+  @get:DoNotStrip
+  @get:Keep
   abstract val supportsLowLightBoost: Boolean
   
   @get:DoNotStrip

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/VisionCamera-Swift-Cxx-Bridge.hpp
@@ -546,21 +546,6 @@ namespace margelo::nitro::camera::bridge::swift {
     return optional.value();
   }
   
-  // pragma MARK: std::optional<double>
-  /**
-   * Specialized version of `std::optional<double>`.
-   */
-  using std__optional_double_ = std::optional<double>;
-  inline std::optional<double> create_std__optional_double_(const double& value) noexcept {
-    return std::optional<double>(value);
-  }
-  inline bool has_value_std__optional_double_(const std::optional<double>& optional) noexcept {
-    return optional.has_value();
-  }
-  inline double get_std__optional_double_(const std::optional<double>& optional) noexcept {
-    return optional.value();
-  }
-  
   // pragma MARK: std::shared_ptr<HybridCameraControllerSpec>
   /**
    * Specialized version of `std::shared_ptr<HybridCameraControllerSpec>`.
@@ -915,6 +900,21 @@ namespace margelo::nitro::camera::bridge::swift {
   // pragma MARK: std::weak_ptr<HybridCameraVideoOutputSpec>
   using std__weak_ptr_HybridCameraVideoOutputSpec_ = std::weak_ptr<HybridCameraVideoOutputSpec>;
   inline std__weak_ptr_HybridCameraVideoOutputSpec_ weakify_std__shared_ptr_HybridCameraVideoOutputSpec_(const std::shared_ptr<HybridCameraVideoOutputSpec>& strong) noexcept { return strong; }
+  
+  // pragma MARK: std::optional<double>
+  /**
+   * Specialized version of `std::optional<double>`.
+   */
+  using std__optional_double_ = std::optional<double>;
+  inline std::optional<double> create_std__optional_double_(const double& value) noexcept {
+    return std::optional<double>(value);
+  }
+  inline bool has_value_std__optional_double_(const std::optional<double>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline double get_std__optional_double_(const std::optional<double>& optional) noexcept {
+    return optional.value();
+  }
   
   // pragma MARK: std::optional<RecorderFileType>
   /**

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraControllerSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraControllerSpecSwift.hpp
@@ -248,8 +248,16 @@ namespace margelo::nitro::camera {
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline std::shared_ptr<Promise<void>> setTorchMode(TorchMode mode, std::optional<double> strength) override {
-      auto __result = _swiftPart.setTorchMode(static_cast<int>(mode), strength);
+    inline std::shared_ptr<Promise<void>> setTorchMode(TorchMode mode) override {
+      auto __result = _swiftPart.setTorchMode(static_cast<int>(mode));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
+    inline std::shared_ptr<Promise<void>> enableTorchWithStrength(double strength) override {
+      auto __result = _swiftPart.enableTorchWithStrength(std::forward<decltype(strength)>(strength));
       if (__result.hasError()) [[unlikely]] {
         std::rethrow_exception(__result.error());
       }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
@@ -221,6 +221,12 @@ namespace margelo::nitro::camera {
     inline bool getSupportsTorchStrength() noexcept override {
       return _swiftPart.getSupportsTorchStrength();
     }
+    inline double getMinTorchStrength() noexcept override {
+      return _swiftPart.getMinTorchStrength();
+    }
+    inline double getMaxTorchStrength() noexcept override {
+      return _swiftPart.getMaxTorchStrength();
+    }
     inline bool getSupportsLowLightBoost() noexcept override {
       return _swiftPart.getSupportsLowLightBoost();
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridCameraDeviceSpecSwift.hpp
@@ -218,6 +218,9 @@ namespace margelo::nitro::camera {
     inline bool getHasTorch() noexcept override {
       return _swiftPart.hasTorch();
     }
+    inline bool getSupportsTorchStrength() noexcept override {
+      return _swiftPart.getSupportsTorchStrength();
+    }
     inline bool getSupportsLowLightBoost() noexcept override {
       return _swiftPart.getSupportsLowLightBoost();
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec.swift
@@ -44,7 +44,8 @@ public protocol HybridCameraControllerSpec_protocol: HybridObject {
   func setZoom(zoom: Double) throws -> Promise<Void>
   func startZoomAnimation(zoom: Double, rate: Double) throws -> Promise<Void>
   func cancelZoomAnimation() throws -> Promise<Void>
-  func setTorchMode(mode: TorchMode, strength: Double?) throws -> Promise<Void>
+  func setTorchMode(mode: TorchMode) throws -> Promise<Void>
+  func enableTorchWithStrength(strength: Double) throws -> Promise<Void>
   func setExposureBias(exposure: Double) throws -> Promise<Void>
   func setFocusLocked(lensPosition: Double) throws -> Promise<Void>
   func lockCurrentFocus() throws -> Promise<Void>

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraControllerSpec_cxx.swift
@@ -436,16 +436,28 @@ open class HybridCameraControllerSpec_cxx {
   }
   
   @inline(__always)
-  public final func setTorchMode(mode: Int32, strength: bridge.std__optional_double_) -> bridge.Result_std__shared_ptr_Promise_void___ {
+  public final func setTorchMode(mode: Int32) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
-      let __result = try self.__implementation.setTorchMode(mode: margelo.nitro.camera.TorchMode(rawValue: mode)!, strength: { () -> Double? in
-        if bridge.has_value_std__optional_double_(strength) {
-          let __unwrapped = bridge.get_std__optional_double_(strength)
-          return __unwrapped
-        } else {
-          return nil
-        }
-      }())
+      let __result = try self.__implementation.setTorchMode(mode: margelo.nitro.camera.TorchMode(rawValue: mode)!)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
+  public final func enableTorchWithStrength(strength: Double) -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.enableTorchWithStrength(strength: strength)
       let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
         let __promise = bridge.create_std__shared_ptr_Promise_void__()
         let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
@@ -43,6 +43,8 @@ public protocol HybridCameraDeviceSpec_protocol: HybridObject {
   var hasFlash: Bool { get }
   var hasTorch: Bool { get }
   var supportsTorchStrength: Bool { get }
+  var minTorchStrength: Double { get }
+  var maxTorchStrength: Double { get }
   var supportsLowLightBoost: Bool { get }
   var minZoom: Double { get }
   var maxZoom: Double { get }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec.swift
@@ -42,6 +42,7 @@ public protocol HybridCameraDeviceSpec_protocol: HybridObject {
   var supportsWhiteBalanceLocking: Bool { get }
   var hasFlash: Bool { get }
   var hasTorch: Bool { get }
+  var supportsTorchStrength: Bool { get }
   var supportsLowLightBoost: Bool { get }
   var minZoom: Double { get }
   var maxZoom: Double { get }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
@@ -400,6 +400,20 @@ open class HybridCameraDeviceSpec_cxx {
     }
   }
   
+  public final var minTorchStrength: Double {
+    @inline(__always)
+    get {
+      return self.__implementation.minTorchStrength
+    }
+  }
+  
+  public final var maxTorchStrength: Double {
+    @inline(__always)
+    get {
+      return self.__implementation.maxTorchStrength
+    }
+  }
+  
   public final var supportsLowLightBoost: Bool {
     @inline(__always)
     get {

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridCameraDeviceSpec_cxx.swift
@@ -393,6 +393,13 @@ open class HybridCameraDeviceSpec_cxx {
     }
   }
   
+  public final var supportsTorchStrength: Bool {
+    @inline(__always)
+    get {
+      return self.__implementation.supportsTorchStrength
+    }
+  }
+  
   public final var supportsLowLightBoost: Bool {
     @inline(__always)
     get {

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.cpp
@@ -47,6 +47,7 @@ namespace margelo::nitro::camera {
       prototype.registerHybridMethod("startZoomAnimation", &HybridCameraControllerSpec::startZoomAnimation);
       prototype.registerHybridMethod("cancelZoomAnimation", &HybridCameraControllerSpec::cancelZoomAnimation);
       prototype.registerHybridMethod("setTorchMode", &HybridCameraControllerSpec::setTorchMode);
+      prototype.registerHybridMethod("enableTorchWithStrength", &HybridCameraControllerSpec::enableTorchWithStrength);
       prototype.registerHybridMethod("setExposureBias", &HybridCameraControllerSpec::setExposureBias);
       prototype.registerHybridMethod("setFocusLocked", &HybridCameraControllerSpec::setFocusLocked);
       prototype.registerHybridMethod("lockCurrentFocus", &HybridCameraControllerSpec::lockCurrentFocus);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraControllerSpec.hpp
@@ -49,7 +49,6 @@ namespace margelo::nitro::camera { struct WhiteBalanceTemperatureAndTint; }
 #include "FocusOptions.hpp"
 #include "ListenerSubscription.hpp"
 #include <functional>
-#include <optional>
 #include "WhiteBalanceTemperatureAndTint.hpp"
 
 namespace margelo::nitro::camera {
@@ -114,7 +113,8 @@ namespace margelo::nitro::camera {
       virtual std::shared_ptr<Promise<void>> setZoom(double zoom) = 0;
       virtual std::shared_ptr<Promise<void>> startZoomAnimation(double zoom, double rate) = 0;
       virtual std::shared_ptr<Promise<void>> cancelZoomAnimation() = 0;
-      virtual std::shared_ptr<Promise<void>> setTorchMode(TorchMode mode, std::optional<double> strength) = 0;
+      virtual std::shared_ptr<Promise<void>> setTorchMode(TorchMode mode) = 0;
+      virtual std::shared_ptr<Promise<void>> enableTorchWithStrength(double strength) = 0;
       virtual std::shared_ptr<Promise<void>> setExposureBias(double exposure) = 0;
       virtual std::shared_ptr<Promise<void>> setFocusLocked(double lensPosition) = 0;
       virtual std::shared_ptr<Promise<void>> lockCurrentFocus() = 0;

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
@@ -47,6 +47,8 @@ namespace margelo::nitro::camera {
       prototype.registerHybridGetter("hasFlash", &HybridCameraDeviceSpec::getHasFlash);
       prototype.registerHybridGetter("hasTorch", &HybridCameraDeviceSpec::getHasTorch);
       prototype.registerHybridGetter("supportsTorchStrength", &HybridCameraDeviceSpec::getSupportsTorchStrength);
+      prototype.registerHybridGetter("minTorchStrength", &HybridCameraDeviceSpec::getMinTorchStrength);
+      prototype.registerHybridGetter("maxTorchStrength", &HybridCameraDeviceSpec::getMaxTorchStrength);
       prototype.registerHybridGetter("supportsLowLightBoost", &HybridCameraDeviceSpec::getSupportsLowLightBoost);
       prototype.registerHybridGetter("minZoom", &HybridCameraDeviceSpec::getMinZoom);
       prototype.registerHybridGetter("maxZoom", &HybridCameraDeviceSpec::getMaxZoom);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.cpp
@@ -46,6 +46,7 @@ namespace margelo::nitro::camera {
       prototype.registerHybridGetter("supportsWhiteBalanceLocking", &HybridCameraDeviceSpec::getSupportsWhiteBalanceLocking);
       prototype.registerHybridGetter("hasFlash", &HybridCameraDeviceSpec::getHasFlash);
       prototype.registerHybridGetter("hasTorch", &HybridCameraDeviceSpec::getHasTorch);
+      prototype.registerHybridGetter("supportsTorchStrength", &HybridCameraDeviceSpec::getSupportsTorchStrength);
       prototype.registerHybridGetter("supportsLowLightBoost", &HybridCameraDeviceSpec::getSupportsLowLightBoost);
       prototype.registerHybridGetter("minZoom", &HybridCameraDeviceSpec::getMinZoom);
       prototype.registerHybridGetter("maxZoom", &HybridCameraDeviceSpec::getMaxZoom);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
@@ -114,6 +114,7 @@ namespace margelo::nitro::camera {
       virtual bool getSupportsWhiteBalanceLocking() = 0;
       virtual bool getHasFlash() = 0;
       virtual bool getHasTorch() = 0;
+      virtual bool getSupportsTorchStrength() = 0;
       virtual bool getSupportsLowLightBoost() = 0;
       virtual double getMinZoom() = 0;
       virtual double getMaxZoom() = 0;

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridCameraDeviceSpec.hpp
@@ -115,6 +115,8 @@ namespace margelo::nitro::camera {
       virtual bool getHasFlash() = 0;
       virtual bool getHasTorch() = 0;
       virtual bool getSupportsTorchStrength() = 0;
+      virtual double getMinTorchStrength() = 0;
+      virtual double getMaxTorchStrength() = 0;
       virtual bool getSupportsLowLightBoost() = 0;
       virtual double getMinZoom() = 0;
       virtual double getMaxZoom() = 0;

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -408,6 +408,7 @@ export interface CameraController
   /**
    * Sets the torch to the specified {@linkcode mode}.
    *
+   * @discussion
    * To enable the torch with a specific brightness level,
    * use {@linkcode enableTorchWithStrength | enableTorchWithStrength(...)}
    * instead.
@@ -421,8 +422,11 @@ export interface CameraController
    * {@linkcode strength} value.
    *
    * @discussion
-   * This method always turns on the torch, but allows using a custom torch strength - if
-   * you simply want to enable the torch, use {@linkcode setTorchMode | setTorchMode('on')}
+   * This method always turns on the torch, but in contrast to {@linkcode setTorchMode | setTorchMode(...)}
+   * (which always uses the default torch strength, often just the maximum), allows you to choose
+   * a custom torch strength level - often useful for dimming the torch slightly rather than using
+   * full strength. On some devices, this also allows using a higher torch strength than the default.
+   * If you simply want to enable the torch, use {@linkcode setTorchMode | setTorchMode('on')}
    * instead.
    *
    * To turn the torch off again, use {@linkcode setTorchMode | setTorchMode('off')}.

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -417,40 +417,27 @@ export interface CameraController
    */
   setTorchMode(mode: TorchMode): Promise<void>
   /**
-   * Enables the torch at a custom {@linkcode strength} brightness level.
+   * Sets the {@linkcode torchStrength} to the given
+   * {@linkcode strength} value.
    *
-   * The valid range for {@linkcode strength} is
-   * `[device.minTorchStrength, device.maxTorchStrength]`, which differs
-   * by platform:
-   * - On iOS, {@linkcode strength} is a continuous value in `[0, 1]`.
-   * - On Android, {@linkcode strength} is a discrete level in
-   *   `[1, device.maxTorchStrength]` - fractional values are floored
-   *   to the nearest integer level.
+   * @discussion
+   * This method always turns on the torch, but allows using a custom torch strength - if
+   * you simply want to enable the torch, use {@linkcode setTorchMode | setTorchMode('on')}
+   * instead.
    *
-   * To turn the torch off again, call
-   * {@linkcode setTorchMode | setTorchMode('off')}.
+   * To turn the torch off again, use {@linkcode setTorchMode | setTorchMode('off')}.
    *
-   * @throws If {@linkcode strength} is outside the
-   *   `[device.minTorchStrength, device.maxTorchStrength]` range.
-   * @throws If the {@linkcode device} does not support configuring
-   *   torch strength (see {@linkcode CameraDevice.supportsTorchStrength}).
-   *   To turn the torch on at the system default brightness, use
-   *   {@linkcode setTorchMode | setTorchMode('on')} instead.
-   *
+   * @throws If the {@linkcode device} does not support setting torch strength (see {@linkcode CameraDevice.supportsTorchStrength})
+   * @throws If the {@linkcode device} does not support this {@linkcode strength} value (see {@linkcode CameraDevice.minTorchStrength} / {@linkcode CameraDevice.maxTorchStrength})
    * @example
-   * Enable torch at maximum brightness:
+   * Set Torch to maximum strength:
    * ```ts
    * const controller = ...
-   * const device = controller.device
-   * if (device.supportsTorchStrength) {
-   *   await controller.enableTorchWithStrength(device.maxTorchStrength)
-   * } else if (device.hasTorch) {
-   *   await controller.setTorchMode('on')
+   * if (controller.device.supportsTorchStrength) {
+   *   const maxStrength = controller.device.maxTorchStrength
+   *   await controller.enableTorchWithStrength(maxStrength)
    * }
    * ```
-   *
-   * @see {@linkcode CameraDevice.minTorchStrength}
-   * @see {@linkcode CameraDevice.maxTorchStrength}
    */
   enableTorchWithStrength(strength: number): Promise<void>
 
@@ -470,7 +457,7 @@ export interface CameraController
    */
   readonly exposureBias: number
   /**
-   * Sets the {@linkcode CameraController.exposureBias | exposureBias} to the given
+   * Sets the {@linkcode exposureBias} to the given
    * {@linkcode exposure} bias value.
    *
    * A positive value (like `1`) means over-exposed ("brighter"),

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -386,29 +386,59 @@ export interface CameraController
    * from `0.0` (weakest) to `1.0` (brightest).
    *
    * The torch's strength can be configured via
-   * {@linkcode setTorchMode | setTorchMode('on', ...)}.
+   * {@linkcode enableTorchWithStrength | enableTorchWithStrength(...)}
+   * on devices that support custom torch brightness
+   * (see {@linkcode CameraDevice.supportsTorchStrength}).
    */
   readonly torchStrength: number
   /**
    * Get the current {@linkcode TorchMode}.
    *
    * The torch can be enabled or disabled via
-   * {@linkcode setTorchMode | setTorchMode(...)}.
+   * {@linkcode setTorchMode | setTorchMode(...)}, or enabled
+   * at a custom brightness level via
+   * {@linkcode enableTorchWithStrength | enableTorchWithStrength(...)}.
    */
   readonly torchMode: TorchMode
   /**
    * Sets the torch to the specified {@linkcode mode}.
    *
-   * - When {@linkcode mode} == {@linkcode TorchMode | 'on'},
-   * you can pass {@linkcode strength} to configure the Torch's
-   * strength, from `0.0` to `1.0`.
-   * - When {@linkcode mode} != {@linkcode TorchMode | 'on'},
-   * the {@linkcode strength} parameter is ignored.
+   * To enable the torch with a specific brightness level,
+   * use {@linkcode enableTorchWithStrength | enableTorchWithStrength(...)}
+   * instead.
    *
-   * @throws If the {@linkcode device} does not have a torch (see {@linkcode CameraDevice.hasTorch})
-   * @throws If {@linkcode strength} is less than `0` or greater than `1`.
+   * @throws If the {@linkcode device} does not have a torch (see {@linkcode CameraDevice.hasTorch}).
+   * @see {@linkcode enableTorchWithStrength | enableTorchWithStrength(...)}
    */
-  setTorchMode(mode: TorchMode, strength?: number): Promise<void>
+  setTorchMode(mode: TorchMode): Promise<void>
+  /**
+   * Enables the torch at a custom {@linkcode strength} brightness
+   * level, from `0.0` (the lowest brightness the device supports)
+   * to `1.0` (full brightness).
+   *
+   * To turn the torch off again, call
+   * {@linkcode setTorchMode | setTorchMode('off')}.
+   *
+   * @param strength The torch brightness, in the range `0.0` to `1.0`.
+   *
+   * @throws If {@linkcode strength} is less than `0` or greater than `1`.
+   * @throws If the {@linkcode device} does not have a torch (see {@linkcode CameraDevice.hasTorch}).
+   * @throws If the {@linkcode device} does not support configuring
+   * torch strength (see {@linkcode CameraDevice.supportsTorchStrength}).
+   * To turn the torch on at the system default brightness, use
+   * {@linkcode setTorchMode | setTorchMode('on')} instead.
+   *
+   * @example
+   * ```ts
+   * const controller = ...
+   * if (controller.device.supportsTorchStrength) {
+   *   await controller.enableTorchWithStrength(0.5)
+   * } else if (controller.device.hasTorch) {
+   *   await controller.setTorchMode('on')
+   * }
+   * ```
+   */
+  enableTorchWithStrength(strength: number): Promise<void>
 
   // pragma MARK: Exposure
   /**

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -382,8 +382,13 @@ export interface CameraController
 
   // pragma MARK: Flash
   /**
-   * Get the current Torch's strength, which is a value
-   * from `0.0` (weakest) to `1.0` (brightest).
+   * Get the current Torch's brightness strength, or `0`
+   * if the torch is currently off.
+   *
+   * When the torch is on, this is a value within the
+   * `[device.minTorchStrength, device.maxTorchStrength]` range —
+   * see {@linkcode CameraDevice.minTorchStrength} and
+   * {@linkcode CameraDevice.maxTorchStrength}.
    *
    * The torch's strength can be configured via
    * {@linkcode enableTorchWithStrength | enableTorchWithStrength(...)}
@@ -412,26 +417,40 @@ export interface CameraController
    */
   setTorchMode(mode: TorchMode): Promise<void>
   /**
-   * Enables the torch at a custom {@linkcode strength} brightness
-   * level, from `0.0` (the lowest brightness the device supports)
-   * to `1.0` (full brightness).
+   * Enables the torch at a custom {@linkcode strength} brightness level.
+   *
+   * The valid range for {@linkcode strength} is
+   * `[device.minTorchStrength, device.maxTorchStrength]`, which differs
+   * by platform:
+   * - On iOS, {@linkcode strength} is a continuous value in `[0, 1]`.
+   * - On Android, {@linkcode strength} is a discrete level in
+   *   `[1, device.maxTorchStrength]` - fractional values are floored
+   *   to the nearest integer level.
    *
    * To turn the torch off again, call
    * {@linkcode setTorchMode | setTorchMode('off')}.
    *
-   * @throws If {@linkcode strength} is less than `0` or greater than `1`.
+   * @throws If {@linkcode strength} is outside the
+   *   `[device.minTorchStrength, device.maxTorchStrength]` range.
    * @throws If the {@linkcode device} does not support configuring
-   * torch strength (see {@linkcode CameraDevice.supportsTorchStrength}).
-   * To turn the torch on at the system default brightness, use
-   * {@linkcode setTorchMode | setTorchMode('on')} instead.
+   *   torch strength (see {@linkcode CameraDevice.supportsTorchStrength}).
+   *   To turn the torch on at the system default brightness, use
+   *   {@linkcode setTorchMode | setTorchMode('on')} instead.
    *
    * @example
+   * Enable torch at maximum brightness:
    * ```ts
    * const controller = ...
-   * if (controller.device.supportsTorchStrength) {
-   *   await controller.enableTorchWithStrength(0.5)
+   * const device = controller.device
+   * if (device.supportsTorchStrength) {
+   *   await controller.enableTorchWithStrength(device.maxTorchStrength)
+   * } else if (device.hasTorch) {
+   *   await controller.setTorchMode('on')
    * }
    * ```
+   *
+   * @see {@linkcode CameraDevice.minTorchStrength}
+   * @see {@linkcode CameraDevice.maxTorchStrength}
    */
   enableTorchWithStrength(strength: number): Promise<void>
 

--- a/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/CameraController.nitro.ts
@@ -419,10 +419,7 @@ export interface CameraController
    * To turn the torch off again, call
    * {@linkcode setTorchMode | setTorchMode('off')}.
    *
-   * @param strength The torch brightness, in the range `0.0` to `1.0`.
-   *
    * @throws If {@linkcode strength} is less than `0` or greater than `1`.
-   * @throws If the {@linkcode device} does not have a torch (see {@linkcode CameraDevice.hasTorch}).
    * @throws If the {@linkcode device} does not support configuring
    * torch strength (see {@linkcode CameraDevice.supportsTorchStrength}).
    * To turn the torch on at the system default brightness, use
@@ -433,8 +430,6 @@ export interface CameraController
    * const controller = ...
    * if (controller.device.supportsTorchStrength) {
    *   await controller.enableTorchWithStrength(0.5)
-   * } else if (controller.device.hasTorch) {
-   *   await controller.setTorchMode('on')
    * }
    * ```
    */

--- a/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
@@ -502,24 +502,14 @@ export interface CameraDevice
    * a custom torch brightness level via
    * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}.
    *
+   * @discussion
    * Many devices with a {@linkcode hasTorch | torch} can only
    * toggle the torch on or off and do not expose a brightness
-   * level — calling
+   * level - calling
    * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}
    * on such a device will fail. Use
    * {@linkcode CameraController.setTorchMode | setTorchMode('on')}
    * instead to turn the torch on at the system default level.
-   *
-   * @discussion
-   * On iOS, {@linkcode supportsTorchStrength} mirrors
-   * {@linkcode hasTorch} — any device that has a torch also
-   * supports adjusting its brightness via
-   * `AVCaptureDevice.setTorchModeOn(level:)`.
-   *
-   * On Android, this flag is gated by CameraX's
-   * `CameraInfo.isTorchStrengthSupported()`. Some devices
-   * with a flash unit still return `false` here, because not
-   * every Camera2 implementation exposes the torch-strength API.
    *
    * @see {@linkcode hasTorch}
    * @see {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}

--- a/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
@@ -516,31 +516,22 @@ export interface CameraDevice
    */
   readonly supportsTorchStrength: boolean
   /**
-   * Gets the minimum supported value for the {@linkcode strength}
-   * parameter in
-   * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)},
+   * Gets the minimum supported torch strength for this device,
    * or `0` if {@linkcode supportsTorchStrength} is false.
    *
-   * @discussion
-   * On iOS this is always `0` — the torch's strength is a
-   * continuous value in `[0, 1]`. On Android this is `1` — the
-   * dimmest discrete brightness level the hardware exposes.
+   * Use {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}
+   * to set the torch strength.
    *
    * @see {@linkcode supportsTorchStrength}
    * @see {@linkcode maxTorchStrength}
    */
   readonly minTorchStrength: number
   /**
-   * Gets the maximum supported value for the {@linkcode strength}
-   * parameter in
-   * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)},
+   * Gets the maximum supported torch strength for this device,
    * or `0` if {@linkcode supportsTorchStrength} is false.
    *
-   * @discussion
-   * On iOS this is always `1` — the torch's strength is a
-   * continuous value in `[0, 1]`. On Android this is the device's
-   * maximum discrete brightness level (e.g. `5` on a device that
-   * exposes 5 levels).
+   * Use {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}
+   * to set the torch strength.
    *
    * @see {@linkcode supportsTorchStrength}
    * @see {@linkcode minTorchStrength}

--- a/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
@@ -489,9 +489,42 @@ export interface CameraDevice
    * In almost all cases, {@linkcode hasTorch} is the
    * same as {@linkcode hasFlash}.
    *
+   * Use {@linkcode supportsTorchStrength} to find out whether
+   * the torch additionally accepts a custom brightness level
+   * via {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}.
+   *
    * @see {@linkcode CameraController.setTorchMode | setTorchMode(...)}
+   * @see {@linkcode supportsTorchStrength}
    */
   readonly hasTorch: boolean
+  /**
+   * Whether this {@linkcode CameraDevice} supports configuring
+   * a custom torch brightness level via
+   * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}.
+   *
+   * Many devices with a {@linkcode hasTorch | torch} can only
+   * toggle the torch on or off and do not expose a brightness
+   * level — calling
+   * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}
+   * on such a device will fail. Use
+   * {@linkcode CameraController.setTorchMode | setTorchMode('on')}
+   * instead to turn the torch on at the system default level.
+   *
+   * @discussion
+   * On iOS, {@linkcode supportsTorchStrength} mirrors
+   * {@linkcode hasTorch} — any device that has a torch also
+   * supports adjusting its brightness via
+   * `AVCaptureDevice.setTorchModeOn(level:)`.
+   *
+   * On Android, this flag is gated by CameraX's
+   * `CameraInfo.isTorchStrengthSupported()`. Some devices
+   * with a flash unit still return `false` here, because not
+   * every Camera2 implementation exposes the torch-strength API.
+   *
+   * @see {@linkcode hasTorch}
+   * @see {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}
+   */
+  readonly supportsTorchStrength: boolean
 
   // pragma MARK: Low Light Boost
   /**

--- a/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/inputs/CameraDevice.nitro.ts
@@ -515,6 +515,37 @@ export interface CameraDevice
    * @see {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)}
    */
   readonly supportsTorchStrength: boolean
+  /**
+   * Gets the minimum supported value for the {@linkcode strength}
+   * parameter in
+   * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)},
+   * or `0` if {@linkcode supportsTorchStrength} is false.
+   *
+   * @discussion
+   * On iOS this is always `0` — the torch's strength is a
+   * continuous value in `[0, 1]`. On Android this is `1` — the
+   * dimmest discrete brightness level the hardware exposes.
+   *
+   * @see {@linkcode supportsTorchStrength}
+   * @see {@linkcode maxTorchStrength}
+   */
+  readonly minTorchStrength: number
+  /**
+   * Gets the maximum supported value for the {@linkcode strength}
+   * parameter in
+   * {@linkcode CameraController.enableTorchWithStrength | enableTorchWithStrength(...)},
+   * or `0` if {@linkcode supportsTorchStrength} is false.
+   *
+   * @discussion
+   * On iOS this is always `1` — the torch's strength is a
+   * continuous value in `[0, 1]`. On Android this is the device's
+   * maximum discrete brightness level (e.g. `5` on a device that
+   * exposes 5 levels).
+   *
+   * @see {@linkcode supportsTorchStrength}
+   * @see {@linkcode minTorchStrength}
+   */
+  readonly maxTorchStrength: number
 
   // pragma MARK: Low Light Boost
   /**


### PR DESCRIPTION
Previously we only had `device.hasTorch`. 

The `setTorchMode(..., strength:)` method doesnt always support strength - some Android devices dont support torch strength. So instead, we now expose a separate method that takes strength, and the primary method just takes on, off or auto.

A device exposes if it supports strength as well as its min and max values.