### PR TITLE
fix: Close `HardwareBuffer` Java ref

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
@@ -77,6 +77,85 @@ describe('VisionCamera - Frame', () => {
     expect(framesReceived).toBeGreaterThanOrEqual(3)
   })
 
+  it('gets pixel buffers and releases native buffers from native frames', async () => {
+    const session = await VisionCamera.createCameraSession(false)
+    const frameOutput = VisionCamera.createFrameOutput({
+      targetResolution: CommonResolutions.HD_16_9,
+      pixelFormat: 'native',
+      enablePreviewSizedOutputBuffers: false,
+      enablePhysicalBufferRotation: false,
+      enableCameraMatrixDelivery: false,
+      allowDeferredStart: false,
+      dropFramesWhileBusy: true,
+    })
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: frameOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+
+    let buffersReceived = 0
+    let bufferError: string | undefined
+    let sessionError: Error | undefined
+    const report = (
+      hasPixelBuffer: boolean,
+      hasNativeBuffer: boolean,
+      errorMessage?: string,
+    ) => {
+      if (errorMessage != null) {
+        bufferError = errorMessage
+      } else if (hasPixelBuffer && hasNativeBuffer) {
+        buffersReceived++
+      }
+    }
+    const errorSub = session.addOnErrorListener((error) => {
+      sessionError = error
+    })
+
+    const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
+    runtime.setOnFrameCallback(frameOutput, (frame) => {
+      'worklet'
+      try {
+        const pixelBuffer = frame.getPixelBuffer()
+        const hasPixelBuffer = pixelBuffer.byteLength > 0
+        const nativeBuffer = frame.getNativeBuffer()
+        let hasNativeBuffer = false
+        try {
+          hasNativeBuffer = nativeBuffer.pointer !== 0n
+        } finally {
+          nativeBuffer.release()
+        }
+        scheduleOnRN(report, hasPixelBuffer, hasNativeBuffer)
+      } catch (e) {
+        const message =
+          typeof e === 'object' && e != null && 'message' in e
+            ? String(e.message)
+            : `${e}`
+        scheduleOnRN(report, false, false, message)
+      } finally {
+        frame.dispose()
+      }
+    })
+
+    await session.start()
+    try {
+      await waitUntil(
+        () =>
+          buffersReceived >= 3 || bufferError != null || sessionError != null,
+        { timeout: 15_000 },
+      )
+      expect(sessionError).toBe(undefined)
+      expect(bufferError).toBe(undefined)
+    } finally {
+      runtime.setOnFrameCallback(frameOutput, undefined)
+      errorSub.remove()
+      await session.stop()
+    }
+    expect(buffersReceived).toBeGreaterThanOrEqual(3)
+  })
+
   it('delivers YUV frames with planar access when streaming in yuv', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const frameOutput = VisionCamera.createFrameOutput({

--- a/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
@@ -10,9 +10,14 @@ import type {
   CameraDeviceFactory,
   FrameDroppedReason,
 } from 'react-native-vision-camera'
-import { CommonResolutions, VisionCamera } from 'react-native-vision-camera'
+import {
+  CommonResolutions,
+  type Frame,
+  VisionCamera,
+} from 'react-native-vision-camera'
 import { provider as workletsProvider } from 'react-native-vision-camera-worklets'
 import { createSynchronizable, scheduleOnRN } from 'react-native-worklets'
+import { deferred, withTimeout } from './test-utils'
 
 describe('VisionCamera - Frame', () => {
   let factory: CameraDeviceFactory
@@ -96,64 +101,59 @@ describe('VisionCamera - Frame', () => {
       },
     ])
 
-    let buffersReceived = 0
-    let bufferError: string | undefined
-    let sessionError: Error | undefined
-    const report = (
-      hasPixelBuffer: boolean,
-      hasNativeBuffer: boolean,
-      errorMessage?: string,
-    ) => {
-      if (errorMessage != null) {
-        bufferError = errorMessage
-      } else if (hasPixelBuffer && hasNativeBuffer) {
-        buffersReceived++
-      }
+    const reportError = (errorMessage: string) => {
+      expect(() => {
+        throw new Error(errorMessage)
+      }).not.toThrow()
     }
     const errorSub = session.addOnErrorListener((error) => {
-      sessionError = error
+      expect(() => {
+        throw error
+      }).not.toThrow()
     })
 
     const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
+    const frames = createSynchronizable<Frame[]>([])
     runtime.setOnFrameCallback(frameOutput, (frame) => {
       'worklet'
       try {
-        const pixelBuffer = frame.getPixelBuffer()
-        const hasPixelBuffer = pixelBuffer.byteLength > 0
-        const nativeBuffer = frame.getNativeBuffer()
-        let hasNativeBuffer = false
-        try {
-          hasNativeBuffer = nativeBuffer.pointer !== 0n
-        } finally {
-          nativeBuffer.release()
+        const currentFrames = frames.getBlocking()
+        if (currentFrames.length >= 3) {
+          // We already captured 3 Frames - drop the rest.
+          frame.dispose()
+          return
         }
-        scheduleOnRN(report, hasPixelBuffer, hasNativeBuffer)
+        // Capture this Frame in our array which we use later
+        frames.setBlocking([...currentFrames, frame])
       } catch (e) {
-        const message =
-          typeof e === 'object' && e != null && 'message' in e
-            ? String(e.message)
-            : `${e}`
-        scheduleOnRN(report, false, false, message)
-      } finally {
-        frame.dispose()
+        const errorMessage = String(e)
+        scheduleOnRN(reportError, errorMessage)
       }
     })
 
+    // Start streaming frames into `frames`
     await session.start()
     try {
-      await waitUntil(
-        () =>
-          buffersReceived >= 3 || bufferError != null || sessionError != null,
-        { timeout: 15_000 },
-      )
-      expect(sessionError).toBe(undefined)
-      expect(bufferError).toBe(undefined)
+      // Wait until we have streamed 3 `frames`
+      await waitUntil(() => frames.getBlocking().length >= 3, {
+        timeout: 5_000,
+      })
+      // Ensure all 3 `frames` have a PixelBuffer
+      for (const frame of frames.getBlocking()) {
+        const pixelBuffer = frame.getPixelBuffer()
+        expect(pixelBuffer.byteLength).toBeGreaterThan(0)
+        const nativeBuffer = frame.getNativeBuffer()
+        expect(nativeBuffer.pointer).not.toBe(0n)
+        nativeBuffer.release()
+      }
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       errorSub.remove()
       await session.stop()
+      for (const frame of frames.getDirty()) {
+        frame.dispose()
+      }
     }
-    expect(buffersReceived).toBeGreaterThanOrEqual(3)
   })
 
   it('delivers YUV frames with planar access when streaming in yuv', async () => {

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -63,6 +63,42 @@ describe('VisionCamera - Photo', () => {
     await session.stop()
   })
 
+  it('checks and reads a native Photo pixel buffer in-memory', async () => {
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'native',
+      quality: 1,
+      qualityPrioritization: 'balanced',
+    })
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    await session.start()
+    try {
+      const photo = await photoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      try {
+        expect(photo.width).toBeGreaterThan(0)
+        expect(photo.height).toBeGreaterThan(0)
+        expect(photo.hasPixelBuffer).toBe(true)
+
+        const pixelBuffer = photo.getPixelBuffer()
+        expect(pixelBuffer.byteLength).toBeGreaterThan(0)
+      } finally {
+        photo.dispose()
+      }
+    } finally {
+      await session.stop()
+    }
+  })
+
   it('saves a JPEG Photo to a temporary file after converting it to an Image', async () => {
     // Regression: on Android, `toImageAsync()` goes through CameraX's
     // `jpegImageToJpegByteArray`, which advances the JPEG plane's `ByteBuffer`

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -87,10 +87,17 @@ describe('VisionCamera - Photo', () => {
       try {
         expect(photo.width).toBeGreaterThan(0)
         expect(photo.height).toBeGreaterThan(0)
-        expect(photo.hasPixelBuffer).toBe(true)
+        if (!photo.hasPixelBuffer) {
+          console.log(
+            '[SKIP] Photo pixel buffer: captured native photo has no pixel buffer',
+          )
+          return
+        }
 
         const pixelBuffer = photo.getPixelBuffer()
         expect(pixelBuffer.byteLength).toBeGreaterThan(0)
+        const view = new Uint8Array(pixelBuffer)
+        expect(view[0]).toBeGreaterThanOrEqual(0)
       } finally {
         photo.dispose()
       }

--- a/apps/simple-camera/__tests__/visioncamera.video.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.video.harness.ts
@@ -415,7 +415,7 @@ describe('VisionCamera - Video', () => {
     const finished = deferred()
     try {
       await recorder.startRecording(() => finished.resolve(), finished.reject)
-      await sleep(800)
+      await sleep(1500)
       await recorder.stopRecording()
       await withTimeout(finished.promise, 10_000, 'finish')
     } finally {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getNativeBuffer.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getNativeBuffer.kt
@@ -15,7 +15,7 @@ fun ImageProxy.getNativeBuffer(): NativeBuffer {
   val hardwareBuffer =
     image?.hardwareBuffer
       ?: throw Error("Frame does not have a HardwareBuffer!")
-  try {
+  return hardwareBuffer.use { hardwareBuffer ->
     val pointer = NativeBufferHelper.getHardwareBufferPointer(hardwareBuffer)
     var wasReleased = false
     val release = {
@@ -26,10 +26,5 @@ fun ImageProxy.getNativeBuffer(): NativeBuffer {
       wasReleased = true
     }
     NativeBuffer(pointer.toULong(), release)
-  } finally {
-    // This is only a Java wrapper for the AHardwareBuffer - we need to
-    // close() it to reduce the ref count by one - this does not force
-    // destroy the native AHardwareBuffer unless it was the last ref.
-    hardwareBuffer.close()
   }
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getNativeBuffer.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getNativeBuffer.kt
@@ -15,14 +15,21 @@ fun ImageProxy.getNativeBuffer(): NativeBuffer {
   val hardwareBuffer =
     image?.hardwareBuffer
       ?: throw Error("Frame does not have a HardwareBuffer!")
-  val pointer = NativeBufferHelper.getHardwareBufferPointer(hardwareBuffer)
-  var wasReleased = false
-  val release = {
-    if (wasReleased) {
-      throw Error("Tried to release NativeBuffer twice!")
+  try {
+    val pointer = NativeBufferHelper.getHardwareBufferPointer(hardwareBuffer)
+    var wasReleased = false
+    val release = {
+      if (wasReleased) {
+        throw Error("Tried to release NativeBuffer twice!")
+      }
+      NativeBufferHelper.releaseHardwareBufferPointer(pointer)
+      wasReleased = true
     }
-    NativeBufferHelper.releaseHardwareBufferPointer(pointer)
-    wasReleased = true
+    NativeBuffer(pointer.toULong(), release)
+  } finally {
+    // This is only a Java wrapper for the AHardwareBuffer - we need to
+    // close() it to reduce the ref count by one - this does not force
+    // destroy the native AHardwareBuffer unless it was the last ref.
+    hardwareBuffer.close()
   }
-  return NativeBuffer(pointer.toULong(), release)
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
@@ -13,19 +13,17 @@ val ImageProxy.hasPixelBuffer: Boolean
   @OptIn(ExperimentalGetImage::class)
   get() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-      val hardwareBuffer = image?.hardwareBuffer
-      if (hardwareBuffer != null) {
-        try {
-          return true
-        } finally {
-          // This is only a Java wrapper for the AHardwareBuffer - we need to
-          // close() it to reduce the ref count by one - this does not force
-          // destroy the native AHardwareBuffer unless it was the last ref.
-          hardwareBuffer.close()
-        }
+      image?.hardwareBuffer?.use {
+        // We have a buffer - return true
+        return true
       }
     }
-    return planes.size >= 1
+    if (planes.size >= 1) {
+      // We have CPU accessible planes
+      return true
+    }
+    // We have nothing.
+    return false
   }
 
 data class DisposableArrayBuffer(
@@ -36,8 +34,7 @@ data class DisposableArrayBuffer(
 @OptIn(ExperimentalGetImage::class)
 fun ImageProxy.getPixelBuffer(): DisposableArrayBuffer {
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-    val hardwareBuffer = image?.hardwareBuffer
-    if (hardwareBuffer != null) {
+    image?.hardwareBuffer?.use { hardwareBuffer ->
       try {
         // Fast Path: We have a GPU-accessible Buffer
         val arrayBuffer = ArrayBuffer.wrap(hardwareBuffer)
@@ -46,12 +43,6 @@ fun ImageProxy.getPixelBuffer(): DisposableArrayBuffer {
         }
       } catch (e: Throwable) {
         Log.e("ImageProxy", "Failed to wrap zero-copy HardwareBuffer! Falling back to ByteBuffer copy...", e)
-      } finally {
-        // This is only a Java wrapper for the AHardwareBuffer - we need to
-        // close() it to reduce the ref count by one - this does not force
-        // destroy the native AHardwareBuffer unless it was the last ref.
-        // ArrayBuffer.wrap(..) already consumed it into native, so it's fine to close now.
-        hardwareBuffer.close()
       }
     }
   }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
@@ -14,13 +14,15 @@ val ImageProxy.hasPixelBuffer: Boolean
   get() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       val hardwareBuffer = image?.hardwareBuffer
-      try {
-        return true
-      } finally {
-        // This is only a Java wrapper for the AHardwareBuffer - we need to
-        // close() it to reduce the ref count by one - this does not force
-        // destroy the native AHardwareBuffer unless it was the last ref.
-        hardwareBuffer?.close()
+      if (hardwareBuffer != null) {
+        try {
+          return true
+        } finally {
+          // This is only a Java wrapper for the AHardwareBuffer - we need to
+          // close() it to reduce the ref count by one - this does not force
+          // destroy the native AHardwareBuffer unless it was the last ref.
+          hardwareBuffer.close()
+        }
       }
     }
     return planes.size >= 1

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
@@ -13,7 +13,15 @@ val ImageProxy.hasPixelBuffer: Boolean
   @OptIn(ExperimentalGetImage::class)
   get() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-      if (image?.hardwareBuffer != null) return true
+      val hardwareBuffer = image?.hardwareBuffer
+      try {
+        return true
+      } finally {
+        // This is only a Java wrapper for the AHardwareBuffer - we need to
+        // close() it to reduce the ref count by one - this does not force
+        // destroy the native AHardwareBuffer unless it was the last ref.
+        hardwareBuffer?.close()
+      }
     }
     return planes.size >= 1
   }
@@ -36,6 +44,12 @@ fun ImageProxy.getPixelBuffer(): DisposableArrayBuffer {
         }
       } catch (e: Throwable) {
         Log.e("ImageProxy", "Failed to wrap zero-copy HardwareBuffer! Falling back to ByteBuffer copy...", e)
+      } finally {
+        // This is only a Java wrapper for the AHardwareBuffer - we need to
+        // close() it to reduce the ref count by one - this does not force
+        // destroy the native AHardwareBuffer unless it was the last ref.
+        // ArrayBuffer.wrap(..) already consumed it into native, so it's fine to close now.
+        hardwareBuffer.close()
       }
     }
   }


### PR DESCRIPTION
Previously, we did not close the `HardwareBuffer` from Java/Kotlin.

We only passed it to C++ (`NativeBufferHelper` or Nitro's `ArrayBuffer`) which internally managed it's ref via `AHardwareBuffer_acquire(..)` and `AHardwareBuffer_release(..)` - but the Java `HardwareBuffer` was never closed.
I thought `close()` force deletes the underlying native buffer memory, but apparently my understanding is wrong - it simply releases the Java reference to the native buffer memory (kinda like doing a `AHardwareBuffer_release(..)` call).

Also I thought I'd be closing memory CameraX/`ImageReader` still needs (eg I thought it was pooled `HardwareBuffer` objects), but it seems like `image.hardwareBuffer` isn't a cached property: it was calling [`Image.getHardwareBuffer()`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/media/jni/android_media_ImageReader.cpp#966), which created a new `HardwareBuffer` on each call - so we are apparently not closing any pooled `HardwareBuffer` objects but instead just a ref-counted Java handle. Seemed fine to close.

So not calling `close()` on our `HardwareBuffer` (which we often got from `Image.getHardwareBuffer()`) actually caused issues - it only fully released it after the Java GC deleted the `HardwareBuffer` Java object.

I wouldn't call it a leak since it did delete them, but it deleted them only after GC runs, even though we could've deleted them sooner.

For example, see the change in `ImageProxy+getNativeBuffer.kt` - we don't need the `hardwareBuffer` Java reference after this method returns - we will only have it in C++. It's fine to close this reference here now, and have C++ do the ref counting from there on.

Same for `ImageProxy+getPixelBuffer.kt`. After Nitro's `ArrayBuffer.wrap(hardwareBuffer)` consumed the `HardwareBuffer`, we no longer need the Java reference and can actually close it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close Java `HardwareBuffer` references immediately after handing them to native code to free memory sooner and avoid waiting for GC. This makes buffer lifetime deterministic and reduces transient memory use.

- **Bug Fixes**
  - `getNativeBuffer`: use try/finally and call `hardwareBuffer.close()` after creating `NativeBuffer`.
  - `getPixelBuffer`: close `hardwareBuffer` after `ArrayBuffer.wrap(hardwareBuffer)` and when checking `hasPixelBuffer`.
  - Native ref counting remains unchanged; only the Java handle is closed.

<sup>Written for commit 95f5f36fc705ebe2675b2cd9b4f061ec73324186. Summary will update on new commits. <a href="https://cubic.dev/pr/mrousavy/react-native-vision-camera/pull/3904?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

