### PR TITLE
chore: Unskip `initialExposureBias` test

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -231,14 +231,11 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  // TODO: Re-enable this test once Android applies `initialExposureBias` after the
-  //       camera is active. Today HybridCameraSession.applyInitialConfig fires
-  //       setExposureCompensationIndex at `configure()` time — before the
-  //       LifecycleOwner is active — so CameraX rejects it with
-  //       "Camera is not active" and the value is never applied.
-  //       (initialZoom happens to survive because setZoomRatio is applied as local
-  //       state before the camera streams.)
-  it.skip('honors initialExposureBias passed to configure', async () => {
+  // Expected to fail on Android until HybridCameraSession.applyInitialConfig
+  // runs after the LifecycleOwner is active — setExposureCompensationIndex at
+  // configure() time hits "Camera is not active" and is dropped. (setZoomRatio
+  // survives because CameraX caches it on CameraControl until activation.)
+  it('honors initialExposureBias passed to configure', async () => {
     if (!backDevice.supportsExposureBias) {
       console.log(
         '[SKIP] initialExposureBias: device does not support exposure bias',


### PR DESCRIPTION
This is currently _slightly_ broken on Android (possibly due to a CameraX bug) but we still dont want to swallow it