### PR TITLE
chore: Upgrade Skia to 2.6.4

### DIFF
--- a/apps/simple-camera/ios/Podfile.lock
+++ b/apps/simple-camera/ios/Podfile.lock
@@ -1606,7 +1606,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-skia (2.4.21):
+  - react-native-skia (2.6.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2797,7 +2797,7 @@ SPEC CHECKSUMS:
   react-native-blur: 4173cfa2b37358b2e767ca690a8afa2cb74b0aae
   react-native-menu: 17321e8d0d15af018c56ae7e4e42268ef297f6c3
   react-native-safe-area-context: 29044d05d61f2c60d0828c373bd0ebe17eed58d0
-  react-native-skia: a9c0ab55f18fa812b0db161c333e8bff4d739bb9
+  react-native-skia: bd98485c5d19b8fb749db4b8aff338d324f24e6c
   react-native-vector-icons-ionicons: 7bc32eadb4d24c93252430b49f25b8be000e2340
   react-native-video: 8cfc70ca7f8f99906233b1a65a8b3c937fb32c1a
   React-NativeModulesApple: 14a8919451154ede904f2bca84b27703a09028ba

--- a/apps/simple-camera/package.json
+++ b/apps/simple-camera/package.json
@@ -20,7 +20,7 @@
     "@react-native-vector-icons/ionicons": "12.4.1",
     "@react-navigation/native": "^7.1.31",
     "@react-navigation/native-stack": "^7.14.2",
-    "@shopify/react-native-skia": "2.4.21",
+    "@shopify/react-native-skia": "2.6.4",
     "@types/jest": "^30.0.0",
     "react": "19.2.3",
     "react-native": "0.84.0",

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "@react-native-vector-icons/ionicons": "12.4.1",
         "@react-navigation/native": "^7.1.31",
         "@react-navigation/native-stack": "^7.14.2",
-        "@shopify/react-native-skia": "2.4.21",
+        "@shopify/react-native-skia": "2.6.4",
         "@types/jest": "^30.0.0",
         "react": "19.2.3",
         "react-native": "0.84.0",
@@ -179,7 +179,7 @@
       "name": "react-native-vision-camera-skia",
       "version": "5.0.11",
       "devDependencies": {
-        "@shopify/react-native-skia": "2.4.21",
+        "@shopify/react-native-skia": "2.6.4",
         "@types/react": "19.2.14",
         "react": "19.2.3",
         "react-native": "0.84.0",
@@ -1065,7 +1065,7 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@shopify/react-native-skia": ["@shopify/react-native-skia@2.4.21", "", { "dependencies": { "canvaskit-wasm": "0.40.0", "react-reconciler": "0.31.0" }, "peerDependencies": { "react": ">=19.0", "react-native": ">=0.78", "react-native-reanimated": ">=3.19.1" }, "optionalPeers": ["react-native", "react-native-reanimated"], "bin": { "setup-skia-web": "scripts/setup-canvaskit.js" } }, "sha512-US1dIpHbnU63k1S1oOAJ1x4oyuQJ6XDHIAs1kXiDSA4g2jWdH7UPoUHvEllqip2MI2Oc2ZNLsip5Ftegz714oA=="],
+    "@shopify/react-native-skia": ["@shopify/react-native-skia@2.6.4", "", { "dependencies": { "canvaskit-wasm": "0.41.0", "react-native-skia-android": "147.1.0", "react-native-skia-apple-ios": "147.1.0", "react-native-skia-apple-macos": "147.1.0", "react-native-skia-apple-tvos": "147.1.0", "react-reconciler": "0.31.0" }, "peerDependencies": { "react": ">=19.0", "react-native": ">=0.78", "react-native-reanimated": ">=3.19.1" }, "optionalPeers": ["react-native", "react-native-reanimated"], "bin": { "install-skia": "scripts/install-libs.js", "setup-skia-web": "scripts/setup-canvaskit.js" } }, "sha512-PhdBdEApukimzt3tJSqbOqeZnjmfQE6kG9H4XaIUaa9EDNK67nYa2jGDTR1HHChgQDguksg21K4IX0zBh5fjQA=="],
 
     "@sideway/address": ["@sideway/address@4.1.5", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q=="],
 
@@ -1355,7 +1355,7 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
 
-    "canvaskit-wasm": ["canvaskit-wasm@0.40.0", "", { "dependencies": { "@webgpu/types": "0.1.21" } }, "sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw=="],
+    "canvaskit-wasm": ["canvaskit-wasm@0.41.0", "", { "dependencies": { "@webgpu/types": "0.1.21" } }, "sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -2412,6 +2412,14 @@
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 
     "react-native-screens": ["react-native-screens@4.24.0", "", { "dependencies": { "react-freeze": "^1.0.0", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-SyoiGaDofiyGPFrUkn1oGsAzkRuX1JUvTD9YQQK3G1JGQ5VWkvHgYSsc1K9OrLsDQxN7NmV71O0sHCAh8cBetA=="],
+
+    "react-native-skia-android": ["react-native-skia-android@147.1.0", "", {}, "sha512-pWA0M0G74AhjEop0HLCkjWJMup2HJxOmuUjfPt6kSDhYeWKVx8AEzWh0Fh19ah78zE/s4hD0Of0Tyem5shhiTg=="],
+
+    "react-native-skia-apple-ios": ["react-native-skia-apple-ios@147.1.0", "", {}, "sha512-cr4rWe4Bf0H0TTutUp5cgHt5/Felttl1bh4BAAAsgAeL2F10FAK9urX8spjUshzMwjqXD7rNOWuFzU6ZcNlGKw=="],
+
+    "react-native-skia-apple-macos": ["react-native-skia-apple-macos@147.1.0", "", {}, "sha512-Qbv0Y7LgawtRKuGk8gnGeh8nDWwNiu03LcX0mVaQzBBbxFDYvqejanA+AkO3p8gsQb+fsXRc9DAk+U8cBnzZvA=="],
+
+    "react-native-skia-apple-tvos": ["react-native-skia-apple-tvos@147.1.0", "", {}, "sha512-b+4vILXHPu++t8H41PHLBVsTab2LPqwXNdzgdScyl4+Cu8Ta34aUQW3T469cB0ogAMPdu//KV00w4YVpDZoRUQ=="],
 
     "react-native-url-polyfill": ["react-native-url-polyfill@3.0.0", "", { "dependencies": { "whatwg-url-without-unicode": "8.0.0-3" }, "peerDependencies": { "react-native": "*" } }, "sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg=="],
 

--- a/packages/react-native-vision-camera-skia/package.json
+++ b/packages/react-native-vision-camera-skia/package.json
@@ -52,7 +52,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@shopify/react-native-skia": "2.4.21",
+    "@shopify/react-native-skia": "2.6.4",
     "@types/react": "19.2.14",
     "react": "19.2.3",
     "react-native": "0.84.0",


### PR DESCRIPTION
## Summary
- Upgrade @shopify/react-native-skia from 2.4.21 to 2.6.4 in the example app and VisionCamera Skia package.
- Refresh the example app Podfile.lock for react-native-skia 2.6.4.

## Changelog review
- 2.5.0 moved Skia prebuilt binaries to npm packages and added 10-bit YUV/color-space handling.
- 2.6.0 introduced the immutable Path API; this repo does not use that API directly.
- 2.6.4 fixes static-framework header search paths, updates the internal Worklets dependency, and resolves `Symbol.dispose` without JS eval.
- Checked the local Skia adapter APIs (`Canvas`, `Skia.Image.MakeImageFromNativeBuffer`, `Skia.Surface.MakeOffscreen`, `SkImage`, `SkCanvas`) and no code migration was required.

## Validation
- bun install --frozen-lockfile
- bun run build
- bun --cwd apps/simple-camera tsc --noEmit
- git diff --check
- PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH /Users/mrousavy/.rbenv/versions/2.7.6/bin/bundle exec pod install

## Notes
- Android assemble validation was attempted with `./gradlew :app:assembleDebug --no-daemon --stacktrace`, but this shell cannot locate a Java runtime.
