### PR TITLE
chore: Use Harness' built-in `context.skip(...)` for better DX

### DIFF
--- a/apps/simple-camera/__tests__/README.md
+++ b/apps/simple-camera/__tests__/README.md
@@ -79,15 +79,18 @@ Each atomic test must tear down any non-trivial objects properly to avoid leakin
 Cameras differ. A failing hard requirement is a real bug; a missing soft feature is a device limitation and should not fail the test.
 
 - **Hard requirement** — checked with `expect(...)`, makes the test fail. Examples: a back camera exists; a photo output produces a photo with `width > 0`; `session.configure` returns one controller per connection, or an API contract holds up to it's promise.
-- **Soft requirement** — gated by the matching capability flag and a `console.log('[SKIP] <what>: <reason>')` early-return when not supported. The skip log is deliberately visible in CI so we can see what the current test device can't cover and pick a different device if needed.
+- **Soft requirement** — gated by the matching capability flag and `context.skip('<what>: <reason>')` when not supported. Harness reports this as a real skipped test with the reason in the run summary and JUnit output, so do not use `console.log(...)` plus `return` for runtime camera capability gaps.
 
 ```ts
-if (!backDevice.supportsPhotoHDR) {
-  console.log('[SKIP] photoHDR: not supported on this device')
-  return
-}
-// hard-assert HDR behavior from here on
+it('resolves photoHDR: true when the device supports photo HDR', async (context) => {
+  if (!backDevice.supportsPhotoHDR) {
+    context.skip('photoHDR: not supported on this device')
+  }
+  // hard-assert HDR behavior from here on
+})
 ```
+
+Use the guard form above instead of `context.skip(condition, reason)` when a nullable value needs to be narrowed afterwards. If only one optional case inside a matrix is unsupported, split that case into its own `it(...)` so the always-supported cases still run and the optional case is reported as skipped.
 
 Capability flags live on
 - `CameraDevice` (`hasFlash`, `hasTorch`, `supportsFocusMetering`, `supportsExposureBias`, `supportsPhotoHDR`, `supportsFPS(n)`, `supportsVideoStabilizationMode('cinematic')`, etc.),
@@ -133,7 +136,7 @@ The exception is when elapsed wall-clock time is part of the behavior under test
 
 ### 8. Platform guards
 
-Pure iOS-only features (`CameraObjectOutput`, `continuity camera`, `getSupportedVideoCodecs`, etc.) or Android-only features (`CameraExtension`, etc.) should start with a `if (Platform.OS !== 'ios') { console.log('[SKIP] ...: iOS only'); return }` guard. Do not branch on `Platform.OS` to mask behavioral differences that should be identical across platforms — flag those as bugs.
+Pure iOS-only features (`CameraObjectOutput`, `continuity camera`, `getSupportedVideoCodecs`, etc.) or Android-only features (`CameraExtension`, etc.) should start with a `context.skip('...: iOS only')` / `context.skip('...: Android only')` platform guard. Do not branch on `Platform.OS` to mask behavioral differences that should be identical across platforms — flag those as bugs.
 If a behavior should be supported on both platforms, write one shared test. If that makes CI red on one platform, keep the failure visible until the platform discrepancy is fixed.
 Do not guard features that expose runtime availability checks behind such flags - e.g. `setFocusLocked(...)` can be probed with `device.supportsManualFocus` - even if this natively is always `false` on Android, this allows us to automatically run the test in the future once we add focus locking support to Android too.
 Also do not guard features that are technically possible to implement on the other platform, but not yet implemented due to a TODO behind such feature flags. `setFocusLocked` would be such a case. In these situations, it's expected to have the test red on the missing platform until it's implemented - kinda like a task list for the maintainers.
@@ -200,7 +203,7 @@ The AWS Device Farm run is the source of truth: it's a real phone, a real SoC, a
 If your PR fails CI, the fastest way to debug is:
 
 1. Download the `harness output log` artifact from the failed workflow run. It contains the full JS console output per test.
-2. Grep for `[SKIP]` to see which soft requirements were skipped — that tells you what your test device lacks.
+2. Inspect the Harness/JUnit skipped-test summary to see which soft requirements were skipped — the skip reason tells you what your test device lacks.
 3. Grep for `FAIL` to see which `it` blocks failed and their stack traces.
 4. Open the JUnit XML artifact in your IDE's JUnit viewer for a structured summary.
 

--- a/apps/simple-camera/__tests__/README.md
+++ b/apps/simple-camera/__tests__/README.md
@@ -84,13 +84,15 @@ Cameras differ. A failing hard requirement is a real bug; a missing soft feature
 ```ts
 it('resolves photoHDR: true when the device supports photo HDR', async (context) => {
   if (!backDevice.supportsPhotoHDR) {
-    context.skip('photoHDR: not supported on this device')
+    return context.skip('photoHDR: not supported on this device')
   }
   // hard-assert HDR behavior from here on
 })
 ```
 
-Use the guard form above instead of `context.skip(condition, reason)` when a nullable value needs to be narrowed afterwards. If only one optional case inside a matrix is unsupported, split that case into its own `it(...)` so the always-supported cases still run and the optional case is reported as skipped.
+Use the guard form above instead of `context.skip(condition, reason)` when a nullable value needs to be narrowed afterwards. Keep the `return` so TypeScript understands the rest of the test only runs when the capability exists. If only one optional case inside a matrix is unsupported, split that case into its own `it(...)` so the always-supported cases still run and the optional case is reported as skipped.
+
+Only call `context.skip(...)` from the `it(...)` body or code that intentionally skips that whole test. Do not hide it inside a shared helper for optional sub-assertions, because it aborts the entire `it(...)`. If a shared cross-platform test has an Android-only extra assertion, let that helper return without logging on iOS; if the Android-only behavior deserves skip accounting, make it a dedicated `it(...)`.
 
 Capability flags live on
 - `CameraDevice` (`hasFlash`, `hasTorch`, `supportsFocusMetering`, `supportsExposureBias`, `supportsPhotoHDR`, `supportsFPS(n)`, `supportsVideoStabilizationMode('cinematic')`, etc.),
@@ -136,7 +138,7 @@ The exception is when elapsed wall-clock time is part of the behavior under test
 
 ### 8. Platform guards
 
-Pure iOS-only features (`CameraObjectOutput`, `continuity camera`, `getSupportedVideoCodecs`, etc.) or Android-only features (`CameraExtension`, etc.) should start with a `context.skip('...: iOS only')` / `context.skip('...: Android only')` platform guard. Do not branch on `Platform.OS` to mask behavioral differences that should be identical across platforms — flag those as bugs.
+Pure iOS-only features (`CameraObjectOutput`, `continuity camera`, `getSupportedVideoCodecs`, etc.) or Android-only features (`CameraExtension`, etc.) should start with a `return context.skip('...: iOS only')` / `return context.skip('...: Android only')` platform guard. Do not branch on `Platform.OS` to mask behavioral differences that should be identical across platforms — flag those as bugs.
 If a behavior should be supported on both platforms, write one shared test. If that makes CI red on one platform, keep the failure visible until the platform discrepancy is fixed.
 Do not guard features that expose runtime availability checks behind such flags - e.g. `setFocusLocked(...)` can be probed with `device.supportsManualFocus` - even if this natively is always `false` on Android, this allows us to automatically run the test in the future once we add focus locking support to Android too.
 Also do not guard features that are technically possible to implement on the other platform, but not yet implemented due to a TODO behind such feature flags. `setFocusLocked` would be such a case. In these situations, it's expected to have the test red on the missing platform until it's implemented - kinda like a task list for the maintainers.

--- a/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
@@ -36,10 +36,6 @@ interface Layout {
   height: number
 }
 
