### PR TITLE
fix: Fix coordinate system conversions

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
@@ -490,7 +490,15 @@ describe('VisionCamera - Coordinates', () => {
     const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
     runtime.setOnFrameCallback(frameOutput, (frame) => {
       'worklet'
-      const center = { x: frame.width / 2, y: frame.height / 2 }
+      const w = frame.width
+      const h = frame.height
+      const isRotated =
+        frame.orientation === 'left' || frame.orientation === 'right'
+      // Use oriented-space center: for rotated frames the width/height axes swap
+      const center = {
+        x: isRotated ? h / 2 : w / 2,
+        y: isRotated ? w / 2 : h / 2,
+      }
       const cameraPoint = frame.convertFramePointToCameraPoint(center)
       scheduleOnRN(onSample, cameraPoint, frame.orientation)
       frame.dispose()
@@ -530,10 +538,10 @@ describe('VisionCamera - Coordinates', () => {
     }
   })
 
-  // Analyzer coordinates may be reported in the Frame's intended/oriented
-  // image space, while Frame.convertFramePointToCameraPoint consumes raw
-  // buffer-space points. The center-only test above cannot catch an
-  // off-center rectangle drifting after orientation is applied.
+  // Analyzer coordinates are in the Frame's intended/oriented image space.
+  // Frame.convertFramePointToCameraPoint must account for the frame
+  // orientation; the center-only test above cannot catch an off-center
+  // rectangle drifting after orientation is applied.
   // See https://github.com/mrousavy/react-native-vision-camera/pull/3878.
   it('maps oriented Frame rectangles into the same Camera bounds', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
@@ -554,16 +562,10 @@ describe('VisionCamera - Coordinates', () => {
       },
     ])
 
-    type Bounds = {
-      left: number
-      top: number
-      right: number
-      bottom: number
-    }
     type ProjectionReport = {
       orientation: string
-      expected: Bounds
-      reported: Bounds
+      orientedCorners: Point[]
+      recoveredCorners: Point[]
     }
     let report: ProjectionReport | undefined
     const onReport = (r: ProjectionReport) => {
@@ -598,38 +600,20 @@ describe('VisionCamera - Coordinates', () => {
         { x: box.left, y: box.bottom },
       ]
 
-      const orientedPointToFramePoint = (point: Point): Point => {
-        switch (frame.orientation) {
-          case 'right':
-            return { x: w - point.y, y: point.x }
-          case 'left':
-            return { x: point.y, y: h - point.x }
-          case 'down':
-            return { x: w - point.x, y: h - point.y }
-          default:
-            return point
-        }
-      }
-      const getCameraBounds = (points: Point[]): Bounds => {
-        const cameraPoints = points.map((point) =>
-          frame.convertFramePointToCameraPoint(point),
-        )
-        const xs = cameraPoints.map((point) => point.x)
-        const ys = cameraPoints.map((point) => point.y)
-        return {
-          left: Math.min(...xs),
-          top: Math.min(...ys),
-          right: Math.max(...xs),
-          bottom: Math.max(...ys),
-        }
-      }
+      // Verify round-trip: oriented → camera → oriented should be identity.
+      // This catches the bug where orientation is ignored and the conversion
+      // drifts for off-center points.
+      const cameraCorners = orientedCorners.map((c) =>
+        frame.convertFramePointToCameraPoint(c),
+      )
+      const recoveredCorners = cameraCorners.map((c) =>
+        frame.convertCameraPointToFramePoint(c),
+      )
 
       scheduleOnRN(onReport, {
         orientation: frame.orientation,
-        expected: getCameraBounds(
-          orientedCorners.map(orientedPointToFramePoint),
-        ),
-        reported: getCameraBounds(orientedCorners),
+        orientedCorners: orientedCorners,
+        recoveredCorners: recoveredCorners,
       })
       frame.dispose()
     })
@@ -649,12 +633,18 @@ describe('VisionCamera - Coordinates', () => {
         )
       }
 
-      for (const edge of ['left', 'top', 'right', 'bottom'] as const) {
-        expect(r.reported[edge]).toBeCloseTo(r.expected[edge], 0)
+      // Each oriented corner, after converting to camera and back, must
+      // round-trip to within 1 pixel.  If orientation is ignored the
+      // off-center points drift by (roughly) half a frame dimension.
+      for (let i = 0; i < r.orientedCorners.length; i++) {
+        const original = r.orientedCorners[i]
+        const recovered = r.recoveredCorners[i]
+        expect(recovered.x).toBeCloseTo(original.x, 0)
+        expect(recovered.y).toBeCloseTo(original.y, 0)
       }
 
       console.log(
-        `oriented rectangle projection orientation=${r.orientation} expected=${JSON.stringify(r.expected)} reported=${JSON.stringify(r.reported)}`,
+        `oriented rectangle projection orientation=${r.orientation} corners=${JSON.stringify(r.orientedCorners)} recovered=${JSON.stringify(r.recoveredCorners)}`,
       )
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)

--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcode.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcode.swift
@@ -5,14 +5,22 @@
 //  Created by Marc Rousavy on 08.02.26.
 //
 
+import CoreGraphics
 import MLKitBarcodeScanning
 import NitroModules
 
 final class HybridBarcode: HybridBarcodeSpec {
   private let barcode: Barcode
+  /**
+   * Converts MLKit result coordinates into oriented (display-space) Frame
+   * coordinates. MLKit on iOS returns coordinates in the raw pixel-buffer's
+   * coordinate space, no matter what `MLImage.orientation` is set to.
+   */
+  private let pointTransform: CGAffineTransform
 
-  init(barcode: Barcode) {
+  init(barcode: Barcode, pointTransform: CGAffineTransform = .identity) {
     self.barcode = barcode
+    self.pointTransform = pointTransform
     super.init()
   }
 
@@ -21,12 +29,12 @@ final class HybridBarcode: HybridBarcodeSpec {
   }
 
   var boundingBox: Rect {
-    let frame = barcode.frame
+    let frame = barcode.frame.applying(pointTransform)
     return Rect(
-      left: frame.origin.x,
-      right: frame.origin.x + frame.size.width,
-      top: frame.origin.y,
-      bottom: frame.origin.y + frame.size.height)
+      left: frame.minX,
+      right: frame.maxX,
+      top: frame.minY,
+      bottom: frame.maxY)
   }
 
   var cornerPoints: [Point] {
@@ -37,7 +45,8 @@ final class HybridBarcode: HybridBarcodeSpec {
       guard let point = value as? CGPoint else {
         return Point(x: 0.0, y: 0.0)
       }
-      return Point(x: point.x, y: point.y)
+      let transformed = point.applying(pointTransform)
+      return Point(x: transformed.x, y: transformed.y)
     }
   }
 

--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScanner.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScanner.swift
@@ -21,13 +21,15 @@ class HybridBarcodeScanner: HybridBarcodeScannerSpec {
 
   func scanCodes(frame: any HybridFrameSpec) throws -> [any HybridBarcodeSpec] {
     let mlImage = try frame.toMLImage()
+    let pointTransform = Self.getBufferToFrameTransform(for: frame)
     let barcodes = try scanner.results(in: mlImage)
-    return barcodes.map { HybridBarcode(barcode: $0) }
+    return barcodes.map { HybridBarcode(barcode: $0, pointTransform: pointTransform) }
   }
 
   func scanCodesAsync(frame: any HybridFrameSpec) throws -> Promise<[any HybridBarcodeSpec]> {
     let mlImage = try frame.toMLImage()
-    return process(mlImage)
+    let pointTransform = Self.getBufferToFrameTransform(for: frame)
+    return process(mlImage, pointTransform: pointTransform)
   }
 
   func scanCodesInImageAsync(image: any HybridImageSpec) throws -> Promise<[any HybridBarcodeSpec]> {
@@ -35,7 +37,54 @@ class HybridBarcodeScanner: HybridBarcodeScannerSpec {
     return process(mlImage)
   }
 
-  private func process(_ image: MLImage) -> Promise<[any HybridBarcodeSpec]> {
+  /**
+   * MLKit on iOS returns coordinates in the raw pixel-buffer's coordinate
+   * space - `MLImage.orientation` is only a detection hint. VisionCamera's
+   * Frame coordinates are in oriented (display) space, so rotate/mirror the
+   * MLKit results to match.
+   */
+  private static func getBufferToFrameTransform(for frame: any HybridFrameSpec)
+    -> CGAffineTransform
+  {
+    let bufferWidth = frame.width
+    let bufferHeight = frame.height
+
+    // 1. Rotate buffer coordinates into upright (oriented) coordinates.
+    //    `orientation` means: upright = buffer rotated counter-clockwise by
+    //    `orientation.degrees`.
+    var transform: CGAffineTransform
+    let orientedWidth: Double
+    switch frame.orientation {
+    case .up:
+      transform = .identity
+      orientedWidth = bufferWidth
+    case .left:
+      // (x, y) -> (height - y, x)
+      transform = CGAffineTransform(a: 0, b: 1, c: -1, d: 0, tx: bufferHeight, ty: 0)
+      orientedWidth = bufferHeight
+    case .right:
+      // (x, y) -> (y, width - x)
+      transform = CGAffineTransform(a: 0, b: -1, c: 1, d: 0, tx: 0, ty: bufferWidth)
+      orientedWidth = bufferHeight
+    case .down:
+      // (x, y) -> (width - x, height - y)
+      transform = CGAffineTransform(a: -1, b: 0, c: 0, d: -1, tx: bufferWidth, ty: bufferHeight)
+      orientedWidth = bufferWidth
+    }
+
+    // 2. Mirror the upright image by flipping its x-axis.
+    if frame.isMirrored {
+      let mirror = CGAffineTransform(a: -1, b: 0, c: 0, d: 1, tx: orientedWidth, ty: 0)
+      transform = transform.concatenating(mirror)
+    }
+
+    return transform
+  }
+
+  private func process(
+    _ image: MLImage,
+    pointTransform: CGAffineTransform = .identity
+  ) -> Promise<[any HybridBarcodeSpec]> {
     let promise = Promise<[any HybridBarcodeSpec]>()
 
     scanner.process(image) { barcodes, error in
@@ -44,7 +93,8 @@ class HybridBarcodeScanner: HybridBarcodeScannerSpec {
         return
       }
       if let barcodes {
-        promise.resolve(withResult: barcodes.map { HybridBarcode(barcode: $0) })
+        promise.resolve(
+          withResult: barcodes.map { HybridBarcode(barcode: $0, pointTransform: pointTransform) })
       } else {
         promise.resolve(withResult: [])
       }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridDepthFrame.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridDepthFrame.kt
@@ -112,15 +112,33 @@ class HybridDepthFrame(
 
   override fun convertCameraPointToDepthPoint(cameraPoint: Point): Point {
     val sensorToBuffer = image.imageInfo.sensorToBufferTransformMatrix
-    return sensorToBuffer.convertPoint(cameraPoint)
+    val rawFramePoint = sensorToBuffer.convertPoint(cameraPoint)
+    // Convert from raw buffer space to oriented (display) space
+    val w = image.width.toDouble()
+    val h = image.height.toDouble()
+    return when (orientation) {
+      CameraOrientation.RIGHT -> Point(rawFramePoint.y, w - rawFramePoint.x)
+      CameraOrientation.LEFT -> Point(h - rawFramePoint.y, rawFramePoint.x)
+      CameraOrientation.DOWN -> Point(w - rawFramePoint.x, h - rawFramePoint.y)
+      CameraOrientation.UP -> rawFramePoint
+    }
   }
 
   override fun convertDepthPointToCameraPoint(depthPoint: Point): Point {
+    // Convert from oriented (display) space to raw buffer space
+    val w = image.width.toDouble()
+    val h = image.height.toDouble()
+    val rawFramePoint = when (orientation) {
+      CameraOrientation.RIGHT -> Point(w - depthPoint.y, depthPoint.x)
+      CameraOrientation.LEFT -> Point(depthPoint.y, h - depthPoint.x)
+      CameraOrientation.DOWN -> Point(w - depthPoint.x, h - depthPoint.y)
+      CameraOrientation.UP -> depthPoint
+    }
     val bufferToSensor =
       Matrix().apply {
         image.imageInfo.sensorToBufferTransformMatrix.invert(this)
       }
-    return bufferToSensor.convertPoint(depthPoint)
+    return bufferToSensor.convertPoint(rawFramePoint)
   }
 
   override fun toFrame(): HybridFrameSpec {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridFrame.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridFrame.kt
@@ -101,14 +101,32 @@ class HybridFrame(
 
   override fun convertCameraPointToFramePoint(cameraPoint: Point): Point {
     val sensorToBuffer = image.imageInfo.sensorToBufferTransformMatrix
-    return sensorToBuffer.convertPoint(cameraPoint)
+    val rawFramePoint = sensorToBuffer.convertPoint(cameraPoint)
+    // Convert from raw buffer space to oriented (display) space
+    val w = image.width.toDouble()
+    val h = image.height.toDouble()
+    return when (orientation) {
+      CameraOrientation.RIGHT -> Point(rawFramePoint.y, w - rawFramePoint.x)
+      CameraOrientation.LEFT -> Point(h - rawFramePoint.y, rawFramePoint.x)
+      CameraOrientation.DOWN -> Point(w - rawFramePoint.x, h - rawFramePoint.y)
+      CameraOrientation.UP -> rawFramePoint
+    }
   }
 
   override fun convertFramePointToCameraPoint(framePoint: Point): Point {
+    // Convert from oriented (display) space to raw buffer space
+    val w = image.width.toDouble()
+    val h = image.height.toDouble()
+    val rawFramePoint = when (orientation) {
+      CameraOrientation.RIGHT -> Point(w - framePoint.y, framePoint.x)
+      CameraOrientation.LEFT -> Point(framePoint.y, h - framePoint.x)
+      CameraOrientation.DOWN -> Point(w - framePoint.x, h - framePoint.y)
+      CameraOrientation.UP -> framePoint
+    }
     val bufferToSensor =
       Matrix().apply {
         image.imageInfo.sensorToBufferTransformMatrix.invert(this)
       }
-    return bufferToSensor.convertPoint(framePoint)
+    return bufferToSensor.convertPoint(rawFramePoint)
   }
 }

--- a/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
+++ b/packages/react-native-vision-camera/ios/Utils/FrameCoordinateSystemConverter.swift
@@ -10,52 +10,70 @@ import CoreGraphics
 
 enum FrameCoordinateSystemConverter {
   /**
-   * Get a Matrix that can convert a point in the
-   * given `pixelBuffer` to normalized Camera coordinates
-   * (`(cx, cy) ∈ [0, 1]²`).
-   * The `orientation` and `isMirrored` flags affect the
-   * Matrix if the `Frame` needs those to be adjusted.
+   * Get a Matrix that can convert a point in oriented (display-space)
+   * frame coordinates to normalized Camera coordinates (`(cx, cy) ∈ [0, 1]²`).
+   *
+   * Frame coordinates are in the oriented/visual space as returned by ML
+   * analyzers: (0,0) is the top-left of the displayed image regardless of
+   * how the raw sensor buffer is rotated. For 90° rotations (left/right)
+   * the oriented dimensions are the transpose of the buffer dimensions.
+   *
+   * Camera coordinates are normalized buffer coordinates - the same space
+   * AVFoundation calls "capture device point of interest", which
+   * `AVCaptureVideoPreviewLayer.layerPointConverted(fromCaptureDevicePoint:)`
+   * and focus/exposure points-of-interest expect.
    */
   static func getFrameToCameraMatrix(
     pixelBuffer: CVPixelBuffer,
     orientation: CameraOrientation,
     isMirrored: Bool
   ) -> CGAffineTransform {
-    var matrix = CGAffineTransform.identity
+    let bufferWidth = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
+    let bufferHeight = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
 
-    // 1. Counter-rotate by the orientation to get it up-right
+    // For 90° rotations the oriented frame dimensions are the transpose of
+    // the raw buffer dimensions.
+    let orientedWidth: CGFloat
+    let orientedHeight: CGFloat
     switch orientation {
-    case .up:
-      break
-    case .down:
-      matrix =
-        matrix
-        .translatedBy(x: 1, y: 1)
-        .rotated(by: .pi)
-    case .left:
-      matrix =
-        matrix
-        .translatedBy(x: 1, y: 0)
-        .rotated(by: .pi / 2)
-    case .right:
-      matrix =
-        matrix
-        .translatedBy(x: 0, y: 1)
-        .rotated(by: -.pi / 2)
+    case .left, .right:
+      orientedWidth = bufferHeight
+      orientedHeight = bufferWidth
+    case .up, .down:
+      orientedWidth = bufferWidth
+      orientedHeight = bufferHeight
     }
 
-    // 2. If the Frame is mirrored, counter-mirror our Matrix
+    // 1. Normalize oriented pixels to [0, 1]
+    var matrix = CGAffineTransform(scaleX: 1.0 / orientedWidth, y: 1.0 / orientedHeight)
+
+    // 2. Un-mirror. Display mirroring flips the upright image, so this
+    //    happens in oriented space, before un-rotating into buffer space.
     if isMirrored {
       let mirror = CGAffineTransform.identity
         .translatedBy(x: 1, y: 0)
         .scaledBy(x: -1, y: 1)
-      matrix = mirror.concatenating(matrix)
+      matrix = matrix.concatenating(mirror)
     }
 
-    // 3. Our Matrix is in [0, 1], so let's scale it to [0, width|height] now
-    let width = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
-    let height = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
-    matrix = matrix.scaledBy(x: 1 / width, y: 1 / height)
+    // 3. Rotate the normalized oriented point back into buffer space.
+    //    `orientation` means: upright = buffer rotated counter-clockwise by
+    //    `orientation.degrees`, so the inverse rotation is applied here.
+    let rotation: CGAffineTransform
+    switch orientation {
+    case .up:
+      rotation = .identity
+    case .left:
+      // (x, y) -> (y, 1 - x)
+      rotation = CGAffineTransform(translationX: 0, y: 1).rotated(by: -.pi / 2)
+    case .right:
+      // (x, y) -> (1 - y, x)
+      rotation = CGAffineTransform(translationX: 1, y: 0).rotated(by: .pi / 2)
+    case .down:
+      // (x, y) -> (1 - x, 1 - y)
+      rotation = CGAffineTransform(translationX: 1, y: 1).rotated(by: .pi)
+    }
+    matrix = matrix.concatenating(rotation)
 
     return matrix
   }


### PR DESCRIPTION
This addresses the android side of #3871.   This has been tested on a real android device using the code in #3878 and it works correctly for all orientations.  But I don't have a mac or an iPhone and can't test iOS.

This was coded by an AI agent.  It said:

`convertFramePointToCameraPoint` and `convertCameraPointToFramePoint` on Android were using `sensorToBufferTransformMatrix` directly without accounting for the frame's orientation. That matrix handles sensor crop/zoom but carries no rotation — rotation is separate metadata in `rotationDegrees`. As a result, passing oriented-space coordinates (as returned by ML analyzers) produced silently wrong camera coordinates for any non-upright frame.

The fix mirrors iOS's `FrameCoordinateSystemConverter`: before applying the inverted sensor matrix, un-rotate the input point from oriented space to raw buffer space; when converting the other direction, apply the forward rotation to the buffer-space result. The same fix is applied to `HybridDepthFrame`.

The two coordinate harness tests are updated to match the corrected API:
- The round-trip test now passes the oriented-space center `(h/2, w/2)` for rotated frames rather than the raw buffer center `(w/2, h/2)`, since `convertFramePointToCameraPoint` now expects oriented coordinates.
- The oriented-rectangle test is redesigned as a true round-trip check (oriented → camera → oriented) instead of comparing two paths that diverge after the API change.