### PR TITLE
fix: initialize iOS preview orientation

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridInterfaceOrientationManager.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridInterfaceOrientationManager.swift
@@ -15,9 +15,12 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
 
   override init() {
     super.init()
-    DispatchQueue.main.async {
-      let interfaceOrientation = UIApplication.shared.interfaceOrientation
-      self.currentOrientation = CameraOrientation(interfaceOrientation: interfaceOrientation)
+    if Thread.isMainThread {
+      updateCurrentOrientation()
+    } else {
+      DispatchQueue.main.async {
+        self.updateCurrentOrientation()
+      }
     }
   }
 
@@ -52,6 +55,7 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
           onChanged(orientation)
         }
       }
+      self.updateCurrentOrientation(onChanged: onChanged)
     }
   }
 
@@ -62,6 +66,22 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
         NotificationCenter.default.removeObserver(observer)
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
       }
+    }
+  }
+
+  private func updateCurrentOrientation(onChanged: ((CameraOrientation) -> Void)? = nil) {
+    let interfaceOrientation = UIApplication.shared.interfaceOrientation
+    guard interfaceOrientation != .unknown else {
+      logger.warning("UIInterfaceOrientation is .unknown!")
+      return
+    }
+    let orientation = CameraOrientation(interfaceOrientation: interfaceOrientation)
+    if self.currentOrientation != orientation {
+      if onChanged != nil {
+        logger.info("Interface orientation changed: \(orientation.stringValue)")
+      }
+      self.currentOrientation = orientation
+      onChanged?(orientation)
     }
   }
 }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPreviewOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPreviewOutput.swift
@@ -59,6 +59,14 @@ final class HybridCameraPreviewOutput: HybridCameraPreviewOutputSpec, NativePrev
     try? connection.setMirrorMode(config.mirrorMode)
     if let interfaceOrientation = orientationManager.currentOrientation {
       try? connection.setOrientation(interfaceOrientation)
+    } else {
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        guard let connection = self.previewLayer.connection else { return }
+        if let interfaceOrientation = self.orientationManager.currentOrientation {
+          try? connection.setOrientation(interfaceOrientation)
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes an iOS preview orientation race when the camera is first configured after launching the app directly into landscape.

`HybridInterfaceOrientationManager` previously initialized `currentOrientation` asynchronously on the main queue. In fast startup paths, `HybridCameraPreviewOutput.configure(...)` could run before that async orientation read completed, leaving the preview connection without the current interface orientation until a later orientation notification arrived.

This PR makes the initial orientation available earlier and applies it more reliably:

- read the initial interface orientation synchronously when already on the main thread;
- refresh the current interface orientation immediately after starting orientation updates;
- retry applying the preview connection orientation on the next main-queue turn if `configure(...)` runs before `currentOrientation` is available.

Reproduction branch:

https://github.com/Phecda/react-native-vision-camera/tree/repro/ios-landscape-preview-orientation

Repro Steps:

1. Build in Release mode
2. Grant camera permission, then fully terminate the app.
3. Rotate the device to landscape and launch the app again.

Expected: the preview is landscape.

Actual: the first preview is rotated by 90 degrees; re-entering the camera screen fixes it.

## Changelog

[IOS] [FIXED] - Initialize and apply preview interface orientation during first camera configuration.

## Test Plan

```sh
swift format --configuration ./config/.swift-format --in-place \
  "packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridInterfaceOrientationManager.swift" \
  "packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPreviewOutput.swift"

git diff --check

bun camera build
```

Result:

```text
TypeScript build completed successfully.
```

I also reproduced the issue with the example app by launching directly in landscape and verified this fix in a downstream app where release builds previously showed the first preview rotated by 90 degrees until leaving and re-entering the camera screen.
