### PR TITLE
feat: Add `Frame.hasPixelBuffer` and `Frame.hasNativeBuffer`

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
@@ -95,36 +95,35 @@ describe('VisionCamera - Frame', () => {
       },
     ])
 
-    const receivedBuffers = deferred()
+    type NativeFrameBufferReport =
+      | { state: 'skip'; reason: string }
+      | { state: 'error'; errorMessage: string }
+      | { state: 'success' }
+
+    type NativeFrameBufferResult =
+      | { state: 'skip'; reason: string }
+      | { state: 'success'; frames: number }
+
+    const receivedBuffers = deferred<NativeFrameBufferResult>()
     let buffersReceived = 0
-    let unsupportedReason: string | undefined
-    const report = (
-      hasPixelBuffer: boolean,
-      pixelBufferBytes: number,
-      hasNativeBuffer: boolean,
-      hasNativeBufferPointer: boolean,
-    ) => {
-      if (!hasPixelBuffer) {
-        unsupportedReason =
-          'native frame buffers: device does not expose readable pixel buffers'
-        receivedBuffers.resolve()
-      } else if (!hasNativeBuffer) {
-        unsupportedReason =
-          'native frame buffers: device does not expose native buffers'
-        receivedBuffers.resolve()
-      } else if (pixelBufferBytes <= 0) {
-        receivedBuffers.reject(new Error('Frame pixel buffer was empty.'))
-      } else if (!hasNativeBufferPointer) {
-        receivedBuffers.reject(new Error('Frame native buffer pointer was 0.'))
-      } else {
-        buffersReceived++
-        if (buffersReceived >= 3) {
-          receivedBuffers.resolve()
-        }
+    const report = (frameBufferReport: NativeFrameBufferReport) => {
+      switch (frameBufferReport.state) {
+        case 'skip':
+          receivedBuffers.resolve(frameBufferReport)
+          break
+        case 'error':
+          receivedBuffers.reject(new Error(frameBufferReport.errorMessage))
+          break
+        case 'success':
+          buffersReceived++
+          if (buffersReceived >= 3) {
+            receivedBuffers.resolve({
+              state: 'success',
+              frames: buffersReceived,
+            })
+          }
+          break
       }
-    }
-    const reportError = (errorMessage: string) => {
-      receivedBuffers.reject(new Error(errorMessage))
     }
     const errorSub = session.addOnErrorListener(receivedBuffers.reject)
 
@@ -132,29 +131,54 @@ describe('VisionCamera - Frame', () => {
     runtime.setOnFrameCallback(frameOutput, (frame) => {
       'worklet'
       try {
-        const hasPixelBuffer = frame.hasPixelBuffer
-        const pixelBufferBytes = hasPixelBuffer
-          ? frame.getPixelBuffer().byteLength
-          : 0
-        const hasNativeBuffer = frame.hasNativeBuffer
-        let hasNativeBufferPointer = false
-        if (hasNativeBuffer) {
-          const nativeBuffer = frame.getNativeBuffer()
-          try {
-            hasNativeBufferPointer = nativeBuffer.pointer !== 0n
-          } finally {
-            nativeBuffer.release()
-          }
+        if (!frame.hasPixelBuffer) {
+          scheduleOnRN(report, {
+            state: 'skip',
+            reason:
+              'native frame buffers: device does not expose readable pixel buffers',
+          })
+          return
         }
-        scheduleOnRN(
-          report,
-          hasPixelBuffer,
-          pixelBufferBytes,
-          hasNativeBuffer,
-          hasNativeBufferPointer,
-        )
+
+        const pixelBufferBytes = frame.getPixelBuffer().byteLength
+        if (pixelBufferBytes <= 0) {
+          scheduleOnRN(report, {
+            state: 'error',
+            errorMessage: 'Frame pixel buffer was empty.',
+          })
+          return
+        }
+
+        if (!frame.hasNativeBuffer) {
+          scheduleOnRN(report, {
+            state: 'skip',
+            reason:
+              'native frame buffers: device does not expose native buffers',
+          })
+          return
+        }
+
+        const nativeBuffer = frame.getNativeBuffer()
+        try {
+          if (nativeBuffer.pointer === 0n) {
+            scheduleOnRN(report, {
+              state: 'error',
+              errorMessage: 'Frame native buffer pointer was 0.',
+            })
+            return
+          }
+        } finally {
+          nativeBuffer.release()
+        }
+
+        scheduleOnRN(report, {
+          state: 'success',
+        })
       } catch (e) {
-        scheduleOnRN(reportError, String(e))
+        scheduleOnRN(report, {
+          state: 'error',
+          errorMessage: String(e),
+        })
       } finally {
         frame.dispose()
       }
@@ -162,20 +186,20 @@ describe('VisionCamera - Frame', () => {
 
     await session.start()
     try {
-      await withTimeout(
+      const result = await withTimeout(
         receivedBuffers.promise,
         15_000,
         'receive native frame buffer reports',
       )
+      if (result.state === 'skip') {
+        return context.skip(result.reason)
+      }
+      expect(result.frames).toBeGreaterThanOrEqual(3)
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       errorSub.remove()
       await session.stop()
     }
-    if (unsupportedReason != null) {
-      return context.skip(unsupportedReason)
-    }
-    expect(buffersReceived).toBeGreaterThanOrEqual(3)
   })
 
   it('keeps YUV plane buffers readable across repeated reads', async () => {

--- a/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
@@ -76,7 +76,7 @@ describe('VisionCamera - Frame', () => {
     expect(framesReceived).toBeGreaterThanOrEqual(3)
   })
 
-  it('gets pixel buffers and releases native buffers from native frames', async () => {
+  it('reports and conditionally reads native frame buffers', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const frameOutput = VisionCamera.createFrameOutput({
       targetResolution: CommonResolutions.HD_16_9,
@@ -96,15 +96,28 @@ describe('VisionCamera - Frame', () => {
     ])
 
     const receivedBuffers = deferred()
-    let buffersReceived = 0
-    const report = (hasPixelBuffer: boolean, hasNativeBuffer: boolean) => {
-      if (!hasPixelBuffer) {
+    let framesReceived = 0
+    let pixelBuffersReceived = 0
+    let nativeBuffersReceived = 0
+    const report = (
+      hasPixelBuffer: boolean,
+      pixelBufferBytes: number,
+      hasNativeBuffer: boolean,
+      hasNativeBufferPointer: boolean,
+    ) => {
+      if (hasPixelBuffer && pixelBufferBytes <= 0) {
         receivedBuffers.reject(new Error('Frame pixel buffer was empty.'))
-      } else if (!hasNativeBuffer) {
+      } else if (hasNativeBuffer && !hasNativeBufferPointer) {
         receivedBuffers.reject(new Error('Frame native buffer pointer was 0.'))
       } else {
-        buffersReceived++
-        if (buffersReceived >= 3) {
+        framesReceived++
+        if (hasPixelBuffer) {
+          pixelBuffersReceived++
+        }
+        if (hasNativeBuffer) {
+          nativeBuffersReceived++
+        }
+        if (framesReceived >= 3) {
           receivedBuffers.resolve()
         }
       }
@@ -118,16 +131,27 @@ describe('VisionCamera - Frame', () => {
     runtime.setOnFrameCallback(frameOutput, (frame) => {
       'worklet'
       try {
-        const pixelBuffer = frame.getPixelBuffer()
-        const hasPixelBuffer = pixelBuffer.byteLength > 0
-        const nativeBuffer = frame.getNativeBuffer()
-        let hasNativeBuffer = false
-        try {
-          hasNativeBuffer = nativeBuffer.pointer !== 0n
-        } finally {
-          nativeBuffer.release()
+        const hasPixelBuffer = frame.hasPixelBuffer
+        const pixelBufferBytes = hasPixelBuffer
+          ? frame.getPixelBuffer().byteLength
+          : 0
+        const hasNativeBuffer = frame.hasNativeBuffer
+        let hasNativeBufferPointer = false
+        if (hasNativeBuffer) {
+          const nativeBuffer = frame.getNativeBuffer()
+          try {
+            hasNativeBufferPointer = nativeBuffer.pointer !== 0n
+          } finally {
+            nativeBuffer.release()
+          }
         }
-        scheduleOnRN(report, hasPixelBuffer, hasNativeBuffer)
+        scheduleOnRN(
+          report,
+          hasPixelBuffer,
+          pixelBufferBytes,
+          hasNativeBuffer,
+          hasNativeBufferPointer,
+        )
       } catch (e) {
         scheduleOnRN(reportError, String(e))
       } finally {
@@ -140,14 +164,17 @@ describe('VisionCamera - Frame', () => {
       await withTimeout(
         receivedBuffers.promise,
         15_000,
-        'receive native frame pixel buffers',
+        'receive native frame buffer reports',
       )
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       errorSub.remove()
       await session.stop()
     }
-    expect(buffersReceived).toBeGreaterThanOrEqual(3)
+    console.log(
+      `native frame buffers: frames=${framesReceived} pixelBuffers=${pixelBuffersReceived} nativeBuffers=${nativeBuffersReceived}`,
+    )
+    expect(framesReceived).toBeGreaterThanOrEqual(3)
   })
 
   it('keeps YUV plane buffers readable across repeated reads', async () => {
@@ -302,7 +329,7 @@ describe('VisionCamera - Frame', () => {
     expect(reportedPlanes).toBeGreaterThanOrEqual(1)
   })
 
-  it('delivers frames when streaming in rgb', async () => {
+  it('delivers readable pixel buffers when streaming in rgb', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const frameOutput = VisionCamera.createFrameOutput({
       targetResolution: CommonResolutions.VGA_16_9,
@@ -322,16 +349,29 @@ describe('VisionCamera - Frame', () => {
     ])
 
     const receivedFrame = deferred()
-    const onFrame = () => {
-      receivedFrame.resolve()
+    const onFrame = (pixelBufferBytes: number) => {
+      if (pixelBufferBytes > 0) {
+        receivedFrame.resolve()
+      } else {
+        receivedFrame.reject(new Error('RGB frame pixel buffer was empty.'))
+      }
+    }
+    const onError = (errorMessage: string) => {
+      receivedFrame.reject(new Error(errorMessage))
     }
     const errorSub = session.addOnErrorListener(receivedFrame.reject)
 
     const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
     runtime.setOnFrameCallback(frameOutput, (frame) => {
       'worklet'
-      scheduleOnRN(onFrame)
-      frame.dispose()
+      try {
+        const pixelBufferBytes = frame.getPixelBuffer().byteLength
+        scheduleOnRN(onFrame, pixelBufferBytes)
+      } catch (e) {
+        scheduleOnRN(onError, String(e))
+      } finally {
+        frame.dispose()
+      }
     })
 
     await session.start()

--- a/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
@@ -76,7 +76,7 @@ describe('VisionCamera - Frame', () => {
     expect(framesReceived).toBeGreaterThanOrEqual(3)
   })
 
-  it('reports and conditionally reads native frame buffers', async () => {
+  it('reports and conditionally reads native frame buffers', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const frameOutput = VisionCamera.createFrameOutput({
       targetResolution: CommonResolutions.HD_16_9,
@@ -96,28 +96,29 @@ describe('VisionCamera - Frame', () => {
     ])
 
     const receivedBuffers = deferred()
-    let framesReceived = 0
-    let pixelBuffersReceived = 0
-    let nativeBuffersReceived = 0
+    let buffersReceived = 0
+    let unsupportedReason: string | undefined
     const report = (
       hasPixelBuffer: boolean,
       pixelBufferBytes: number,
       hasNativeBuffer: boolean,
       hasNativeBufferPointer: boolean,
     ) => {
-      if (hasPixelBuffer && pixelBufferBytes <= 0) {
+      if (!hasPixelBuffer) {
+        unsupportedReason =
+          'native frame buffers: device does not expose readable pixel buffers'
+        receivedBuffers.resolve()
+      } else if (!hasNativeBuffer) {
+        unsupportedReason =
+          'native frame buffers: device does not expose native buffers'
+        receivedBuffers.resolve()
+      } else if (pixelBufferBytes <= 0) {
         receivedBuffers.reject(new Error('Frame pixel buffer was empty.'))
-      } else if (hasNativeBuffer && !hasNativeBufferPointer) {
+      } else if (!hasNativeBufferPointer) {
         receivedBuffers.reject(new Error('Frame native buffer pointer was 0.'))
       } else {
-        framesReceived++
-        if (hasPixelBuffer) {
-          pixelBuffersReceived++
-        }
-        if (hasNativeBuffer) {
-          nativeBuffersReceived++
-        }
-        if (framesReceived >= 3) {
+        buffersReceived++
+        if (buffersReceived >= 3) {
           receivedBuffers.resolve()
         }
       }
@@ -171,10 +172,10 @@ describe('VisionCamera - Frame', () => {
       errorSub.remove()
       await session.stop()
     }
-    console.log(
-      `native frame buffers: frames=${framesReceived} pixelBuffers=${pixelBuffersReceived} nativeBuffers=${nativeBuffersReceived}`,
-    )
-    expect(framesReceived).toBeGreaterThanOrEqual(3)
+    if (unsupportedReason != null) {
+      return context.skip(unsupportedReason)
+    }
+    expect(buffersReceived).toBeGreaterThanOrEqual(3)
   })
 
   it('keeps YUV plane buffers readable across repeated reads', async () => {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getNativeBuffer.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getNativeBuffer.kt
@@ -7,6 +7,18 @@ import androidx.camera.core.ImageProxy
 import com.margelo.nitro.camera.NativeBuffer
 import com.margelo.nitro.camera.utils.NativeBufferHelper
 
+val ImageProxy.hasNativeBuffer: Boolean
+  @OptIn(ExperimentalGetImage::class)
+  get() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+      return false
+    }
+    image?.hardwareBuffer?.use {
+      return true
+    }
+    return false
+  }
+
 @OptIn(ExperimentalGetImage::class)
 fun ImageProxy.getNativeBuffer(): NativeBuffer {
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+getPixelBuffer.kt
@@ -7,6 +7,7 @@ import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageProxy
 import com.margelo.nitro.camera.utils.DirectByteBufferPool
 import com.margelo.nitro.core.ArrayBuffer
+import java.nio.ByteBuffer
 
 val ImageProxy.hasPixelBuffer: Boolean
   @OptIn(ExperimentalGetImage::class)
@@ -30,6 +31,23 @@ data class DisposableArrayBuffer(
   val dispose: () -> Unit,
 )
 
+private fun ByteBuffer.wrapOrCopyIntoArrayBuffer(): DisposableArrayBuffer {
+  val buffer = readableBytes()
+  if (buffer.isDirect) {
+    val arrayBuffer = ArrayBuffer.wrap(buffer)
+    return DisposableArrayBuffer(arrayBuffer) {
+      // no release
+    }
+  }
+
+  val directBuffer = DirectByteBufferPool.Shared.acquire(buffer.remaining())
+  directBuffer.put(buffer)
+  val arrayBuffer = ArrayBuffer.wrap(directBuffer)
+  return DisposableArrayBuffer(arrayBuffer) {
+    DirectByteBufferPool.Shared.release(directBuffer)
+  }
+}
+
 @OptIn(ExperimentalGetImage::class)
 fun ImageProxy.getPixelBuffer(): DisposableArrayBuffer {
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -47,12 +65,8 @@ fun ImageProxy.getPixelBuffer(): DisposableArrayBuffer {
   }
   when {
     planes.size == 1 -> {
-      // Medium Path: We can wrap a single plane as a ByteBuffer
-      val byteBuffer = planes.single().buffer.readableBytes()
-      val arrayBuffer = ArrayBuffer.wrap(byteBuffer)
-      return DisposableArrayBuffer(arrayBuffer) {
-        // no release
-      }
+      // Medium Path: We can wrap a single direct plane as a ByteBuffer, or copy it into one if needed.
+      return planes.single().buffer.wrapOrCopyIntoArrayBuffer()
     }
     planes.size > 1 -> {
       // Slow Path: We have to copy all planes into a new ByteBuffer.

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridFrame.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridFrame.kt
@@ -12,6 +12,8 @@ import com.margelo.nitro.camera.extensions.DisposableArrayBuffer
 import com.margelo.nitro.camera.extensions.convertPoint
 import com.margelo.nitro.camera.extensions.getNativeBuffer
 import com.margelo.nitro.camera.extensions.getPixelBuffer
+import com.margelo.nitro.camera.extensions.hasNativeBuffer
+import com.margelo.nitro.camera.extensions.hasPixelBuffer
 import com.margelo.nitro.camera.extensions.mapToArray
 import com.margelo.nitro.camera.extensions.pixelFormat
 import com.margelo.nitro.camera.public.NativeFrame
@@ -50,6 +52,10 @@ class HybridFrame(
     get() = image.pixelFormat
   override val isPlanar: Boolean
     get() = image.planes.size > 1
+  override val hasPixelBuffer: Boolean
+    get() = image.hasPixelBuffer
+  override val hasNativeBuffer: Boolean
+    get() = image.hasNativeBuffer
 
   // TODO: Implement `cameraIntrinsicMatrix`
   override val cameraIntrinsicMatrix: DoubleArray?

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Image Types/HybridFrame.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Image Types/HybridFrame.swift
@@ -74,6 +74,14 @@ final class HybridFrame: HybridFrameSpec, NativeFrame, LazyLockableBuffer {
     return CVPixelBufferIsPlanar(pixelBuffer)
   }
 
+  var hasPixelBuffer: Bool {
+    return pixelBuffer != nil
+  }
+
+  var hasNativeBuffer: Bool {
+    return pixelBuffer != nil
+  }
+
   var pixelFormat: PixelFormat {
     guard let pixelBuffer else {
       return .unknown

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridFrameSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridFrameSpec.cpp
@@ -112,6 +112,16 @@ namespace margelo::nitro::camera {
     auto __result = method(_javaPart);
     return static_cast<bool>(__result);
   }
+  bool JHybridFrameSpec::getHasPixelBuffer() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getHasPixelBuffer");
+    auto __result = method(_javaPart);
+    return static_cast<bool>(__result);
+  }
+  bool JHybridFrameSpec::getHasNativeBuffer() {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getHasNativeBuffer");
+    auto __result = method(_javaPart);
+    return static_cast<bool>(__result);
+  }
   std::optional<std::vector<double>> JHybridFrameSpec::getCameraIntrinsicMatrix() {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayDouble>()>("getCameraIntrinsicMatrix");
     auto __result = method(_javaPart);

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridFrameSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridFrameSpec.hpp
@@ -59,6 +59,8 @@ namespace margelo::nitro::camera {
     CameraOrientation getOrientation() override;
     bool getIsMirrored() override;
     bool getIsPlanar() override;
+    bool getHasPixelBuffer() override;
+    bool getHasNativeBuffer() override;
     std::optional<std::vector<double>> getCameraIntrinsicMatrix() override;
 
   public:

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridFrameSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridFrameSpec.kt
@@ -29,39 +29,47 @@ abstract class HybridFrameSpec: HybridObject() {
   @get:DoNotStrip
   @get:Keep
   abstract val timestamp: Double
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val isValid: Boolean
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val width: Double
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val height: Double
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val bytesPerRow: Double
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val pixelFormat: PixelFormat
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val orientation: CameraOrientation
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val isMirrored: Boolean
-  
+
   @get:DoNotStrip
   @get:Keep
   abstract val isPlanar: Boolean
-  
+
+  @get:DoNotStrip
+  @get:Keep
+  abstract val hasPixelBuffer: Boolean
+
+  @get:DoNotStrip
+  @get:Keep
+  abstract val hasNativeBuffer: Boolean
+
   @get:DoNotStrip
   @get:Keep
   abstract val cameraIntrinsicMatrix: DoubleArray?
@@ -70,19 +78,19 @@ abstract class HybridFrameSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun getPlanes(): Array<HybridFramePlaneSpec>
-  
+
   @DoNotStrip
   @Keep
   abstract fun getPixelBuffer(): ArrayBuffer
-  
+
   @DoNotStrip
   @Keep
   abstract fun getNativeBuffer(): NativeBuffer
-  
+
   @DoNotStrip
   @Keep
   abstract fun convertCameraPointToFramePoint(cameraPoint: Point): Point
-  
+
   @DoNotStrip
   @Keep
   abstract fun convertFramePointToCameraPoint(framePoint: Point): Point

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridFrameSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridFrameSpecSwift.hpp
@@ -112,6 +112,12 @@ namespace margelo::nitro::camera {
     inline bool getIsPlanar() noexcept override {
       return _swiftPart.isPlanar();
     }
+    inline bool getHasPixelBuffer() noexcept override {
+      return _swiftPart.hasPixelBuffer();
+    }
+    inline bool getHasNativeBuffer() noexcept override {
+      return _swiftPart.hasNativeBuffer();
+    }
     inline std::optional<std::vector<double>> getCameraIntrinsicMatrix() noexcept override {
       auto __result = _swiftPart.getCameraIntrinsicMatrix();
       return __result;

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridFrameSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridFrameSpec.swift
@@ -19,6 +19,8 @@ public protocol HybridFrameSpec_protocol: HybridObject {
   var orientation: CameraOrientation { get }
   var isMirrored: Bool { get }
   var isPlanar: Bool { get }
+  var hasPixelBuffer: Bool { get }
+  var hasNativeBuffer: Bool { get }
   var cameraIntrinsicMatrix: [Double]? { get }
 
   // Methods

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridFrameSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridFrameSpec_cxx.swift
@@ -84,7 +84,7 @@ open class HybridFrameSpec_cxx {
     }
   }
 
-  
+
 
   /**
    * Get the memory size of the Swift class (plus size of any other allocations)
@@ -127,63 +127,77 @@ open class HybridFrameSpec_cxx {
       return self.__implementation.timestamp
     }
   }
-  
+
   public final var isValid: Bool {
     @inline(__always)
     get {
       return self.__implementation.isValid
     }
   }
-  
+
   public final var width: Double {
     @inline(__always)
     get {
       return self.__implementation.width
     }
   }
-  
+
   public final var height: Double {
     @inline(__always)
     get {
       return self.__implementation.height
     }
   }
-  
+
   public final var bytesPerRow: Double {
     @inline(__always)
     get {
       return self.__implementation.bytesPerRow
     }
   }
-  
+
   public final var pixelFormat: Int32 {
     @inline(__always)
     get {
       return self.__implementation.pixelFormat.rawValue
     }
   }
-  
+
   public final var orientation: Int32 {
     @inline(__always)
     get {
       return self.__implementation.orientation.rawValue
     }
   }
-  
+
   public final var isMirrored: Bool {
     @inline(__always)
     get {
       return self.__implementation.isMirrored
     }
   }
-  
+
   public final var isPlanar: Bool {
     @inline(__always)
     get {
       return self.__implementation.isPlanar
     }
   }
-  
+
+  public final var hasPixelBuffer: Bool {
+    @inline(__always)
+    get {
+      return self.__implementation.hasPixelBuffer
+    }
+  }
+
+  public final var hasNativeBuffer: Bool {
+    @inline(__always)
+    get {
+      return self.__implementation.hasNativeBuffer
+    }
+  }
+
   public final var cameraIntrinsicMatrix: bridge.std__optional_std__vector_double__ {
     @inline(__always)
     get {
@@ -224,7 +238,7 @@ open class HybridFrameSpec_cxx {
       return bridge.create_Result_std__vector_std__shared_ptr_HybridFramePlaneSpec___(__exceptionPtr)
     }
   }
-  
+
   @inline(__always)
   public final func getPixelBuffer() -> bridge.Result_std__shared_ptr_ArrayBuffer__ {
     do {
@@ -236,7 +250,7 @@ open class HybridFrameSpec_cxx {
       return bridge.create_Result_std__shared_ptr_ArrayBuffer__(__exceptionPtr)
     }
   }
-  
+
   @inline(__always)
   public final func getNativeBuffer() -> bridge.Result_NativeBuffer_ {
     do {
@@ -248,7 +262,7 @@ open class HybridFrameSpec_cxx {
       return bridge.create_Result_NativeBuffer_(__exceptionPtr)
     }
   }
-  
+
   @inline(__always)
   public final func convertCameraPointToFramePoint(cameraPoint: Point) -> bridge.Result_Point_ {
     do {
@@ -260,7 +274,7 @@ open class HybridFrameSpec_cxx {
       return bridge.create_Result_Point_(__exceptionPtr)
     }
   }
-  
+
   @inline(__always)
   public final func convertFramePointToCameraPoint(framePoint: Point) -> bridge.Result_Point_ {
     do {

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridFrameSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridFrameSpec.cpp
@@ -23,6 +23,8 @@ namespace margelo::nitro::camera {
       prototype.registerHybridGetter("orientation", &HybridFrameSpec::getOrientation);
       prototype.registerHybridGetter("isMirrored", &HybridFrameSpec::getIsMirrored);
       prototype.registerHybridGetter("isPlanar", &HybridFrameSpec::getIsPlanar);
+      prototype.registerHybridGetter("hasPixelBuffer", &HybridFrameSpec::getHasPixelBuffer);
+      prototype.registerHybridGetter("hasNativeBuffer", &HybridFrameSpec::getHasNativeBuffer);
       prototype.registerHybridGetter("cameraIntrinsicMatrix", &HybridFrameSpec::getCameraIntrinsicMatrix);
       prototype.registerHybridMethod("getPlanes", &HybridFrameSpec::getPlanes);
       prototype.registerHybridMethod("getPixelBuffer", &HybridFrameSpec::getPixelBuffer);

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridFrameSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridFrameSpec.hpp
@@ -70,6 +70,8 @@ namespace margelo::nitro::camera {
       virtual CameraOrientation getOrientation() = 0;
       virtual bool getIsMirrored() = 0;
       virtual bool getIsPlanar() = 0;
+      virtual bool getHasPixelBuffer() = 0;
+      virtual bool getHasNativeBuffer() = 0;
       virtual std::optional<std::vector<double>> getCameraIntrinsicMatrix() = 0;
 
     public:

--- a/packages/react-native-vision-camera/src/specs/instances/Frame.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/instances/Frame.nitro.ts
@@ -251,17 +251,30 @@ export interface Frame
   readonly isPlanar: boolean
 
   /**
-   * Get whether this {@linkcode Frame} has a readable pixel buffer
+   * Get whether this {@linkcode Frame} has a readable Pixel Buffer
    * attached to it.
+   *
+   * @discussion
+   * Usually a {@linkcode Frame} has an application-accessible Pixel Buffer
+   * if its {@linkcode pixelFormat} is application-accessible - aka
+   * every {@linkcode PixelFormat} except for {@linkcode PixelFormat | 'private'}.
+   * On iOS, every Frame has an application-accessible Pixel Buffer.
    *
    * @see {@linkcode getPixelBuffer | getPixelBuffer()}
    */
   readonly hasPixelBuffer: boolean
   /**
-   * Get whether this {@linkcode Frame} has a native buffer
+   * Get whether this {@linkcode Frame} has a Native Buffer
    * attached to it.
    *
+   * @discussion
+   * Usually a {@linkcode Frame} has a Native Buffer if
+   * its {@linkcode pixelFormat} is application-accessible - aka
+   * every {@linkcode PixelFormat} except for {@linkcode PixelFormat | 'private'}.
+   * On iOS, every Frame has a Native Buffer.
+   *
    * @see {@linkcode getNativeBuffer | getNativeBuffer()}
+   * @see {@linkcode NativeBuffer}
    */
   readonly hasNativeBuffer: boolean
 
@@ -290,7 +303,16 @@ export interface Frame
    * Once the {@linkcode Frame} gets invalidated ({@linkcode isValid} == false),
    * this ArrayBuffer is no longer safe to access.
    *
-   * @throws If this Frame is invalid ({@linkcode isValid}).
+   * @throws If this Frame is invalid ({@linkcode isValid}) or
+   * {@linkcode hasPixelBuffer | hasPixelBuffer} is false.
+   *
+   * @example
+   * ```ts
+   * if (frame.hasPixelBuffer) {
+   *   const pixelBuffer = frame.getPixelBuffer()
+   *   console.log(`Frame has ${pixelBuffer.byteLength} bytes.`)
+   * }
+   * ```
    */
   getPixelBuffer(): ArrayBuffer
 
@@ -304,6 +326,17 @@ export interface Frame
    * The {@linkcode NativeBuffer} must be released
    * again by its consumer via {@linkcode NativeBuffer.release | release()},
    * otherwise the Camera pipeline might stall.
+   *
+   * @throws If {@linkcode hasNativeBuffer | hasNativeBuffer} is false.
+   *
+   * @example
+   * ```ts
+   * if (frame.hasNativeBuffer) {
+   *   const nativeBuffer = frame.getNativeBuffer()
+   *   console.log(`Native Buffer pointer: ${nativeBuffer.pointer}`)
+   *   nativeBuffer.release()
+   * }
+   * ```
    */
   getNativeBuffer(): NativeBuffer
 

--- a/packages/react-native-vision-camera/src/specs/instances/Frame.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/instances/Frame.nitro.ts
@@ -251,6 +251,21 @@ export interface Frame
   readonly isPlanar: boolean
 
   /**
+   * Get whether this {@linkcode Frame} has a readable pixel buffer
+   * attached to it.
+   *
+   * @see {@linkcode getPixelBuffer | getPixelBuffer()}
+   */
+  readonly hasPixelBuffer: boolean
+  /**
+   * Get whether this {@linkcode Frame} has a native buffer
+   * attached to it.
+   *
+   * @see {@linkcode getNativeBuffer | getNativeBuffer()}
+   */
+  readonly hasNativeBuffer: boolean
+
+  /**
    * Returns each plane of a **planar** Frame (see {@linkcode isPlanar}).
    * If this Frame is **non-planar**, this method returns an empty array (`[]`).
    *


### PR DESCRIPTION
Adds APIs to check if a `Frame` has an accessible pixel buffer (`getPixelBuffer(): ArrayBuffer`) or NativeBuffer (`getNativeBuffer(): NativeBuffer`).

Previously, those methods could've just thrown on Android. Now we can check the availability for those things. On iOS, those are always available/true.