### PR TITLE
fix(ios): guard against nil AVCaptureDevice in isMicrophone on iOS 16

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureInput+isMicrophone.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureInput+isMicrophone.swift
@@ -13,6 +13,14 @@ extension AVCaptureInput {
     guard let self = self as? AVCaptureDeviceInput else {
       return false
     }
+    // On iOS 16 with older devices (e.g. iPhone 8 / A11 chip), iterating
+    // `AVCaptureSession.inputs` during a `beginConfiguration`/`commitConfiguration`
+    // block can yield an `AVCaptureDeviceInput` whose underlying `device` has
+    // already been deallocated. Calling `.deviceType` on a nil `device` causes
+    // a SIGSEGV (KERN_INVALID_ADDRESS at 0x0). Guard against this before access.
+    guard self.device != nil else {
+      return false
+    }
     if #available(iOS 17.0, *) {
       return self.device.deviceType == .microphone
     } else {


### PR DESCRIPTION
## Problem

On **iOS 16** with older devices (e.g. **iPhone 8 / A11 chip**), the app crashes with `EXC_BAD_ACCESS (SIGSEGV)` — `KERN_INVALID_ADDRESS at 0x0` — when the camera session is being configured.

**Crash stack:**
```
Thread 17 Crashed:
0  AVCaptureInput.isMicrophone.getter         HybridCameraSession.swift:228
1  HybridCameraSession.updateInputs(_:)
2  closure in HybridCameraSession.configure(connections:config:)  line 66
```

## Root Cause

Inside `updateInputs(_:)`, we iterate `self.session.inputs` while the session is between `beginConfiguration()` and `commitConfiguration()`. On iOS 16 with certain older hardware, this can yield an `AVCaptureDeviceInput` whose underlying `AVCaptureDevice` has already been deallocated. Accessing `.deviceType` on a `nil` device causes the SIGSEGV.

The call chain:
```
self.session.inputs  →  AVCaptureDeviceInput  →  .device (nil)  →  .deviceType  → 💥 SIGSEGV
```

## Fix

Add a `guard self.device != nil` check in `AVCaptureInput.isMicrophone` before accessing `.deviceType`. If the device has been deallocated, we conservatively return `false` (treat it as a non-microphone input).

## Tested On

- iPhone 8 (iPhone10,1) / iOS 16.7.15 — crash no longer reproduced after the fix

## Notes

This does not affect iOS 17+ devices, where `AVCaptureDeviceType.microphone` replaces `.builtInMicrophone` — the `#available` check already handles that branch.