### PR TITLE
chore: Upgrade Node types to 25.9.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -87,7 +87,7 @@
         "@playwright/test": "1.58.2",
         "@tailwindcss/postcss": "4.2.1",
         "@types/mdx": "^2.0.13",
-        "@types/node": "25.3.2",
+        "@types/node": "25.9.1",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "postcss": "^8.5.6",
@@ -1167,7 +1167,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@25.3.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q=="],
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
@@ -2703,7 +2703,7 @@
 
     "undici": ["undici@6.23.0", "", {}, "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,7 +39,7 @@
     "@playwright/test": "1.58.2",
     "@tailwindcss/postcss": "4.2.1",
     "@types/mdx": "^2.0.13",
-    "@types/node": "25.3.2",
+    "@types/node": "25.9.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "postcss": "^8.5.6",

--- a/docs/tsconfig.scripts.json
+++ b/docs/tsconfig.scripts.json
@@ -9,6 +9,9 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "types": ["node"]
   },
   "include": [


### PR DESCRIPTION
## Summary
- Upgrades docs `@types/node` from 25.3.2 to 25.9.1.
- Adds the docs scripts `@/*` path mapping so script type checks that import docs source helpers are independently verifiable.

## Changelog Notes
- `@types/node` 25.9.1 is the current latest package and the active dist-tag for TypeScript 5.3 through 6.0.
- No runtime Node dependency changes are included; this is type-only.

## Validation
- `bun install --frozen-lockfile`
- `bun --cwd docs tsc --noEmit`
- `bun --cwd docs tsc -p tsconfig.scripts.json --noEmit`
- `bun --cwd docs test:logic`
- `bun --cwd docs build`
- `git diff --check`
