### PR TITLE
chore: Upgrade react-native-video to 6.19.2

### DIFF
--- a/apps/simple-camera/ios/Podfile.lock
+++ b/apps/simple-camera/ios/Podfile.lock
@@ -1631,7 +1631,7 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - react-native-vector-icons-ionicons (12.4.1)
-  - react-native-video (6.19.1):
+  - react-native-video (6.19.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1643,7 +1643,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-video/Video (= 6.19.1)
+    - react-native-video/Video (= 6.19.2)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1654,7 +1654,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-video/Fabric (6.19.1):
+  - react-native-video/Fabric (6.19.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1676,7 +1676,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-video/Video (6.19.1):
+  - react-native-video/Video (6.19.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2799,7 +2799,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 29044d05d61f2c60d0828c373bd0ebe17eed58d0
   react-native-skia: a9c0ab55f18fa812b0db161c333e8bff4d739bb9
   react-native-vector-icons-ionicons: 7bc32eadb4d24c93252430b49f25b8be000e2340
-  react-native-video: 8cfc70ca7f8f99906233b1a65a8b3c937fb32c1a
+  react-native-video: 7d8b2953c75b8a13bbb726103ec7a0b71784b9c3
   React-NativeModulesApple: 14a8919451154ede904f2bca84b27703a09028ba
   React-networking: 46c0037f9202c1919493b78662a47cbe13022fdd
   React-oscompat: b924b8609d06899f00ab1aa813b0cde9c5e12771

--- a/apps/simple-camera/package.json
+++ b/apps/simple-camera/package.json
@@ -31,7 +31,7 @@
     "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "^4.24.0",
     "react-native-vector-icons": "^10.3.0",
-    "react-native-video": "6.19.1",
+    "react-native-video": "6.19.2",
     "react-native-vision-camera": "../../packages/react-native-vision-camera",
     "react-native-vision-camera-barcode-scanner": "../../packages/react-native-vision-camera-barcode-scanner",
     "react-native-vision-camera-location": "../../packages/react-native-vision-camera-location",

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "react-native-safe-area-context": "^5.7.0",
         "react-native-screens": "^4.24.0",
         "react-native-vector-icons": "^10.3.0",
-        "react-native-video": "6.19.1",
+        "react-native-video": "6.19.2",
         "react-native-vision-camera": "../../packages/react-native-vision-camera",
         "react-native-vision-camera-barcode-scanner": "../../packages/react-native-vision-camera-barcode-scanner",
         "react-native-vision-camera-location": "../../packages/react-native-vision-camera-location",
@@ -2417,7 +2417,7 @@
 
     "react-native-vector-icons": ["react-native-vector-icons@10.3.0", "", { "dependencies": { "prop-types": "^15.7.2", "yargs": "^16.1.1" }, "bin": { "fa5-upgrade": "bin/fa5-upgrade.sh", "fa6-upgrade": "bin/fa6-upgrade.sh", "fa-upgrade.sh": "bin/fa-upgrade.sh", "generate-icon": "bin/generate-icon.js" } }, "sha512-IFQ0RE57819hOUdFvgK4FowM5aMXg7C7XKsuGLevqXkkIJatc3QopN0wYrb2IrzUgmdpfP+QVIbI3S6h7M0btw=="],
 
-    "react-native-video": ["react-native-video@6.19.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Tbiyt0JMirVHc4XzGIANjs3SaNjFXQO2qe+buvY7xMJjlyCekkDjJqD9YtlaEloJD2PGWhoPytEXB6gVT7T6lw=="],
+    "react-native-video": ["react-native-video@6.19.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-gh5dBMGSHywKr8+p4azRXrFQgT+QTmS1tI4sz6kVRjSENORfsrGGLQzmyo/7S9m+ZOTLWQJ3h8ONaXxR4F2Fcw=="],
 
     "react-native-vision-camera": ["react-native-vision-camera@workspace:packages/react-native-vision-camera"],
 


### PR DESCRIPTION
## Summary
- Upgrade react-native-video from 6.19.1 to 6.19.2.
- Refresh the example app Podfile.lock for the react-native-video pod.

## Changelog review
- 6.19.2 replaces internal `StyleSheet.absoluteFillObject` usage with `StyleSheet.absoluteFill`, which aligns with React Native 0.85 compatibility.
- The app only renders `<Video source={{ uri }} controls />`, so no code migration was required.

## Validation
- bun install --frozen-lockfile
- bun run build
- bun --cwd apps/simple-camera tsc --noEmit
- git diff --check
- PATH=/Users/mrousavy/.nvm/versions/node/v20.19.4/bin:$PATH /Users/mrousavy/.rbenv/versions/2.7.6/bin/bundle exec pod install

## Notes
- Android assemble validation was attempted with `./gradlew :app:assembleDebug --no-daemon --stacktrace`, but this shell cannot locate a Java runtime.