-type SkipContext = {
-  skip: (note?: string) => never
-}
-
 function toLayout(event: LayoutChangeEvent): Layout {
   const layout = event.nativeEvent.layout
   return {
@@ -72,12 +68,11 @@ function expectPreviewGeometry(camera: CameraRef, layout: Layout) {
 }
 
 async function expectPreviewSnapshotDimensionsToMatchLayout(
-  context: SkipContext,
   camera: CameraRef,
   layout: Layout,
 ) {
   if (Platform.OS !== 'android') {
-    context.skip('takeSnapshot dimensions: Android only')
+    return
   }
 
   const snapshot = await camera.takeSnapshot()
@@ -111,7 +106,7 @@ describe('VisionCamera - Camera View', () => {
     cleanup()
   })
 
-  it('starts the high-level Camera preview and exposes preview/controller ref methods', async (context) => {
+  it('starts the high-level Camera preview and exposes preview/controller ref methods', async () => {
     const cameraRef = createRef<CameraRef>()
     const layout = deferred<Layout>()
     const started = deferred()
@@ -154,11 +149,7 @@ describe('VisionCamera - Camera View', () => {
     const camera = cameraRef.current
     if (camera == null) throw new Error('no Camera ref')
     expectPreviewGeometry(camera, cameraLayout)
-    await expectPreviewSnapshotDimensionsToMatchLayout(
-      context,
-      camera,
-      cameraLayout,
-    )
+    await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
 
     await rerender(
       <Camera
@@ -323,7 +314,7 @@ describe('VisionCamera - Camera View', () => {
     await withTimeout(stopped.promise, 10_000, 'gesture Camera onStopped')
   })
 
-  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async (context) => {
+  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async () => {
     const cameraRef = createRef<CameraRef>()
     const layout = deferred<Layout>()
     const started = deferred()
@@ -375,11 +366,7 @@ describe('VisionCamera - Camera View', () => {
     const camera = cameraRef.current
     if (camera == null) throw new Error('no Camera ref')
     expectPreviewGeometry(camera, cameraLayout)
-    await expectPreviewSnapshotDimensionsToMatchLayout(
-      context,
-      camera,
-      cameraLayout,
-    )
+    await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
 
     await rerender(
       <View style={styles.issuePaddedContainer}>
@@ -397,7 +384,7 @@ describe('VisionCamera - Camera View', () => {
     await withTimeout(stopped.promise, 10_000, 'padded Camera onStopped')
   })
 
-  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async (context) => {
+  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async () => {
     for (let attempt = 1; attempt <= 5; attempt++) {
       const cameraRef = createRef<CameraRef>()
       const layout = deferred<Layout>()
@@ -459,11 +446,7 @@ describe('VisionCamera - Camera View', () => {
       const camera = cameraRef.current
       if (camera == null) throw new Error('no Camera ref')
       expectPreviewGeometry(camera, cameraLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(
-        context,
-        camera,
-        cameraLayout,
-      )
+      await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
 
       await rerender(
         <View style={styles.issuePaddedContainer}>
@@ -487,7 +470,7 @@ describe('VisionCamera - Camera View', () => {
     }
   })
 
-  it('keeps a fixed 150x300 preview centered on first mount', async (context) => {
+  it('keeps a fixed 150x300 preview centered on first mount', async () => {
     const cameraRef = createRef<CameraRef>()
     const rootLayout = deferred<Layout>()
     const wrapperLayout = deferred<Layout>()
@@ -573,11 +556,7 @@ describe('VisionCamera - Camera View', () => {
     const cameraRefValue = cameraRef.current
     if (cameraRefValue == null) throw new Error('no Camera ref')
     expectPreviewGeometry(cameraRefValue, camera)
-    await expectPreviewSnapshotDimensionsToMatchLayout(
-      context,
-      cameraRefValue,
-      camera,
-    )
+    await expectPreviewSnapshotDimensionsToMatchLayout(cameraRefValue, camera)
 
     await rerender(
       <View style={styles.centeredRoot}>
@@ -746,7 +725,7 @@ describe('VisionCamera - Camera View', () => {
     expectPreviewGeometry(secondCamera, secondCameraLayout)
   })
 
-  it('supports cover and contain resizeMode previews', async (context) => {
+  it('supports cover and contain resizeMode previews', async () => {
     const resizeModes: PreviewResizeMode[] = ['cover', 'contain']
     let coverTopLeft: Point | undefined
     let containTopLeft: Point | undefined
@@ -807,11 +786,7 @@ describe('VisionCamera - Camera View', () => {
       const camera = cameraRef.current
       if (camera == null) throw new Error('no Camera ref')
       expectPreviewGeometry(camera, cameraLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(
-        context,
-        camera,
-        cameraLayout,
-      )
+      await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
       const topLeft = camera.convertViewPointToCameraPoint({ x: 0, y: 0 })
       if (resizeMode === 'cover') coverTopLeft = topLeft
       else containTopLeft = topLeft
@@ -856,7 +831,7 @@ describe('VisionCamera - Camera View', () => {
 
   it('supports both Android preview implementation modes', async (context) => {
     if (Platform.OS !== 'android') {
-      context.skip('implementationMode: Android only')
+      return context.skip('implementationMode: Android only')
     }
 
     const implementationModes: PreviewImplementationMode[] = [
@@ -916,11 +891,7 @@ describe('VisionCamera - Camera View', () => {
       const camera = cameraRef.current
       if (camera == null) throw new Error('no Camera ref')
       expectPreviewGeometry(camera, cameraLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(
-        context,
-        camera,
-        cameraLayout,
-      )
+      await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
 
       await rerender(
         <Camera

--- a/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
@@ -36,6 +36,10 @@ interface Layout {
   height: number
 }
 
+type SkipContext = {
+  skip: (note?: string) => never
+}
+
 function toLayout(event: LayoutChangeEvent): Layout {
   const layout = event.nativeEvent.layout
   return {
@@ -68,12 +72,12 @@ function expectPreviewGeometry(camera: CameraRef, layout: Layout) {
 }
 
 async function expectPreviewSnapshotDimensionsToMatchLayout(
+  context: SkipContext,
   camera: CameraRef,
   layout: Layout,
 ) {
   if (Platform.OS !== 'android') {
-    console.log('[SKIP] takeSnapshot dimensions: Android only')
-    return
+    context.skip('takeSnapshot dimensions: Android only')
   }
 
   const snapshot = await camera.takeSnapshot()
@@ -107,7 +111,7 @@ describe('VisionCamera - Camera View', () => {
     cleanup()
   })
 
-  it('starts the high-level Camera preview and exposes preview/controller ref methods', async () => {
+  it('starts the high-level Camera preview and exposes preview/controller ref methods', async (context) => {
     const cameraRef = createRef<CameraRef>()
     const layout = deferred<Layout>()
     const started = deferred()
@@ -150,7 +154,11 @@ describe('VisionCamera - Camera View', () => {
     const camera = cameraRef.current
     if (camera == null) throw new Error('no Camera ref')
     expectPreviewGeometry(camera, cameraLayout)
-    await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
+    await expectPreviewSnapshotDimensionsToMatchLayout(
+      context,
+      camera,
+      cameraLayout,
+    )
 
     await rerender(
       <Camera
@@ -315,7 +323,7 @@ describe('VisionCamera - Camera View', () => {
     await withTimeout(stopped.promise, 10_000, 'gesture Camera onStopped')
   })
 
-  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async () => {
+  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async (context) => {
     const cameraRef = createRef<CameraRef>()
     const layout = deferred<Layout>()
     const started = deferred()
@@ -367,7 +375,11 @@ describe('VisionCamera - Camera View', () => {
     const camera = cameraRef.current
     if (camera == null) throw new Error('no Camera ref')
     expectPreviewGeometry(camera, cameraLayout)
-    await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
+    await expectPreviewSnapshotDimensionsToMatchLayout(
+      context,
+      camera,
+      cameraLayout,
+    )
 
     await rerender(
       <View style={styles.issuePaddedContainer}>
@@ -385,7 +397,7 @@ describe('VisionCamera - Camera View', () => {
     await withTimeout(stopped.promise, 10_000, 'padded Camera onStopped')
   })
 
-  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async () => {
+  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async (context) => {
     for (let attempt = 1; attempt <= 5; attempt++) {
       const cameraRef = createRef<CameraRef>()
       const layout = deferred<Layout>()
@@ -447,7 +459,11 @@ describe('VisionCamera - Camera View', () => {
       const camera = cameraRef.current
       if (camera == null) throw new Error('no Camera ref')
       expectPreviewGeometry(camera, cameraLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
+      await expectPreviewSnapshotDimensionsToMatchLayout(
+        context,
+        camera,
+        cameraLayout,
+      )
 
       await rerender(
         <View style={styles.issuePaddedContainer}>
@@ -471,7 +487,7 @@ describe('VisionCamera - Camera View', () => {
     }
   })
 
-  it('keeps a fixed 150x300 preview centered on first mount', async () => {
+  it('keeps a fixed 150x300 preview centered on first mount', async (context) => {
     const cameraRef = createRef<CameraRef>()
     const rootLayout = deferred<Layout>()
     const wrapperLayout = deferred<Layout>()
@@ -557,7 +573,11 @@ describe('VisionCamera - Camera View', () => {
     const cameraRefValue = cameraRef.current
     if (cameraRefValue == null) throw new Error('no Camera ref')
     expectPreviewGeometry(cameraRefValue, camera)
-    await expectPreviewSnapshotDimensionsToMatchLayout(cameraRefValue, camera)
+    await expectPreviewSnapshotDimensionsToMatchLayout(
+      context,
+      cameraRefValue,
+      camera,
+    )
 
     await rerender(
       <View style={styles.centeredRoot}>
@@ -726,7 +746,7 @@ describe('VisionCamera - Camera View', () => {
     expectPreviewGeometry(secondCamera, secondCameraLayout)
   })
 
-  it('supports cover and contain resizeMode previews', async () => {
+  it('supports cover and contain resizeMode previews', async (context) => {
     const resizeModes: PreviewResizeMode[] = ['cover', 'contain']
     let coverTopLeft: Point | undefined
     let containTopLeft: Point | undefined
@@ -787,7 +807,11 @@ describe('VisionCamera - Camera View', () => {
       const camera = cameraRef.current
       if (camera == null) throw new Error('no Camera ref')
       expectPreviewGeometry(camera, cameraLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
+      await expectPreviewSnapshotDimensionsToMatchLayout(
+        context,
+        camera,
+        cameraLayout,
+      )
       const topLeft = camera.convertViewPointToCameraPoint({ x: 0, y: 0 })
       if (resizeMode === 'cover') coverTopLeft = topLeft
       else containTopLeft = topLeft
@@ -830,10 +854,9 @@ describe('VisionCamera - Camera View', () => {
     expect(roundedCoverTopLeft).not.toEqual(roundedContainTopLeft)
   })
 
-  it('supports both Android preview implementation modes', async () => {
+  it('supports both Android preview implementation modes', async (context) => {
     if (Platform.OS !== 'android') {
-      console.log('[SKIP] implementationMode: Android only')
-      return
+      context.skip('implementationMode: Android only')
     }
 
     const implementationModes: PreviewImplementationMode[] = [
@@ -893,7 +916,11 @@ describe('VisionCamera - Camera View', () => {
       const camera = cameraRef.current
       if (camera == null) throw new Error('no Camera ref')
       expectPreviewGeometry(camera, cameraLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(camera, cameraLayout)
+      await expectPreviewSnapshotDimensionsToMatchLayout(
+        context,
+        camera,
+        cameraLayout,
+      )
 
       await rerender(
         <Camera

--- a/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
@@ -84,10 +84,9 @@ describe('VisionCamera - Constraints', () => {
     await session.stop()
   })
 
-  it('resolves a fps: 60 constraint if the device supports it', async () => {
+  it('resolves a fps: 60 constraint if the device supports it', async (context) => {
     if (!backDevice.supportsFPS(60)) {
-      console.log('[SKIP] fps: 60 not supported on this device')
-      return
+      context.skip('fps: 60 not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -110,10 +109,9 @@ describe('VisionCamera - Constraints', () => {
     await session.stop()
   })
 
-  it('resolves photoHDR: true when the device supports photo HDR', async () => {
+  it('resolves photoHDR: true when the device supports photo HDR', async (context) => {
     if (!backDevice.supportsPhotoHDR) {
-      console.log('[SKIP] photoHDR: not supported on this device')
-      return
+      context.skip('photoHDR: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -138,13 +136,12 @@ describe('VisionCamera - Constraints', () => {
     await session.stop()
   })
 
-  it('resolves a HDR video dynamic range when the device supports it', async () => {
+  it('resolves a HDR video dynamic range when the device supports it', async (context) => {
     const hasHdr = backDevice.supportedVideoDynamicRanges.some(
       (d) => d.bitDepth === 'hdr-10-bit',
     )
     if (!hasHdr) {
-      console.log('[SKIP] video HDR: no HDR dynamic range on this device')
-      return
+      context.skip('video HDR: no HDR dynamic range on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -170,7 +167,7 @@ describe('VisionCamera - Constraints', () => {
     await session.stop()
   })
 
-  it('resolves a video stabilization constraint when supported', async () => {
+  it('resolves a video stabilization constraint when supported', async (context) => {
     // The resolver downgrades stabilization modes (cinematic → standard → off)
     // when the requested one isn't supported, so picking the most demanding
     // mode the device exposes gives the test the most coverage.
@@ -178,10 +175,9 @@ describe('VisionCamera - Constraints', () => {
       d.supportsVideoStabilizationMode('cinematic'),
     )
     if (stabDevice == null) {
-      console.log(
-        '[SKIP] videoStabilizationMode: no device on this system supports "cinematic"',
+      context.skip(
+        'videoStabilizationMode: no device on this system supports "cinematic"',
       )
-      return
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -204,15 +200,14 @@ describe('VisionCamera - Constraints', () => {
     await session.stop()
   })
 
-  it('resolves a preview stabilization constraint when supported', async () => {
+  it('resolves a preview stabilization constraint when supported', async (context) => {
     const stabDevice = factory.cameraDevices.find((d) =>
       d.supportsPreviewStabilizationMode('preview-optimized'),
     )
     if (stabDevice == null) {
-      console.log(
-        '[SKIP] previewStabilizationMode: no device on this system supports "preview-optimized"',
+      context.skip(
+        'previewStabilizationMode: no device on this system supports "preview-optimized"',
       )
-      return
     }
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
@@ -232,7 +227,7 @@ describe('VisionCamera - Constraints', () => {
     await session.stop()
   })
 
-  it('resolves a binned: true constraint when supported', async () => {
+  it('resolves a binned: true constraint when supported', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
       targetResolution: CommonResolutions.HD_4_3,
@@ -253,25 +248,21 @@ describe('VisionCamera - Constraints', () => {
     ])
     await waitUntil(() => received != null, { timeout: 5_000 })
     if (received?.isBinned !== true) {
-      console.log(
-        `[SKIP] binned: true: device resolved to isBinned=${received?.isBinned}`,
-      )
       await session.stop()
-      return
+      context.skip(
+        `binned: true: device resolved to isBinned=${received?.isBinned}`,
+      )
     }
     expect(received.isBinned).toBe(true)
     await session.stop()
   })
 
-  it('honors a pixelFormat constraint matching a supported device format', async () => {
+  it('honors a pixelFormat constraint matching a supported device format', async (context) => {
     const candidate = backDevice.supportedPixelFormats.find(
       (f) => f !== 'unknown',
     )
     if (candidate == null) {
-      console.log(
-        '[SKIP] pixelFormat constraint: device has no non-unknown formats',
-      )
-      return
+      context.skip('pixelFormat constraint: device has no non-unknown formats')
     }
     const session = await VisionCamera.createCameraSession(false)
     const frameOutput = VisionCamera.createFrameOutput({
@@ -388,7 +379,7 @@ describe('VisionCamera - Constraints', () => {
   // instead of the last" or "priority order is silently reversed", without
   // depending on which feature combinations the AWS Device Farm device happens
   // to support together.
-  it('honors constraint priority ordering between stabilization and HDR', async () => {
+  it('honors constraint priority ordering between stabilization and HDR', async (context) => {
     let chosenStabilizationMode: 'cinematic' | 'standard' | undefined
     for (const mode of ['cinematic', 'standard'] as const) {
       if (backDevice.supportsVideoStabilizationMode(mode)) {
@@ -401,10 +392,9 @@ describe('VisionCamera - Constraints', () => {
     )
 
     if (chosenStabilizationMode == null || !hasHdr) {
-      console.log(
-        '[SKIP] priority ordering: device lacks stabilization and/or HDR support',
+      context.skip(
+        'priority ordering: device lacks stabilization and/or HDR support',
       )
-      return
     }
 
     const videoOutput = VisionCamera.createVideoOutput({
@@ -448,12 +438,9 @@ describe('VisionCamera - Constraints', () => {
     )
   })
 
-  it('reconfigures the running session with a different constraint set', async () => {
+  it('reconfigures the running session with a different constraint set', async (context) => {
     if (!backDevice.supportsFPS(60)) {
-      console.log(
-        '[SKIP] reconfigure with new constraints: fps: 60 not supported',
-      )
-      return
+      context.skip('reconfigure with new constraints: fps: 60 not supported')
     }
 
     const session = await VisionCamera.createCameraSession(false)

--- a/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
@@ -86,7 +86,7 @@ describe('VisionCamera - Constraints', () => {
 
   it('resolves a fps: 60 constraint if the device supports it', async (context) => {
     if (!backDevice.supportsFPS(60)) {
-      context.skip('fps: 60 not supported on this device')
+      return context.skip('fps: 60 not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -111,7 +111,7 @@ describe('VisionCamera - Constraints', () => {
 
   it('resolves photoHDR: true when the device supports photo HDR', async (context) => {
     if (!backDevice.supportsPhotoHDR) {
-      context.skip('photoHDR: not supported on this device')
+      return context.skip('photoHDR: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -141,7 +141,7 @@ describe('VisionCamera - Constraints', () => {
       (d) => d.bitDepth === 'hdr-10-bit',
     )
     if (!hasHdr) {
-      context.skip('video HDR: no HDR dynamic range on this device')
+      return context.skip('video HDR: no HDR dynamic range on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -175,7 +175,7 @@ describe('VisionCamera - Constraints', () => {
       d.supportsVideoStabilizationMode('cinematic'),
     )
     if (stabDevice == null) {
-      context.skip(
+      return context.skip(
         'videoStabilizationMode: no device on this system supports "cinematic"',
       )
     }
@@ -205,7 +205,7 @@ describe('VisionCamera - Constraints', () => {
       d.supportsPreviewStabilizationMode('preview-optimized'),
     )
     if (stabDevice == null) {
-      context.skip(
+      return context.skip(
         'previewStabilizationMode: no device on this system supports "preview-optimized"',
       )
     }
@@ -249,7 +249,7 @@ describe('VisionCamera - Constraints', () => {
     await waitUntil(() => received != null, { timeout: 5_000 })
     if (received?.isBinned !== true) {
       await session.stop()
-      context.skip(
+      return context.skip(
         `binned: true: device resolved to isBinned=${received?.isBinned}`,
       )
     }
@@ -262,7 +262,9 @@ describe('VisionCamera - Constraints', () => {
       (f) => f !== 'unknown',
     )
     if (candidate == null) {
-      context.skip('pixelFormat constraint: device has no non-unknown formats')
+      return context.skip(
+        'pixelFormat constraint: device has no non-unknown formats',
+      )
     }
     const session = await VisionCamera.createCameraSession(false)
     const frameOutput = VisionCamera.createFrameOutput({
@@ -392,7 +394,7 @@ describe('VisionCamera - Constraints', () => {
     )
 
     if (chosenStabilizationMode == null || !hasHdr) {
-      context.skip(
+      return context.skip(
         'priority ordering: device lacks stabilization and/or HDR support',
       )
     }
@@ -440,7 +442,9 @@ describe('VisionCamera - Constraints', () => {
 
   it('reconfigures the running session with a different constraint set', async (context) => {
     if (!backDevice.supportsFPS(60)) {
-      context.skip('reconfigure with new constraints: fps: 60 not supported')
+      return context.skip(
+        'reconfigure with new constraints: fps: 60 not supported',
+      )
     }
 
     const session = await VisionCamera.createCameraSession(false)

--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -81,7 +81,7 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('runs a zoom animation', async () => {
+  it('runs a zoom animation', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
       targetResolution: CommonResolutions.HD_4_3,
@@ -101,8 +101,7 @@ describe('VisionCamera - Controller', () => {
 
     try {
       if (controller.minZoom === controller.maxZoom) {
-        console.log('[SKIP] zoom animation: device exposes no zoom range')
-        return
+        context.skip('zoom animation: device exposes no zoom range')
       }
 
       await controller.setZoom(controller.minZoom)
@@ -144,10 +143,9 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('sets torchMode on/off when the device has a torch', async () => {
+  it('sets torchMode on/off when the device has a torch', async (context) => {
     if (!backDevice.hasTorch) {
-      console.log('[SKIP] torch: device has no torch')
-      return
+      context.skip('torch: device has no torch')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -177,13 +175,10 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('rejects setTorchMode on a device without a torch', async () => {
+  it('rejects setTorchMode on a device without a torch', async (context) => {
     const noTorchDevice = factory.cameraDevices.find((d) => !d.hasTorch)
     if (noTorchDevice == null) {
-      console.log(
-        '[SKIP] no-torch path: no device on this system lacks a torch',
-      )
-      return
+      context.skip('no-torch path: no device on this system lacks a torch')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -209,16 +204,12 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('enables torch at min/max strength when the device supports it', async () => {
+  it('enables torch at min/max strength when the device supports it', async (context) => {
     if (!backDevice.hasTorch) {
-      console.log('[SKIP] torch strength: device has no torch')
-      return
+      context.skip('torch strength: device has no torch')
     }
     if (!backDevice.supportsTorchStrength) {
-      console.log(
-        '[SKIP] torch strength: device does not support custom strength',
-      )
-      return
+      context.skip('torch strength: device does not support custom strength')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -278,12 +269,11 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('rejects enableTorchWithStrength outside the device range', async () => {
+  it('rejects enableTorchWithStrength outside the device range', async (context) => {
     if (!backDevice.hasTorch || !backDevice.supportsTorchStrength) {
-      console.log(
-        '[SKIP] torch strength out-of-range: device does not support custom strength',
+      context.skip(
+        'torch strength out-of-range: device does not support custom strength',
       )
-      return
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -320,15 +310,14 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('rejects enableTorchWithStrength on a device without torch strength support', async () => {
+  it('rejects enableTorchWithStrength on a device without torch strength support', async (context) => {
     const noStrengthDevice = factory.cameraDevices.find(
       (d) => !d.supportsTorchStrength,
     )
     if (noStrengthDevice == null) {
-      console.log(
-        '[SKIP] no-torch-strength path: every device on this system supports custom torch strength',
+      context.skip(
+        'no-torch-strength path: every device on this system supports custom torch strength',
       )
-      return
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -354,10 +343,9 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('sets exposure bias to min/max when the device supports it', async () => {
+  it('sets exposure bias to min/max when the device supports it', async (context) => {
     if (!backDevice.supportsExposureBias) {
-      console.log('[SKIP] exposureBias: not supported on this device')
-      return
+      context.skip('exposureBias: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -392,12 +380,9 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('rejects setExposureBias outside the device range', async () => {
+  it('rejects setExposureBias outside the device range', async (context) => {
     if (!backDevice.supportsExposureBias) {
-      console.log(
-        '[SKIP] exposureBias out-of-range: not supported on this device',
-      )
-      return
+      context.skip('exposureBias out-of-range: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -431,12 +416,11 @@ describe('VisionCamera - Controller', () => {
   })
 
   // TODO(Android): Re-enable once initial CameraX control config is applied after the camera is active.
-  it.skip('honors initialExposureBias passed to configure', async () => {
+  it.skip('honors initialExposureBias passed to configure', async (context) => {
     if (!backDevice.supportsExposureBias) {
-      console.log(
-        '[SKIP] initialExposureBias: device does not support exposure bias',
+      context.skip(
+        'initialExposureBias: device does not support exposure bias',
       )
-      return
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -464,10 +448,9 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('runs focusTo and resetFocus when the device supports focus metering', async () => {
+  it('runs focusTo and resetFocus when the device supports focus metering', async (context) => {
     if (!backDevice.supportsFocusMetering) {
-      console.log('[SKIP] focusTo: device does not support focus metering')
-      return
+      context.skip('focusTo: device does not support focus metering')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -498,15 +481,12 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('enables low-light boost via CameraController.configure when supported', async () => {
+  it('enables low-light boost via CameraController.configure when supported', async (context) => {
     const lowLightDevice = factory.cameraDevices.find(
       (d) => d.supportsLowLightBoost,
     )
     if (lowLightDevice == null) {
-      console.log(
-        '[SKIP] low-light boost: no device on this system supports it',
-      )
-      return
+      context.skip('low-light boost: no device on this system supports it')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -594,10 +574,9 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('locks focus to a specific lens position when the device supports it', async () => {
+  it('locks focus to a specific lens position when the device supports it', async (context) => {
     if (!backDevice.supportsFocusLocking) {
-      console.log('[SKIP] focus locking: not supported on this device')
-      return
+      context.skip('focus locking: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -631,10 +610,9 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('locks exposure to a specific duration/ISO when the device supports it', async () => {
+  it('locks exposure to a specific duration/ISO when the device supports it', async (context) => {
     if (!backDevice.supportsExposureLocking) {
-      console.log('[SKIP] exposure locking: not supported on this device')
-      return
+      context.skip('exposure locking: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -672,10 +650,9 @@ describe('VisionCamera - Controller', () => {
     }
   })
 
-  it('locks white-balance to specific gains when the device supports it', async () => {
+  it('locks white-balance to specific gains when the device supports it', async (context) => {
     if (!backDevice.supportsWhiteBalanceLocking) {
-      console.log('[SKIP] white-balance locking: not supported on this device')
-      return
+      context.skip('white-balance locking: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({

--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -101,7 +101,7 @@ describe('VisionCamera - Controller', () => {
 
     try {
       if (controller.minZoom === controller.maxZoom) {
-        context.skip('zoom animation: device exposes no zoom range')
+        return context.skip('zoom animation: device exposes no zoom range')
       }
 
       await controller.setZoom(controller.minZoom)
@@ -145,7 +145,7 @@ describe('VisionCamera - Controller', () => {
 
   it('sets torchMode on/off when the device has a torch', async (context) => {
     if (!backDevice.hasTorch) {
-      context.skip('torch: device has no torch')
+      return context.skip('torch: device has no torch')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -178,7 +178,9 @@ describe('VisionCamera - Controller', () => {
   it('rejects setTorchMode on a device without a torch', async (context) => {
     const noTorchDevice = factory.cameraDevices.find((d) => !d.hasTorch)
     if (noTorchDevice == null) {
-      context.skip('no-torch path: no device on this system lacks a torch')
+      return context.skip(
+        'no-torch path: no device on this system lacks a torch',
+      )
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -206,10 +208,12 @@ describe('VisionCamera - Controller', () => {
 
   it('enables torch at min/max strength when the device supports it', async (context) => {
     if (!backDevice.hasTorch) {
-      context.skip('torch strength: device has no torch')
+      return context.skip('torch strength: device has no torch')
     }
     if (!backDevice.supportsTorchStrength) {
-      context.skip('torch strength: device does not support custom strength')
+      return context.skip(
+        'torch strength: device does not support custom strength',
+      )
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -271,7 +275,7 @@ describe('VisionCamera - Controller', () => {
 
   it('rejects enableTorchWithStrength outside the device range', async (context) => {
     if (!backDevice.hasTorch || !backDevice.supportsTorchStrength) {
-      context.skip(
+      return context.skip(
         'torch strength out-of-range: device does not support custom strength',
       )
     }
@@ -315,7 +319,7 @@ describe('VisionCamera - Controller', () => {
       (d) => !d.supportsTorchStrength,
     )
     if (noStrengthDevice == null) {
-      context.skip(
+      return context.skip(
         'no-torch-strength path: every device on this system supports custom torch strength',
       )
     }
@@ -345,7 +349,7 @@ describe('VisionCamera - Controller', () => {
 
   it('sets exposure bias to min/max when the device supports it', async (context) => {
     if (!backDevice.supportsExposureBias) {
-      context.skip('exposureBias: not supported on this device')
+      return context.skip('exposureBias: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -382,7 +386,9 @@ describe('VisionCamera - Controller', () => {
 
   it('rejects setExposureBias outside the device range', async (context) => {
     if (!backDevice.supportsExposureBias) {
-      context.skip('exposureBias out-of-range: not supported on this device')
+      return context.skip(
+        'exposureBias out-of-range: not supported on this device',
+      )
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -418,7 +424,7 @@ describe('VisionCamera - Controller', () => {
   // TODO(Android): Re-enable once initial CameraX control config is applied after the camera is active.
   it.skip('honors initialExposureBias passed to configure', async (context) => {
     if (!backDevice.supportsExposureBias) {
-      context.skip(
+      return context.skip(
         'initialExposureBias: device does not support exposure bias',
       )
     }
@@ -450,7 +456,7 @@ describe('VisionCamera - Controller', () => {
 
   it('runs focusTo and resetFocus when the device supports focus metering', async (context) => {
     if (!backDevice.supportsFocusMetering) {
-      context.skip('focusTo: device does not support focus metering')
+      return context.skip('focusTo: device does not support focus metering')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -486,7 +492,9 @@ describe('VisionCamera - Controller', () => {
       (d) => d.supportsLowLightBoost,
     )
     if (lowLightDevice == null) {
-      context.skip('low-light boost: no device on this system supports it')
+      return context.skip(
+        'low-light boost: no device on this system supports it',
+      )
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -576,7 +584,7 @@ describe('VisionCamera - Controller', () => {
 
   it('locks focus to a specific lens position when the device supports it', async (context) => {
     if (!backDevice.supportsFocusLocking) {
-      context.skip('focus locking: not supported on this device')
+      return context.skip('focus locking: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -612,7 +620,7 @@ describe('VisionCamera - Controller', () => {
 
   it('locks exposure to a specific duration/ISO when the device supports it', async (context) => {
     if (!backDevice.supportsExposureLocking) {
-      context.skip('exposure locking: not supported on this device')
+      return context.skip('exposure locking: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -652,7 +660,7 @@ describe('VisionCamera - Controller', () => {
 
   it('locks white-balance to specific gains when the device supports it', async (context) => {
     if (!backDevice.supportsWhiteBalanceLocking) {
-      context.skip('white-balance locking: not supported on this device')
+      return context.skip('white-balance locking: not supported on this device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({

--- a/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
@@ -644,10 +644,7 @@ describe('VisionCamera - Coordinates', () => {
       if (r == null) throw new Error('no rectangle projection report')
 
       if (r.orientation === 'up') {
-        console.log(
-          '[SKIP] oriented rectangle projection: frame orientation is up',
-        )
-        return
+        context.skip('oriented rectangle projection: frame orientation is up')
       }
 
       for (const edge of ['left', 'top', 'right', 'bottom'] as const) {
@@ -670,12 +667,9 @@ describe('VisionCamera - Coordinates', () => {
   //       ScannedObject today is via `CameraObjectOutput`, which depends
   //       on a real QR code being visible to the rear camera — not
   //       reliable on AWS Device Farm or a closed test rig.
-  it.skip("converts a ScannedObject's bounding box into view coordinates (iOS only)", async () => {
+  it.skip("converts a ScannedObject's bounding box into view coordinates (iOS only)", async (context) => {
     if (Platform.OS !== 'ios') {
-      console.log(
-        '[SKIP] convertScannedObjectCoordinatesToViewCoordinates: iOS only',
-      )
-      return
+      context.skip('convertScannedObjectCoordinatesToViewCoordinates: iOS only')
     }
     // Pending API: a way to mint a ScannedObject without a live scan.
   })

--- a/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
@@ -644,7 +644,9 @@ describe('VisionCamera - Coordinates', () => {
       if (r == null) throw new Error('no rectangle projection report')
 
       if (r.orientation === 'up') {
-        context.skip('oriented rectangle projection: frame orientation is up')
+        return context.skip(
+          'oriented rectangle projection: frame orientation is up',
+        )
       }
 
       for (const edge of ['left', 'top', 'right', 'bottom'] as const) {
@@ -669,7 +671,9 @@ describe('VisionCamera - Coordinates', () => {
   //       reliable on AWS Device Farm or a closed test rig.
   it.skip("converts a ScannedObject's bounding box into view coordinates (iOS only)", async (context) => {
     if (Platform.OS !== 'ios') {
-      context.skip('convertScannedObjectCoordinatesToViewCoordinates: iOS only')
+      return context.skip(
+        'convertScannedObjectCoordinatesToViewCoordinates: iOS only',
+      )
     }
     // Pending API: a way to mint a ScannedObject without a live scan.
   })

--- a/apps/simple-camera/__tests__/visioncamera.devices.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.devices.harness.ts
@@ -30,7 +30,7 @@ describe('VisionCamera - Devices', () => {
       (d) => d.position === 'external',
     )
     if (external.length === 0) {
-      context.skip('external cameras: none available on this device')
+      return context.skip('external cameras: none available on this device')
     }
     for (const device of external) {
       console.log(
@@ -163,7 +163,7 @@ describe('VisionCamera - Devices', () => {
   it('every device in a supportedMultiCamDeviceCombinations combination is also present in cameraDevices', (context) => {
     const combinations = factory.supportedMultiCamDeviceCombinations
     if (combinations.length === 0) {
-      context.skip(
+      return context.skip(
         'supportedMultiCamDeviceCombinations device lookup: no combinations on this platform',
       )
     }

--- a/apps/simple-camera/__tests__/visioncamera.devices.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.devices.harness.ts
@@ -25,13 +25,12 @@ describe('VisionCamera - Devices', () => {
     expect(hasFront).toBe(true)
   })
 
-  it('logs external cameras when present (optional)', () => {
+  it('logs external cameras when present (optional)', (context) => {
     const external = factory.cameraDevices.filter(
       (d) => d.position === 'external',
     )
     if (external.length === 0) {
-      console.log('[SKIP] external cameras: none available on this device')
-      return
+      context.skip('external cameras: none available on this device')
     }
     for (const device of external) {
       console.log(
@@ -161,13 +160,12 @@ describe('VisionCamera - Devices', () => {
     }
   })
 
-  it('every device in a supportedMultiCamDeviceCombinations combination is also present in cameraDevices', () => {
+  it('every device in a supportedMultiCamDeviceCombinations combination is also present in cameraDevices', (context) => {
     const combinations = factory.supportedMultiCamDeviceCombinations
     if (combinations.length === 0) {
-      console.log(
-        '[SKIP] supportedMultiCamDeviceCombinations device lookup: no combinations on this platform',
+      context.skip(
+        'supportedMultiCamDeviceCombinations device lookup: no combinations on this platform',
       )
-      return
     }
     const knownIds = factory.cameraDevices.map((d) => d.id)
     for (const combination of combinations) {

--- a/apps/simple-camera/__tests__/visioncamera.nativepreviewview.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.nativepreviewview.harness.tsx
@@ -33,6 +33,10 @@ interface Layout {
   height: number
 }
 
+type SkipContext = {
+  skip: (note?: string) => never
+}
+
 function toLayout(event: LayoutChangeEvent): Layout {
   const layout = event.nativeEvent.layout
   return {
@@ -63,12 +67,12 @@ function expectPreviewGeometry(preview: PreviewView, layout: Layout) {
 }
 
 async function expectPreviewSnapshotDimensionsToMatchLayout(
+  context: SkipContext,
   preview: PreviewView,
   layout: Layout,
 ) {
   if (Platform.OS !== 'android') {
-    console.log('[SKIP] takeSnapshot dimensions: Android only')
-    return
+    context.skip('takeSnapshot dimensions: Android only')
   }
 
   const snapshot = await preview.takeSnapshot()
@@ -103,7 +107,7 @@ describe('VisionCamera - NativePreviewView', () => {
     cleanup()
   })
 
-  it('starts a bare NativePreviewView and exposes ref methods', async () => {
+  it('starts a bare NativePreviewView and exposes ref methods', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -157,14 +161,18 @@ describe('VisionCamera - NativePreviewView', () => {
       )
 
       expectPreviewGeometry(preview, previewLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(preview, previewLayout)
+      await expectPreviewSnapshotDimensionsToMatchLayout(
+        context,
+        preview,
+        previewLayout,
+      )
     } finally {
       errorSub.remove()
       await session.stop()
     }
   })
 
-  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async () => {
+  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -223,14 +231,18 @@ describe('VisionCamera - NativePreviewView', () => {
       expect(previewLayout.y).toBeCloseTo(PADDING_TOP, 0)
       expect(previewLayout.height).toBeGreaterThan(0)
       expectPreviewGeometry(preview, previewLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(preview, previewLayout)
+      await expectPreviewSnapshotDimensionsToMatchLayout(
+        context,
+        preview,
+        previewLayout,
+      )
     } finally {
       errorSub.remove()
       await session.stop()
     }
   })
 
-  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async () => {
+  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async (context) => {
     for (let attempt = 1; attempt <= 5; attempt++) {
       const session = await VisionCamera.createCameraSession(false)
       const previewOutput = VisionCamera.createPreviewOutput()
@@ -296,6 +308,7 @@ describe('VisionCamera - NativePreviewView', () => {
         expect(previewLayout.y).toBeCloseTo(PADDING_TOP, 0)
         expectPreviewGeometry(preview, previewLayout)
         await expectPreviewSnapshotDimensionsToMatchLayout(
+          context,
           preview,
           previewLayout,
         )
@@ -307,7 +320,7 @@ describe('VisionCamera - NativePreviewView', () => {
     }
   })
 
-  it('keeps a fixed 150x300 preview centered on first mount', async () => {
+  it('keeps a fixed 150x300 preview centered on first mount', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -399,14 +412,14 @@ describe('VisionCamera - NativePreviewView', () => {
       expect(layout.width).toBeCloseTo(FIXED_PREVIEW_WIDTH, 0)
       expect(layout.height).toBeCloseTo(FIXED_PREVIEW_HEIGHT, 0)
       expectPreviewGeometry(preview, layout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(preview, layout)
+      await expectPreviewSnapshotDimensionsToMatchLayout(context, preview, layout)
     } finally {
       errorSub.remove()
       await session.stop()
     }
   })
 
-  it('updates geometry when the preview layout changes while running', async () => {
+  it('updates geometry when the preview layout changes while running', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -491,7 +504,7 @@ describe('VisionCamera - NativePreviewView', () => {
       expect(second.width).toBeCloseTo(WIDE_PREVIEW_WIDTH, 0)
       expect(second.height).toBeCloseTo(WIDE_PREVIEW_HEIGHT, 0)
       expectPreviewGeometry(preview, second)
-      await expectPreviewSnapshotDimensionsToMatchLayout(preview, second)
+      await expectPreviewSnapshotDimensionsToMatchLayout(context, preview, second)
     } finally {
       errorSub.remove()
       await session.stop()
@@ -665,19 +678,17 @@ describe('VisionCamera - NativePreviewView', () => {
     }
   })
 
-  it('mounts two NativePreviewViews from two preview outputs in one multi-cam session', async () => {
+  it('mounts two NativePreviewViews from two preview outputs in one multi-cam session', async (context) => {
     if (VisionCamera.supportsMultiCamSessions === false) {
-      console.log('[SKIP] two NativePreviewViews: multi-cam not supported')
-      return
+      context.skip('two NativePreviewViews: multi-cam not supported')
     }
     const combination = factory.supportedMultiCamDeviceCombinations.find(
       (devices) => devices.length >= 2,
     )
     if (combination == null) {
-      console.log(
-        '[SKIP] two NativePreviewViews: no multi-cam combination with two devices',
+      context.skip(
+        'two NativePreviewViews: no multi-cam combination with two devices',
       )
-      return
     }
 
     const firstDevice = combination[0]
@@ -857,7 +868,7 @@ describe('VisionCamera - NativePreviewView', () => {
     }
   })
 
-  it('supports cover and contain resizeMode previews', async () => {
+  it('supports cover and contain resizeMode previews', async (context) => {
     const resizeModes: PreviewResizeMode[] = ['cover', 'contain']
     let coverTopLeft: Point | undefined
     let containTopLeft: Point | undefined
@@ -922,6 +933,7 @@ describe('VisionCamera - NativePreviewView', () => {
 
         expectPreviewGeometry(preview, previewLayout)
         await expectPreviewSnapshotDimensionsToMatchLayout(
+          context,
           preview,
           previewLayout,
         )
@@ -949,10 +961,9 @@ describe('VisionCamera - NativePreviewView', () => {
     expect(roundedCoverTopLeft).not.toEqual(roundedContainTopLeft)
   })
 
-  it('supports both Android preview implementation modes', async () => {
+  it('supports both Android preview implementation modes', async (context) => {
     if (Platform.OS !== 'android') {
-      console.log('[SKIP] implementationMode: Android only')
-      return
+      context.skip('implementationMode: Android only')
     }
 
     const implementationModes: PreviewImplementationMode[] = [
@@ -1016,6 +1027,7 @@ describe('VisionCamera - NativePreviewView', () => {
 
         expectPreviewGeometry(preview, previewLayout)
         await expectPreviewSnapshotDimensionsToMatchLayout(
+          context,
           preview,
           previewLayout,
         )

--- a/apps/simple-camera/__tests__/visioncamera.nativepreviewview.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.nativepreviewview.harness.tsx
@@ -33,10 +33,6 @@ interface Layout {
   height: number
 }
 
-type SkipContext = {
-  skip: (note?: string) => never
-}
-
 function toLayout(event: LayoutChangeEvent): Layout {
   const layout = event.nativeEvent.layout
   return {
@@ -67,12 +63,11 @@ function expectPreviewGeometry(preview: PreviewView, layout: Layout) {
 }
 
 async function expectPreviewSnapshotDimensionsToMatchLayout(
-  context: SkipContext,
   preview: PreviewView,
   layout: Layout,
 ) {
   if (Platform.OS !== 'android') {
-    context.skip('takeSnapshot dimensions: Android only')
+    return
   }
 
   const snapshot = await preview.takeSnapshot()
@@ -107,7 +102,7 @@ describe('VisionCamera - NativePreviewView', () => {
     cleanup()
   })
 
-  it('starts a bare NativePreviewView and exposes ref methods', async (context) => {
+  it('starts a bare NativePreviewView and exposes ref methods', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -161,18 +156,14 @@ describe('VisionCamera - NativePreviewView', () => {
       )
 
       expectPreviewGeometry(preview, previewLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(
-        context,
-        preview,
-        previewLayout,
-      )
+      await expectPreviewSnapshotDimensionsToMatchLayout(preview, previewLayout)
     } finally {
       errorSub.remove()
       await session.stop()
     }
   })
 
-  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async (context) => {
+  it('keeps a flex preview laid out inside a padded overflow-hidden parent', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -231,18 +222,14 @@ describe('VisionCamera - NativePreviewView', () => {
       expect(previewLayout.y).toBeCloseTo(PADDING_TOP, 0)
       expect(previewLayout.height).toBeGreaterThan(0)
       expectPreviewGeometry(preview, previewLayout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(
-        context,
-        preview,
-        previewLayout,
-      )
+      await expectPreviewSnapshotDimensionsToMatchLayout(preview, previewLayout)
     } finally {
       errorSub.remove()
       await session.stop()
     }
   })
 
-  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async (context) => {
+  it('survives repeated conditional placeholder-to-preview mounts in a padded parent', async () => {
     for (let attempt = 1; attempt <= 5; attempt++) {
       const session = await VisionCamera.createCameraSession(false)
       const previewOutput = VisionCamera.createPreviewOutput()
@@ -308,7 +295,6 @@ describe('VisionCamera - NativePreviewView', () => {
         expect(previewLayout.y).toBeCloseTo(PADDING_TOP, 0)
         expectPreviewGeometry(preview, previewLayout)
         await expectPreviewSnapshotDimensionsToMatchLayout(
-          context,
           preview,
           previewLayout,
         )
@@ -320,7 +306,7 @@ describe('VisionCamera - NativePreviewView', () => {
     }
   })
 
-  it('keeps a fixed 150x300 preview centered on first mount', async (context) => {
+  it('keeps a fixed 150x300 preview centered on first mount', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -412,14 +398,14 @@ describe('VisionCamera - NativePreviewView', () => {
       expect(layout.width).toBeCloseTo(FIXED_PREVIEW_WIDTH, 0)
       expect(layout.height).toBeCloseTo(FIXED_PREVIEW_HEIGHT, 0)
       expectPreviewGeometry(preview, layout)
-      await expectPreviewSnapshotDimensionsToMatchLayout(context, preview, layout)
+      await expectPreviewSnapshotDimensionsToMatchLayout(preview, layout)
     } finally {
       errorSub.remove()
       await session.stop()
     }
   })
 
-  it('updates geometry when the preview layout changes while running', async (context) => {
+  it('updates geometry when the preview layout changes while running', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
     await session.configure([
@@ -504,7 +490,7 @@ describe('VisionCamera - NativePreviewView', () => {
       expect(second.width).toBeCloseTo(WIDE_PREVIEW_WIDTH, 0)
       expect(second.height).toBeCloseTo(WIDE_PREVIEW_HEIGHT, 0)
       expectPreviewGeometry(preview, second)
-      await expectPreviewSnapshotDimensionsToMatchLayout(context, preview, second)
+      await expectPreviewSnapshotDimensionsToMatchLayout(preview, second)
     } finally {
       errorSub.remove()
       await session.stop()
@@ -680,13 +666,13 @@ describe('VisionCamera - NativePreviewView', () => {
 
   it('mounts two NativePreviewViews from two preview outputs in one multi-cam session', async (context) => {
     if (VisionCamera.supportsMultiCamSessions === false) {
-      context.skip('two NativePreviewViews: multi-cam not supported')
+      return context.skip('two NativePreviewViews: multi-cam not supported')
     }
     const combination = factory.supportedMultiCamDeviceCombinations.find(
       (devices) => devices.length >= 2,
     )
     if (combination == null) {
-      context.skip(
+      return context.skip(
         'two NativePreviewViews: no multi-cam combination with two devices',
       )
     }
@@ -868,7 +854,7 @@ describe('VisionCamera - NativePreviewView', () => {
     }
   })
 
-  it('supports cover and contain resizeMode previews', async (context) => {
+  it('supports cover and contain resizeMode previews', async () => {
     const resizeModes: PreviewResizeMode[] = ['cover', 'contain']
     let coverTopLeft: Point | undefined
     let containTopLeft: Point | undefined
@@ -933,7 +919,6 @@ describe('VisionCamera - NativePreviewView', () => {
 
         expectPreviewGeometry(preview, previewLayout)
         await expectPreviewSnapshotDimensionsToMatchLayout(
-          context,
           preview,
           previewLayout,
         )
@@ -963,7 +948,7 @@ describe('VisionCamera - NativePreviewView', () => {
 
   it('supports both Android preview implementation modes', async (context) => {
     if (Platform.OS !== 'android') {
-      context.skip('implementationMode: Android only')
+      return context.skip('implementationMode: Android only')
     }
 
     const implementationModes: PreviewImplementationMode[] = [
@@ -1027,7 +1012,6 @@ describe('VisionCamera - NativePreviewView', () => {
 
         expectPreviewGeometry(preview, previewLayout)
         await expectPreviewSnapshotDimensionsToMatchLayout(
-          context,
           preview,
           previewLayout,
         )

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -89,7 +89,7 @@ describe('VisionCamera - Photo', () => {
         expect(photo.width).toBeGreaterThan(0)
         expect(photo.height).toBeGreaterThan(0)
         if (!photo.hasPixelBuffer) {
-          context.skip(
+          return context.skip(
             'Photo pixel buffer: captured native photo has no pixel buffer',
           )
         }
@@ -249,7 +249,9 @@ describe('VisionCamera - Photo', () => {
 
   it('captures with speed qualityPrioritization when supported', async (context) => {
     if (!backDevice.supportsSpeedQualityPrioritization) {
-      context.skip('qualityPrioritization: speed not supported on device')
+      return context.skip(
+        'qualityPrioritization: speed not supported on device',
+      )
     }
 
     const session = await VisionCamera.createCameraSession(false)
@@ -505,7 +507,7 @@ describe('VisionCamera - Photo', () => {
 
   it('delivers a preview image when previewImageTargetSize is set and the device supports it', async (context) => {
     if (!backDevice.supportsPreviewImage) {
-      context.skip(
+      return context.skip(
         'onPreviewImageAvailable: device has no preview image support',
       )
     }
@@ -573,7 +575,7 @@ describe('VisionCamera - Photo', () => {
 
   it('captures with flashMode on when the device has flash', async (context) => {
     if (!backDevice.hasFlash) {
-      context.skip('flashMode on: device has no flash')
+      return context.skip('flashMode on: device has no flash')
     }
 
     const session = await VisionCamera.createCameraSession(false)
@@ -633,7 +635,7 @@ describe('VisionCamera - Photo', () => {
 
   it('applies enableDistortionCorrection when the device supports it', async (context) => {
     if (!backDevice.supportsDistortionCorrection) {
-      context.skip('enableDistortionCorrection: not supported on device')
+      return context.skip('enableDistortionCorrection: not supported on device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -784,7 +786,7 @@ describe('VisionCamera - Photo', () => {
         d.type === 'dual',
     )
     if (depthDevice == null) {
-      context.skip(
+      return context.skip(
         'supportsDepthDataDelivery: no depth-capable device on this system',
       )
     }

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -64,7 +64,7 @@ describe('VisionCamera - Photo', () => {
     await session.stop()
   })
 
-  it('checks and reads a native Photo pixel buffer in-memory', async () => {
+  it('checks and reads a native Photo pixel buffer in-memory', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
       targetResolution: CommonResolutions.HD_4_3,
@@ -89,10 +89,9 @@ describe('VisionCamera - Photo', () => {
         expect(photo.width).toBeGreaterThan(0)
         expect(photo.height).toBeGreaterThan(0)
         if (!photo.hasPixelBuffer) {
-          console.log(
-            '[SKIP] Photo pixel buffer: captured native photo has no pixel buffer',
+          context.skip(
+            'Photo pixel buffer: captured native photo has no pixel buffer',
           )
-          return
         }
 
         const pixelBuffer = photo.getPixelBuffer()
@@ -221,11 +220,6 @@ describe('VisionCamera - Photo', () => {
 
   it('captures with each qualityPrioritization the device supports', async () => {
     const priorities: QualityPrioritization[] = ['quality', 'balanced']
-    if (backDevice.supportsSpeedQualityPrioritization) {
-      priorities.push('speed')
-    } else {
-      console.log('[SKIP] qualityPrioritization: speed not supported on device')
-    }
 
     for (const qualityPrioritization of priorities) {
       const session = await VisionCamera.createCameraSession(false)
@@ -251,6 +245,35 @@ describe('VisionCamera - Photo', () => {
       photo.dispose()
       await session.stop()
     }
+  })
+
+  it('captures with speed qualityPrioritization when supported', async (context) => {
+    if (!backDevice.supportsSpeedQualityPrioritization) {
+      context.skip('qualityPrioritization: speed not supported on device')
+    }
+
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'speed',
+    })
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    await session.start()
+    const photo = await photoOutput.capturePhoto(
+      { flashMode: 'off', enableShutterSound: false },
+      {},
+    )
+    expect(photo.width).toBeGreaterThan(0)
+    photo.dispose()
+    await session.stop()
   })
 
   it('captures at several target resolutions', async () => {
@@ -480,12 +503,11 @@ describe('VisionCamera - Photo', () => {
     expect(didCapture).toBe(1)
   })
 
-  it('delivers a preview image when previewImageTargetSize is set and the device supports it', async () => {
+  it('delivers a preview image when previewImageTargetSize is set and the device supports it', async (context) => {
     if (!backDevice.supportsPreviewImage) {
-      console.log(
-        '[SKIP] onPreviewImageAvailable: device has no preview image support',
+      context.skip(
+        'onPreviewImageAvailable: device has no preview image support',
       )
-      return
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -522,11 +544,6 @@ describe('VisionCamera - Photo', () => {
 
   it('captures with each flashMode the device supports', async () => {
     const modes: FlashMode[] = ['off', 'auto']
-    if (backDevice.hasFlash) {
-      modes.push('on')
-    } else {
-      console.log('[SKIP] flashMode on: device has no flash')
-    }
 
     for (const flashMode of modes) {
       const session = await VisionCamera.createCameraSession(false)
@@ -552,6 +569,35 @@ describe('VisionCamera - Photo', () => {
       photo.dispose()
       await session.stop()
     }
+  })
+
+  it('captures with flashMode on when the device has flash', async (context) => {
+    if (!backDevice.hasFlash) {
+      context.skip('flashMode on: device has no flash')
+    }
+
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    await session.start()
+    const photo = await photoOutput.capturePhoto(
+      { flashMode: 'on', enableShutterSound: false },
+      {},
+    )
+    expect(photo.width).toBeGreaterThan(0)
+    photo.dispose()
+    await session.stop()
   })
 
   it('toggles enableShutterSound and enableRedEyeReduction without error', async () => {
@@ -585,10 +631,9 @@ describe('VisionCamera - Photo', () => {
     await session.stop()
   })
 
-  it('applies enableDistortionCorrection when the device supports it', async () => {
+  it('applies enableDistortionCorrection when the device supports it', async (context) => {
     if (!backDevice.supportsDistortionCorrection) {
-      console.log('[SKIP] enableDistortionCorrection: not supported on device')
-      return
+      context.skip('enableDistortionCorrection: not supported on device')
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({
@@ -726,7 +771,7 @@ describe('VisionCamera - Photo', () => {
     await session.stop()
   })
 
-  it('reports supportsDepthDataDelivery on a depth-capable device', async () => {
+  it('reports supportsDepthDataDelivery on a depth-capable device', async (context) => {
     // `supportsDepthDataDelivery` is a per-output property that flips to `true`
     // once the photo output is bound to a device that can produce depth data.
     // The default back wide-angle on most phones does not — depth-capable
@@ -739,10 +784,9 @@ describe('VisionCamera - Photo', () => {
         d.type === 'dual',
     )
     if (depthDevice == null) {
-      console.log(
-        '[SKIP] supportsDepthDataDelivery: no depth-capable device on this system',
+      context.skip(
+        'supportsDepthDataDelivery: no depth-capable device on this system',
       )
-      return
     }
     const session = await VisionCamera.createCameraSession(false)
     const photoOutput = VisionCamera.createPhotoOutput({

--- a/apps/simple-camera/__tests__/visioncamera.session.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.session.harness.ts
@@ -470,10 +470,9 @@ describe('VisionCamera - Session', () => {
     }
   })
 
-  it('supports a multi-cam session when the platform allows it', async () => {
+  it('supports a multi-cam session when the platform allows it', async (context) => {
     if (!VisionCamera.supportsMultiCamSessions) {
-      console.log('[SKIP] multi-cam session: not supported on this platform')
-      return
+      context.skip('multi-cam session: not supported on this platform')
     }
     const back = factory.getDefaultCamera('back')
     const front = factory.getDefaultCamera('front')
@@ -526,19 +525,15 @@ describe('VisionCamera - Session', () => {
     }
   })
 
-  it('configures, starts and stops a multi-cam session for every supported device combination', async () => {
+  it('configures, starts and stops a multi-cam session for every supported device combination', async (context) => {
     if (!VisionCamera.supportsMultiCamSessions) {
-      console.log(
-        '[SKIP] multi-cam combinations: not supported on this platform',
-      )
-      return
+      context.skip('multi-cam combinations: not supported on this platform')
     }
     const combinations = factory.supportedMultiCamDeviceCombinations
     if (combinations.length === 0) {
-      console.log(
-        '[SKIP] multi-cam combinations: no combinations reported on this device',
+      context.skip(
+        'multi-cam combinations: no combinations reported on this device',
       )
-      return
     }
 
     for (const combination of combinations) {

--- a/apps/simple-camera/__tests__/visioncamera.session.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.session.harness.ts
@@ -472,7 +472,7 @@ describe('VisionCamera - Session', () => {
 
   it('supports a multi-cam session when the platform allows it', async (context) => {
     if (!VisionCamera.supportsMultiCamSessions) {
-      context.skip('multi-cam session: not supported on this platform')
+      return context.skip('multi-cam session: not supported on this platform')
     }
     const back = factory.getDefaultCamera('back')
     const front = factory.getDefaultCamera('front')
@@ -527,11 +527,13 @@ describe('VisionCamera - Session', () => {
 
   it('configures, starts and stops a multi-cam session for every supported device combination', async (context) => {
     if (!VisionCamera.supportsMultiCamSessions) {
-      context.skip('multi-cam combinations: not supported on this platform')
+      return context.skip(
+        'multi-cam combinations: not supported on this platform',
+      )
     }
     const combinations = factory.supportedMultiCamDeviceCombinations
     if (combinations.length === 0) {
-      context.skip(
+      return context.skip(
         'multi-cam combinations: no combinations reported on this device',
       )
     }

--- a/apps/simple-camera/__tests__/visioncamera.video.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.video.harness.ts
@@ -346,13 +346,10 @@ describe('VisionCamera - Video', () => {
     }
   })
 
-  it('keeps a persistent recording running while switching the input device', async () => {
+  it('keeps a persistent recording running while switching the input device', async (context) => {
     const frontDevice = factory.getDefaultCamera('front')
     if (frontDevice == null) {
-      console.log(
-        '[SKIP] persistent recorder device switch: no front camera available',
-      )
-      return
+      context.skip('persistent recorder device switch: no front camera available')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -397,10 +394,9 @@ describe('VisionCamera - Video', () => {
     }
   })
 
-  it('records with enableHigherResolutionCodecs on Android', async () => {
+  it('records with enableHigherResolutionCodecs on Android', async (context) => {
     if (Platform.OS !== 'android') {
-      console.log('[SKIP] enableHigherResolutionCodecs: Android only')
-      return
+      context.skip('enableHigherResolutionCodecs: Android only')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -662,10 +658,9 @@ describe('VisionCamera - Video', () => {
     }
   })
 
-  it('returns supported video codecs on iOS after the output is attached', async () => {
+  it('returns supported video codecs on iOS after the output is attached', async (context) => {
     if (Platform.OS !== 'ios') {
-      console.log('[SKIP] getSupportedVideoCodecs: iOS only')
-      return
+      context.skip('getSupportedVideoCodecs: iOS only')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({

--- a/apps/simple-camera/__tests__/visioncamera.video.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.video.harness.ts
@@ -349,7 +349,9 @@ describe('VisionCamera - Video', () => {
   it('keeps a persistent recording running while switching the input device', async (context) => {
     const frontDevice = factory.getDefaultCamera('front')
     if (frontDevice == null) {
-      context.skip('persistent recorder device switch: no front camera available')
+      return context.skip(
+        'persistent recorder device switch: no front camera available',
+      )
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -396,7 +398,7 @@ describe('VisionCamera - Video', () => {
 
   it('records with enableHigherResolutionCodecs on Android', async (context) => {
     if (Platform.OS !== 'android') {
-      context.skip('enableHigherResolutionCodecs: Android only')
+      return context.skip('enableHigherResolutionCodecs: Android only')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({
@@ -660,7 +662,7 @@ describe('VisionCamera - Video', () => {
 
   it('returns supported video codecs on iOS after the output is attached', async (context) => {
     if (Platform.OS !== 'ios') {
-      context.skip('getSupportedVideoCodecs: iOS only')
+      return context.skip('getSupportedVideoCodecs: iOS only')
     }
     const session = await VisionCamera.createCameraSession(false)
     const videoOutput = VisionCamera.createVideoOutput({

--- a/apps/simple-camera/package.json
+++ b/apps/simple-camera/package.json
@@ -47,13 +47,13 @@
     "@react-native-community/cli": "20.1.2",
     "@react-native-community/cli-platform-android": "20.1.2",
     "@react-native-community/cli-platform-ios": "20.1.2",
-    "@react-native-harness/platform-android": "1.2.0",
-    "@react-native-harness/platform-apple": "1.2.0",
+    "@react-native-harness/platform-android": "1.3.0",
+    "@react-native-harness/platform-apple": "1.3.0",
     "@react-native/babel-preset": "0.84.0",
     "@react-native/metro-config": "0.84.0",
     "@react-native/typescript-config": "0.84.0",
     "@types/react": "19.2.14",
-    "react-native-harness": "1.2.0",
+    "react-native-harness": "1.3.0",
     "typescript": "5.9.3"
   },
   "engines": {

--- a/bun.lock
+++ b/bun.lock
@@ -54,13 +54,13 @@
         "@react-native-community/cli": "20.1.2",
         "@react-native-community/cli-platform-android": "20.1.2",
         "@react-native-community/cli-platform-ios": "20.1.2",
-        "@react-native-harness/platform-android": "1.2.0",
-        "@react-native-harness/platform-apple": "1.2.0",
+        "@react-native-harness/platform-android": "1.3.0",
+        "@react-native-harness/platform-apple": "1.3.0",
         "@react-native/babel-preset": "0.84.0",
         "@react-native/metro-config": "0.84.0",
         "@react-native/typescript-config": "0.84.0",
         "@types/react": "19.2.14",
-        "react-native-harness": "1.2.0",
+        "react-native-harness": "1.3.0",
         "typescript": "5.9.3",
       },
     },
@@ -917,31 +917,31 @@
 
     "@react-native-community/cli-types": ["@react-native-community/cli-types@20.1.2", "", { "dependencies": { "joi": "^17.2.1" } }, "sha512-WYK98VdcJE+lRuyRzigE/GQAbaJZOKkjpaLwhmMMItXVTqMmIccfGu9b4pRoQOVfs1aLq87DuwUOi9sxz6OG1g=="],
 
-    "@react-native-harness/babel-preset": ["@react-native-harness/babel-preset@1.2.0", "", { "dependencies": { "@babel/plugin-transform-class-static-block": "^7.27.1", "babel-plugin-istanbul": "^7.0.1" }, "peerDependencies": { "@babel/core": "^7.22.0", "@babel/plugin-transform-react-jsx": "*" } }, "sha512-/BkCiutQmCcZ25GOSCE5HTNvgXCPJLa0BENplJHnuXx4TdNMpoD+FhTwRDt+YFbZyh/L2f2iaB7S8oZnbYHyaQ=="],
+    "@react-native-harness/babel-preset": ["@react-native-harness/babel-preset@1.3.0", "", { "dependencies": { "@babel/plugin-transform-class-static-block": "^7.27.1", "babel-plugin-istanbul": "^7.0.1" }, "peerDependencies": { "@babel/core": "^7.22.0", "@babel/plugin-transform-react-jsx": "*" } }, "sha512-LROjbH7nZizVsX3fTlHaeYo2fd0MajlPtvM1w2iQHUB7siTnWhmGZmnCtT7SFrhMg3x33sPFZnwgn6q5p3O1Xg=="],
 
-    "@react-native-harness/bridge": ["@react-native-harness/bridge@1.2.0", "", { "dependencies": { "@react-native-harness/platforms": "1.2.0", "@react-native-harness/tools": "1.2.0", "birpc": "^2.4.0", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "ssim.js": "^3.5.0", "tslib": "^2.3.0", "ws": "^8.18.2" } }, "sha512-a/UPgk46+BVIw8aJDsa5kyGKAHSf5hvPXJ1bubYs7Ceor7xTQUeJQX/u36+OzrkSODrnVgtvPDuiGP1ZOPfaIQ=="],
+    "@react-native-harness/bridge": ["@react-native-harness/bridge@1.3.0", "", { "dependencies": { "@react-native-harness/platforms": "1.3.0", "@react-native-harness/tools": "1.3.0", "birpc": "^2.4.0", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "ssim.js": "^3.5.0", "tslib": "^2.3.0", "ws": "^8.18.2" } }, "sha512-4RbYb8ySxzNUIwyvTD6ulvjqTKCT+XEXaFjM4smofvbRXQiCojfgM4S1K0CGjXD+ieexfgWAYt13+s7ZYvKeNw=="],
 
-    "@react-native-harness/bundler-metro": ["@react-native-harness/bundler-metro@1.2.0", "", { "dependencies": { "@react-native-harness/babel-preset": "1.2.0", "@react-native-harness/config": "1.2.0", "@react-native-harness/runtime": "1.2.0", "@react-native-harness/tools": "1.2.0", "@react-native/metro-config": "*", "connect": "^3.7.0", "nocache": "^4.0.0", "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*", "metro-cache": "*", "metro-config": "*", "metro-resolver": "*" } }, "sha512-aMsVhLlKxzykFds0xVOg/+mIPZIrF8JgvKExD5hzSCtfDeMqGPZJPXY4emdOAH7IgFZlkCRYR5wNmKVThJEsFA=="],
+    "@react-native-harness/bundler-metro": ["@react-native-harness/bundler-metro@1.3.0", "", { "dependencies": { "@react-native-harness/babel-preset": "1.3.0", "@react-native-harness/config": "1.3.0", "@react-native-harness/runtime": "1.3.0", "@react-native-harness/tools": "1.3.0", "@react-native/metro-config": "*", "connect": "^3.7.0", "nocache": "^4.0.0", "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*", "metro-cache": "*", "metro-config": "*", "metro-resolver": "*" } }, "sha512-Uj5TNfdEarGrzxJ2glkwrBr/E2JYghA3KVaP94BKpQCOvR82UXTmBKTqbOyzYUbOcz5SklRRC49fAay+PL/Jlg=="],
 
-    "@react-native-harness/cli": ["@react-native-harness/cli@1.2.0", "", { "dependencies": { "@react-native-harness/bridge": "1.2.0", "@react-native-harness/config": "1.2.0", "@react-native-harness/platforms": "1.2.0", "@react-native-harness/tools": "1.2.0", "tslib": "^2.3.0" }, "peerDependencies": { "jest-cli": "*" } }, "sha512-S74BM3em2VN2OzES4I65PAKCFaX8ZRFmvpGRSIla0asNqXi3x4NnaXxn0fdbyK7vYUBIDGzVHv7eq5Uu3A+T9g=="],
+    "@react-native-harness/cli": ["@react-native-harness/cli@1.3.0", "", { "dependencies": { "@react-native-harness/bridge": "1.3.0", "@react-native-harness/config": "1.3.0", "@react-native-harness/platforms": "1.3.0", "@react-native-harness/tools": "1.3.0", "tslib": "^2.3.0" }, "peerDependencies": { "jest-cli": "*" } }, "sha512-QoAcORw3AyE5/IFJyg1dQXlpJWpzEmKlE+/4HVgg8YQx44vskXkKeKg9KFmNLdERUSGA1/vti9Wy7DGbUbkxUQ=="],
 
-    "@react-native-harness/config": ["@react-native-harness/config@1.2.0", "", { "dependencies": { "@react-native-harness/plugins": "1.2.0", "@react-native-harness/tools": "1.2.0", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-VVz/LajyOFuj82v6F7GkLCUtjh7J+oMSADCyRKm+o226anRIm6VVKCeSpejqWzR2j3wupxAsbkWoHC0yXPPBSg=="],
+    "@react-native-harness/config": ["@react-native-harness/config@1.3.0", "", { "dependencies": { "@react-native-harness/plugins": "1.3.0", "@react-native-harness/tools": "1.3.0", "tslib": "^2.3.0", "zod": "^3.25.67" } }, "sha512-qwQ8bk1GDYKjj53rGCmfUYcel1t6d+k2PqWGNioLCWWNmYriGc4eP3mmQRDlczE+WDbe+m0pZS407HYzNpesIw=="],
 
-    "@react-native-harness/jest": ["@react-native-harness/jest@1.2.0", "", { "dependencies": { "@jest/test-result": "^30.2.0", "@react-native-harness/bridge": "1.2.0", "@react-native-harness/bundler-metro": "1.2.0", "@react-native-harness/config": "1.2.0", "@react-native-harness/platforms": "1.2.0", "@react-native-harness/plugins": "1.2.0", "@react-native-harness/tools": "1.2.0", "chalk": "^4.1.2", "jest-message-util": "^30.2.0", "jest-util": "^30.2.0", "tslib": "^2.3.0", "yargs": "^17.7.2" } }, "sha512-IxAxkL6BWZ+DyhlF+KX+cXz7VY9Ij3WDFjKLB3z753TH+NUa6SSkPREugDOrkibcfH0laZYt7KC/zd/ZsPcYXQ=="],
+    "@react-native-harness/jest": ["@react-native-harness/jest@1.3.0", "", { "dependencies": { "@jest/test-result": "^30.2.0", "@react-native-harness/bridge": "1.3.0", "@react-native-harness/bundler-metro": "1.3.0", "@react-native-harness/config": "1.3.0", "@react-native-harness/platforms": "1.3.0", "@react-native-harness/plugins": "1.3.0", "@react-native-harness/tools": "1.3.0", "chalk": "^4.1.2", "jest-message-util": "^30.2.0", "jest-util": "^30.2.0", "tslib": "^2.3.0", "yargs": "^17.7.2" } }, "sha512-TVcfSBSbIaDHKfThed+dfbBwsTInw21OqJiNYux6zn0FD2fuyp0elyoyEgGjZCr1NT4bdK5VUkP5fk2oqF1fvQ=="],
 
-    "@react-native-harness/metro": ["@react-native-harness/metro@1.2.0", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*" } }, "sha512-6XyBYwckrnFFY5XWioGOMoOY0tFbP96VXvsXAzY9iwyanHYjK5+ZyoEBygEtOhmHlQeVypEvdCyAH9+f/sQYFg=="],
+    "@react-native-harness/metro": ["@react-native-harness/metro@1.3.0", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "metro": "*" } }, "sha512-BgxV+AwppDHoatken9V7ANw26TmUlwByS21n9WKRP+4jxAG4gqM9cotgYBRMP1GGhm5WxRzkSs+iEpNpVpEHqg=="],
 
-    "@react-native-harness/platform-android": ["@react-native-harness/platform-android@1.2.0", "", { "dependencies": { "@react-native-harness/config": "1.2.0", "@react-native-harness/platforms": "1.2.0", "@react-native-harness/tools": "1.2.0", "tslib": "^2.3.0", "vite": "^7.2.2", "zod": "^3.25.67" } }, "sha512-7qj27TfdW5qnIdJJQBCXTnwQS67FPQy1J+zq06AJR2xa2fFX+GnBMgG3zPir6TdC2jtAlgSVm/EPXi47S3YI3Q=="],
+    "@react-native-harness/platform-android": ["@react-native-harness/platform-android@1.3.0", "", { "dependencies": { "@react-native-harness/config": "1.3.0", "@react-native-harness/platforms": "1.3.0", "@react-native-harness/tools": "1.3.0", "tslib": "^2.3.0", "vite": "^7.2.2", "zod": "^3.25.67" } }, "sha512-6TS4eBji+lXzgQB9n//OI49dq/g6LL1B4ECbUTQZvRJ9rCttdyCzEEeLulfnKsPiYPyDU/HiYpvQP4GQEKyTeg=="],
 
-    "@react-native-harness/platform-apple": ["@react-native-harness/platform-apple@1.2.0", "", { "dependencies": { "@react-native-harness/config": "1.2.0", "@react-native-harness/platforms": "1.2.0", "@react-native-harness/tools": "1.2.0", "tslib": "^2.3.0", "yargs": "^17.7.2", "zod": "^3.25.67" } }, "sha512-XeU3eZ0CU2d0pYOBIfFluM/kHwMj7jNGH/xjXjuA3M4dcXtuRdZsN2HH0a9BWg9lEsO57lrOvuU0TAwccUSbsA=="],
+    "@react-native-harness/platform-apple": ["@react-native-harness/platform-apple@1.3.0", "", { "dependencies": { "@react-native-harness/config": "1.3.0", "@react-native-harness/platforms": "1.3.0", "@react-native-harness/tools": "1.3.0", "tslib": "^2.3.0", "yargs": "^17.7.2", "zod": "^3.25.67" } }, "sha512-AFOiJKkJNzc3+0DEpPdVfQFCWjBjN0+pC2t8RN+5GYaaYTQWOejOqUOJC2ko1tgQbpnO4bCy3inHLxgTU5wK3g=="],
 
-    "@react-native-harness/platforms": ["@react-native-harness/platforms@1.2.0", "", { "dependencies": { "tslib": "^2.3.0" } }, "sha512-i13G9exNAR9AED5RDel3mR/kOOVJp8pyJhIwMcV4oCDURaVXUQmynJx9GTM1qQEuDRtar5M/lW8ZfY1uw331Ow=="],
+    "@react-native-harness/platforms": ["@react-native-harness/platforms@1.3.0", "", { "dependencies": { "tslib": "^2.3.0" } }, "sha512-oBNxZIHuKQFclfs/N7T9VVayktkSo6FCPXlmNqHLtQpPApGCkngW8ElUGAksCar91V4MXYvRxmjRoxcebj2J8A=="],
 
-    "@react-native-harness/plugins": ["@react-native-harness/plugins@1.2.0", "", { "dependencies": { "@react-native-harness/bridge": "1.2.0", "@react-native-harness/platforms": "1.2.0", "@react-native-harness/tools": "1.2.0", "hookable": "^6.1.0", "tslib": "^2.3.0" } }, "sha512-LU0PEHuGYqJqExFcxnj3mcw7+dbgGb+6ClduN7nhu2Orbwc4/DTmuyzt0LjHkUHbUepqf/Z01MEw2/SuOfIX4A=="],
+    "@react-native-harness/plugins": ["@react-native-harness/plugins@1.3.0", "", { "dependencies": { "@react-native-harness/bridge": "1.3.0", "@react-native-harness/platforms": "1.3.0", "@react-native-harness/tools": "1.3.0", "hookable": "^6.1.0", "tslib": "^2.3.0" } }, "sha512-PgQdtLFBi9ALK3cPfPLKjzqzId5V9T0DYDwCBrHr7/fH4BIcD4DLAtJWjtNTWBV7C3XcrY0ZFDhwQUQKjQfPnQ=="],
 
-    "@react-native-harness/runtime": ["@react-native-harness/runtime@1.2.0", "", { "dependencies": { "@react-native-harness/bridge": "1.2.0", "@vitest/expect": "4.0.16", "@vitest/spy": "4.0.16", "chai": "^6.2.2", "event-target-shim": "^6.0.2", "react-native-url-polyfill": "^3.0.0", "use-sync-external-store": "^1.6.0", "zustand": "^5.0.5" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-aIfJPKWPIrn6MOei52a0vAQfX1DtzvTTL2fXcKtSLyylKOpJZu60tZP+i25npceiS6FFOWPwBk9u0he3OqjSFQ=="],
+    "@react-native-harness/runtime": ["@react-native-harness/runtime@1.3.0", "", { "dependencies": { "@react-native-harness/bridge": "1.3.0", "@vitest/expect": "4.0.16", "@vitest/spy": "4.0.16", "chai": "^6.2.2", "event-target-shim": "^6.0.2", "react-native-url-polyfill": "^3.0.0", "use-sync-external-store": "^1.6.0", "zustand": "^5.0.5" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-iWtNxkBUJVV7cdX7X92pXoJ2jky1/6F23YcQHbIrT2b6x/QjpyZ6eaEZCJkrGiwCCtJF3UXHiydmLV9xTXDDHw=="],
 
-    "@react-native-harness/tools": ["@react-native-harness/tools@1.2.0", "", { "dependencies": { "@clack/prompts": "1.0.0-alpha.9", "nano-spawn": "^1.0.2", "picocolors": "^1.1.1", "tslib": "^2.3.0" }, "peerDependencies": { "react-native": "*" } }, "sha512-XDUI5n1sa3F+U98fc1BxeCQO8aog8yTdXw6RGfUIiXPGWtrZGgGiLxcQxzGwXWq+2oam2O9KE+lg914XN5nRSQ=="],
+    "@react-native-harness/tools": ["@react-native-harness/tools@1.3.0", "", { "dependencies": { "@clack/prompts": "1.0.0-alpha.9", "nano-spawn": "^1.0.2", "picocolors": "^1.1.1", "tslib": "^2.3.0" }, "peerDependencies": { "react-native": "*" } }, "sha512-Zlk9yKSkLv3zqdF2pvS1+FMh/XJNm8fbU+krlw3Mnqlvf8FuyjllbJcI6rs1irhUWpNmhPesF3aZMfuMPnG5/w=="],
 
     "@react-native-menu/menu": ["@react-native-menu/menu@2.0.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-hb8Mirw6aKPGONhgo52IiNpwHtISVrgCT3rMdFX1qS7eOFNzOcQh8d2UDnaH5zVpxN+QuvWtaaiRMGFpIjzdtA=="],
 
@@ -2399,7 +2399,7 @@
 
     "react-native-gesture-handler": ["react-native-gesture-handler@2.30.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA=="],
 
-    "react-native-harness": ["react-native-harness@1.2.0", "", { "dependencies": { "@react-native-harness/babel-preset": "1.2.0", "@react-native-harness/cli": "1.2.0", "@react-native-harness/jest": "1.2.0", "@react-native-harness/metro": "1.2.0", "@react-native-harness/runtime": "1.2.0", "tslib": "^2.3.0" }, "bin": { "react-native-harness": "bin.js", "harness": "bin.js" } }, "sha512-6/oihn6j1MA4ufnObDA4+2ncolpJQg0qTz37XS0dblry6fgss6Z/eQzANG8pSxI1VZe9HEi5QT43gMFolpAnBA=="],
+    "react-native-harness": ["react-native-harness@1.3.0", "", { "dependencies": { "@react-native-harness/babel-preset": "1.3.0", "@react-native-harness/cli": "1.3.0", "@react-native-harness/jest": "1.3.0", "@react-native-harness/metro": "1.3.0", "@react-native-harness/runtime": "1.3.0", "tslib": "^2.3.0" }, "bin": { "react-native-harness": "bin.js", "harness": "bin.js" } }, "sha512-wqhx7t+rkwMcv6eHlQDuHwfN8sUJu1xcjCNp8QZVlQ9MLnSttuwbZEDqNDglQsnyn1GS0tUtr0vDwQhoQnCrng=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA=="],
 


### PR DESCRIPTION
Before:

```
Test Suites: 4 failed, 7 passed, 11 total
Tests:       5 failed, 7 skipped, 125 passed, 137 total
```

After:

```
Test Suites: 3 failed, 8 passed, 11 total
Tests:       4 failed, 21 skipped, 114 passed, 139 total
```