### PR TITLE
chore: Add todo comment

### DIFF
--- a/packages/react-native-vision-camera/src/hooks/useCameraDevice.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCameraDevice.ts
@@ -24,6 +24,8 @@ export function useCameraDevice(
   position: CameraPosition,
   filter?: DeviceFilter,
 ): CameraDevice | undefined {
+  // TODO: Use CameraDeviceFactory.getDefaultCamera() if filter is null, otherwise filter manually.
+  //       For that, CameraDevices.ts must give us the shared factory though.
   const devices = useCameraDevices()
 
   // TODO: Can we use something like useSyncExternalStore or whatever to avoid "wrong" dependencies?


### PR DESCRIPTION
`useCameraDevice(..)` and `useCameraDevices()` needs to change a bit.

If no `filter?` arg is passed, we should use `CameraDeviceFactory.getDefaultCamera(..)` instead - this is the OS recommended Camera. If an argument is passed, we should filter based on all available Camera Devices.

However, the CameraDeviceFactory is created asynchronously and should be shared across hooks calls and ideally also imperative API calls in the other file. Also, there's `addOnCameraDevicesChangedListener(..)`, which potentially also affects the result of `CameraDeviceFactory.getDefaultCamera(..)` - at least we should treat it as if it would affect that even though it likely only affects external Cameras in practice. 
Still, in this case the hook _may_ recompute that Camera if that changed. I guess we should compare it via `id`? Otherwise it'd be a new object + full Camera Session reconfigure each re-compute.

Anyways, the default case should be the `CameraDeviceFactory.getDefaultCamera(..)` - without compromising advanced cases for filtering. We should also add depth to filter options so users can find depth capable cameras more quickly