### PR TITLE
fix: Fix coordinate system converters (`convertCameraPointToViewPoint(...)`)

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
@@ -1,4 +1,4 @@
-import { type LayoutChangeEvent, Platform, StyleSheet } from 'react-native'
+import { type LayoutChangeEvent, StyleSheet } from 'react-native'
 import {
   afterEach,
   beforeAll,
@@ -402,12 +402,9 @@ describe('VisionCamera - Coordinates', () => {
       const mp = previewRef.createMeteringPoint(viewCenter.x, viewCenter.y)
 
       // relativeX/Y is documented to echo the view coordinate the user
-      // tapped. On Android the native side scales by pixelRatio before
-      // storing, so compare after applying the same scale.
-      const pixelRatio =
-        Platform.OS === 'android' ? mp.relativeX / viewCenter.x : 1
-      expect(mp.relativeX).toBeCloseTo(viewCenter.x * pixelRatio, 0)
-      expect(mp.relativeY).toBeCloseTo(viewCenter.y * pixelRatio, 0)
+      // tapped.
+      expect(mp.relativeX).toBeCloseTo(viewCenter.x, 0)
+      expect(mp.relativeY).toBeCloseTo(viewCenter.y, 0)
 
       // normalizedX/Y are the camera-space coords after orientation /
       // cropping / scaling, and per MeteringPoint.nitro.ts must be in [0, 1].

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/views/HybridPreviewView.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/views/HybridPreviewView.kt
@@ -86,14 +86,14 @@ class HybridPreviewView(
     }
   private var isPreviewing: Boolean = false
   private val meteringPointFactory: MeteringPointFactory
-  private var cameraSpaceToViewSpaceMatrix: Matrix? = null
+  private var cameraSpaceToViewPixelsMatrix: Matrix? = null
   private val pixelRatio: Float
 
   init {
     previewView.installHierarchyFitter()
     previewView.previewStreamState.observeForever(this)
     previewView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-      updateCameraSpaceToViewSpaceMatrix()
+      updateCameraSpaceToViewPixelsMatrix()
     }
     previewView.setOnTouchListener(this)
     meteringPointFactory = previewView.meteringPointFactory
@@ -119,8 +119,8 @@ class HybridPreviewView(
         meteringPointFactory.createPoint(absoluteViewX.toFloat(), absoluteViewY.toFloat())
       }
     return HybridMeteringPoint(
-      absoluteViewX,
-      absoluteViewY,
+      viewX,
+      viewY,
       size,
       meteringPoint,
     )
@@ -137,18 +137,27 @@ class HybridPreviewView(
 
   override fun convertCameraPointToViewPoint(cameraPoint: Point): Point {
     val matrix =
-      cameraSpaceToViewSpaceMatrix
+      cameraSpaceToViewPixelsMatrix
         ?: throw Error("Cannot convert camera point to view point - PreviewView isn't ready yet!")
-    return matrix.convertPoint(cameraPoint)
+    val viewPixels = matrix.convertPoint(cameraPoint)
+    return Point(
+      viewPixels.x / pixelRatio,
+      viewPixels.y / pixelRatio,
+    )
   }
 
   override fun convertViewPointToCameraPoint(viewPoint: Point): Point {
     val matrix =
-      cameraSpaceToViewSpaceMatrix
-        ?: throw Error("Cannot convert camera point to view point - PreviewView isn't ready yet!")
+      cameraSpaceToViewPixelsMatrix
+        ?: throw Error("Cannot convert view point to camera point - PreviewView isn't ready yet!")
     val inverted = Matrix()
     matrix.invert(inverted)
-    return inverted.convertPoint(viewPoint)
+    val viewPixels =
+      Point(
+        viewPoint.x * pixelRatio,
+        viewPoint.y * pixelRatio,
+      )
+    return inverted.convertPoint(viewPixels)
   }
 
   override fun convertScannedObjectCoordinatesToViewCoordinates(scannedObject: HybridScannedObjectSpec): HybridScannedObjectSpec {
@@ -183,17 +192,18 @@ class HybridPreviewView(
       }
     }
     this.isPreviewing = isPreviewing
-    updateCameraSpaceToViewSpaceMatrix()
+    updateCameraSpaceToViewPixelsMatrix()
   }
 
-  // This Matrix has to be updated when the PreviewView's layout changes,
+  // This matrix maps CameraX sensor coordinates to Android view pixels.
+  // It has to be updated when the PreviewView's layout changes,
   // we cannot access it directly from `convertCameraPointToViewPoint` each time
   // since it's accessible from the UI-Thread only.
-  private fun updateCameraSpaceToViewSpaceMatrix() {
+  private fun updateCameraSpaceToViewPixelsMatrix() {
     val matrix =
       previewView.sensorToViewTransform
         ?: return
-    this.cameraSpaceToViewSpaceMatrix = matrix
+    this.cameraSpaceToViewPixelsMatrix = matrix
   }
 
   override fun onTouch(

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/Track.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/Track.swift
@@ -25,7 +25,7 @@ final class Track {
 
   /**
    Gets whether the track has been marked as finished or not.
-  
+
    A track is finished when stop() was called, and a buffer with a later timestamp
    than the one from the stop() call arrives.
    */

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/Track.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Recording/Track.swift
@@ -25,7 +25,7 @@ final class Track {
 
   /**
    Gets whether the track has been marked as finished or not.
-
+  
    A track is finished when stop() was called, and a buffer with a later timestamp
    than the one from the stop() call arrives.
    */

--- a/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
+++ b/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
@@ -10,51 +10,50 @@ import CoreGraphics
 
 enum FrameCoordinateSystemConverter {
   /**
-   * Get a Matrix that maps a point in the given `pixelBuffer` to a normalized
-   * camera point `(cx, cy) ∈ [0, 1]²`, applying `orientation` and `isMirrored`.
-   *
-   * Each orientation maps the frame pixel `(x, y)` to:
-   * - `.up`    → (    x/w,     y/h)
-   * - `.down`  → (1 - x/w, 1 - y/h)
-   * - `.left`  → (    y/h, 1 - x/w)
-   * - `.right` → (1 - y/h,     x/w)
-   *
-   * Implemented as a direct affine matrix per orientation rather than chained
-   * `.scaledBy().translatedBy().rotated()` calls — those translate in pixel
-   * space (the scale is post-pended) so `(1, 0)` shifts by one pixel, not by
-   * the full width. Issue #3871.
+   * Returns a matrix that maps a point in the given `pixelBuffer` to a
+   * normalized camera point `(cx, cy) ∈ [0, 1]²`, applying `orientation`
+   * and `isMirrored`.
    */
   static func getFrameToCameraMatrix(
     pixelBuffer: CVPixelBuffer,
     orientation: CameraOrientation,
     isMirrored: Bool
   ) -> CGAffineTransform {
-    let w = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
-    let h = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
+    var matrix = CGAffineTransform.identity
 
-    // CGAffineTransform applies as `cx = a*x + c*y + tx`, `cy = b*x + d*y + ty`.
-    var matrix: CGAffineTransform
+    // 1. Counter-rotate by the orientation to get it up-right
     switch orientation {
     case .up:
-      matrix = CGAffineTransform(a: 1 / w, b: 0, c: 0, d: 1 / h, tx: 0, ty: 0)
+      break
     case .down:
-      matrix = CGAffineTransform(a: -1 / w, b: 0, c: 0, d: -1 / h, tx: 1, ty: 1)
+      matrix =
+        matrix
+        .translatedBy(x: 1, y: 1)
+        .rotated(by: .pi)
     case .left:
-      matrix = CGAffineTransform(a: 0, b: -1 / w, c: 1 / h, d: 0, tx: 0, ty: 1)
+      matrix =
+        matrix
+        .translatedBy(x: 1, y: 0)
+        .rotated(by: .pi / 2)
     case .right:
-      matrix = CGAffineTransform(a: 0, b: 1 / w, c: -1 / h, d: 0, tx: 1, ty: 0)
+      matrix =
+        matrix
+        .translatedBy(x: 0, y: 1)
+        .rotated(by: -.pi / 2)
     }
 
+    // 2. If the Frame is mirrored, counter-mirror our Matrix
     if isMirrored {
-      // Mirror in normalized output space: `(cx, cy) → (1 - cx, cy)`. For an
-      // affine `[a c tx; b d ty]`, post-composing flips the signs of `a` and
-      // `c` and replaces `tx` with `1 - tx`.
-      matrix = CGAffineTransform(
-        a: -matrix.a, b: matrix.b,
-        c: -matrix.c, d: matrix.d,
-        tx: 1 - matrix.tx, ty: matrix.ty
-      )
+      let mirror = CGAffineTransform.identity
+        .translatedBy(x: 1, y: 0)
+        .scaledBy(x: -1, y: 1)
+      matrix = mirror.concatenating(matrix)
     }
+
+    // 3. Our Matrix is in [0, 1], so let's scale it to [0, width|height] now
+    let width = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
+    let height = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
+    matrix = matrix.scaledBy(x: 1 / width, y: 1 / height)
 
     return matrix
   }

--- a/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
+++ b/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
@@ -10,55 +10,50 @@ import CoreGraphics
 
 enum FrameCoordinateSystemConverter {
   /**
-   * Get a Matrix that can convert a point in the
-   * given `pixelBuffer` to normalized Camera coordiantes.
-   * The `orientation` and `isMirrored` flags affect the
-   * Matrix if the `Frame` needs those to be adjusted.
+   * Get a Matrix that maps a point in the given `pixelBuffer` to a normalized
+   * camera point `(cx, cy) ∈ [0, 1]²`, applying `orientation` and `isMirrored`.
+   *
+   * Each orientation maps the frame pixel `(x, y)` to:
+   * - `.up`    → (    x/w,     y/h)
+   * - `.down`  → (1 - x/w, 1 - y/h)
+   * - `.left`  → (    y/h, 1 - x/w)
+   * - `.right` → (1 - y/h,     x/w)
+   *
+   * Implemented as a direct affine matrix per orientation rather than chained
+   * `.scaledBy().translatedBy().rotated()` calls — those translate in pixel
+   * space (the scale is post-pended) so `(1, 0)` shifts by one pixel, not by
+   * the full width. Issue #3871.
    */
   static func getFrameToCameraMatrix(
     pixelBuffer: CVPixelBuffer,
     orientation: CameraOrientation,
     isMirrored: Bool
   ) -> CGAffineTransform {
-    let width = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
-    let height = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
+    let w = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
+    let h = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
 
-    // Normalized 0...width/0...height -> 0...1/0...1
-    var matrix = CGAffineTransform.identity
-      .scaledBy(x: 1.0 / width, y: 1.0 / height)
-
-    // CameraOrientation is applied in normalized space around origin.
-    // We add translations so the transformed result stays in [0,1]x[0,1].
+    // CGAffineTransform applies as `cx = a*x + c*y + tx`, `cy = b*x + d*y + ty`.
+    var matrix: CGAffineTransform
     switch orientation {
     case .up:
-      // (x, y)
-      break
+      matrix = CGAffineTransform(a: 1 / w, b: 0, c: 0, d: 1 / h, tx: 0, ty: 0)
     case .down:
-      // (1-x, 1-y)
-      matrix =
-        matrix
-        .translatedBy(x: 1, y: 1)
-        .rotated(by: .pi)
+      matrix = CGAffineTransform(a: -1 / w, b: 0, c: 0, d: -1 / h, tx: 1, ty: 1)
     case .left:
-      // portrait: (y, 1-x)
-      matrix =
-        matrix
-        .translatedBy(x: 1, y: 0)
-        .rotated(by: .pi / 2)
+      matrix = CGAffineTransform(a: 0, b: -1 / w, c: 1 / h, d: 0, tx: 0, ty: 1)
     case .right:
-      // portraitUpsideDown: (1-y, x)
-      matrix =
-        matrix
-        .translatedBy(x: 0, y: 1)
-        .rotated(by: -.pi / 2)
+      matrix = CGAffineTransform(a: 0, b: 1 / w, c: -1 / h, d: 0, tx: 1, ty: 0)
     }
 
     if isMirrored {
-      // Mirror in normalized space: x -> 1-x
-      matrix =
-        matrix
-        .translatedBy(x: 1, y: 0)
-        .scaledBy(x: -1, y: 1)
+      // Mirror in normalized output space: `(cx, cy) → (1 - cx, cy)`. For an
+      // affine `[a c tx; b d ty]`, post-composing flips the signs of `a` and
+      // `c` and replaces `tx` with `1 - tx`.
+      matrix = CGAffineTransform(
+        a: -matrix.a, b: matrix.b,
+        c: -matrix.c, d: matrix.d,
+        tx: 1 - matrix.tx, ty: matrix.ty
+      )
     }
 
     return matrix

--- a/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
+++ b/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
@@ -10,9 +10,11 @@ import CoreGraphics
 
 enum FrameCoordinateSystemConverter {
   /**
-   * Returns a matrix that maps a point in the given `pixelBuffer` to a
-   * normalized camera point `(cx, cy) ∈ [0, 1]²`, applying `orientation`
-   * and `isMirrored`.
+   * Get a Matrix that can convert a point in the
+   * given `pixelBuffer` to normalized Camera coordinates
+   * (`(cx, cy) ∈ [0, 1]²`).
+   * The `orientation` and `isMirrored` flags affect the
+   * Matrix if the `Frame` needs those to be adjusted.
    */
   static func getFrameToCameraMatrix(
     pixelBuffer: CVPixelBuffer,


### PR DESCRIPTION
Coordinate system conversion methods (e.g. `convertCameraPointToViewPoint(...)`, `convertViewPointToCameraPoint(...)` and `convertFramePointToCameraPoint(...)`) were buggy due to two different bugs;

- iOS: We use a `identity.scaledBy().translatedBy().rotated()` `CGAffineTransform` chain, which was other way around - order matters. Now we flipped that, operate in `[0, 1]` space first, and then upscale at the end. Pre-translate before rotate/scale was the issue
- Android: I think we didn't take pixel ratio into account

Fixes https://github.com/mrousavy/react-native-vision-camera/issues/3871