### PR TITLE
chore: Upgrade Android toolchain to AGP 9.1.1

### DIFF
--- a/apps/simple-camera/android/app/src/main/AndroidManifest.xml
+++ b/apps/simple-camera/android/app/src/main/AndroidManifest.xml
@@ -6,10 +6,13 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
       android:name=".MainApplication"

--- a/apps/simple-camera/android/build.gradle
+++ b/apps/simple-camera/android/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
     ext {
-        buildToolsVersion = "36.0.0"
+        buildToolsVersion = "36.1.0"
         minSdkVersion = 26
         compileSdkVersion = 36
         targetSdkVersion = 36
-        ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.1.20"
+        ndkVersion = "29.0.14206865"
+        kotlinVersion = "2.2.21"
     }
     repositories {
         google()

--- a/packages/react-native-vision-camera-barcode-scanner/android/build.gradle
+++ b/packages/react-native-vision-camera-barcode-scanner/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:9.1.0"
+    classpath "com.android.tools.build:gradle:9.1.1"
   }
 }
 

--- a/packages/react-native-vision-camera-barcode-scanner/android/gradle.properties
+++ b/packages/react-native-vision-camera-barcode-scanner/android/gradle.properties
@@ -1,5 +1,5 @@
-VisionCameraBarcodeScanner_kotlinVersion=2.1.20
+VisionCameraBarcodeScanner_kotlinVersion=2.2.21
 VisionCameraBarcodeScanner_minSdkVersion=23
 VisionCameraBarcodeScanner_targetSdkVersion=36
 VisionCameraBarcodeScanner_compileSdkVersion=36
-VisionCameraBarcodeScanner_ndkVersion=27.1.12297006
+VisionCameraBarcodeScanner_ndkVersion=29.0.14206865

--- a/packages/react-native-vision-camera-location/android/build.gradle
+++ b/packages/react-native-vision-camera-location/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:9.1.0"
+    classpath "com.android.tools.build:gradle:9.1.1"
   }
 }
 

--- a/packages/react-native-vision-camera-location/android/gradle.properties
+++ b/packages/react-native-vision-camera-location/android/gradle.properties
@@ -1,5 +1,5 @@
-VisionCameraLocation_kotlinVersion=2.1.20
+VisionCameraLocation_kotlinVersion=2.2.21
 VisionCameraLocation_minSdkVersion=23
 VisionCameraLocation_targetSdkVersion=36
 VisionCameraLocation_compileSdkVersion=36
-VisionCameraLocation_ndkVersion=27.1.12297006
+VisionCameraLocation_ndkVersion=29.0.14206865

--- a/packages/react-native-vision-camera-resizer/android/build.gradle
+++ b/packages/react-native-vision-camera-resizer/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:9.1.0"
+    classpath "com.android.tools.build:gradle:9.1.1"
   }
 }
 

--- a/packages/react-native-vision-camera-resizer/android/gradle.properties
+++ b/packages/react-native-vision-camera-resizer/android/gradle.properties
@@ -1,5 +1,5 @@
-VisionCameraResizer_kotlinVersion=2.1.20
+VisionCameraResizer_kotlinVersion=2.2.21
 VisionCameraResizer_minSdkVersion=26
 VisionCameraResizer_targetSdkVersion=36
 VisionCameraResizer_compileSdkVersion=36
-VisionCameraResizer_ndkVersion=27.1.12297006
+VisionCameraResizer_ndkVersion=29.0.14206865

--- a/packages/react-native-vision-camera-worklets/android/build.gradle
+++ b/packages/react-native-vision-camera-worklets/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:9.1.0"
+    classpath "com.android.tools.build:gradle:9.1.1"
   }
 }
 

--- a/packages/react-native-vision-camera-worklets/android/gradle.properties
+++ b/packages/react-native-vision-camera-worklets/android/gradle.properties
@@ -1,5 +1,5 @@
-VisionCameraWorklets_kotlinVersion=2.1.20
+VisionCameraWorklets_kotlinVersion=2.2.21
 VisionCameraWorklets_minSdkVersion=23
 VisionCameraWorklets_targetSdkVersion=36
 VisionCameraWorklets_compileSdkVersion=36
-VisionCameraWorklets_ndkVersion=27.1.12297006
+VisionCameraWorklets_ndkVersion=29.0.14206865

--- a/packages/react-native-vision-camera/android/build.gradle
+++ b/packages/react-native-vision-camera/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:9.1.0"
+    classpath "com.android.tools.build:gradle:9.1.1"
   }
 }
 

--- a/packages/react-native-vision-camera/android/gradle.properties
+++ b/packages/react-native-vision-camera/android/gradle.properties
@@ -1,5 +1,5 @@
-VisionCamera_kotlinVersion=2.1.20
+VisionCamera_kotlinVersion=2.2.21
 VisionCamera_minSdkVersion=23
 VisionCamera_targetSdkVersion=36
 VisionCamera_compileSdkVersion=36
-VisionCamera_ndkVersion=27.1.12297006
+VisionCamera_ndkVersion=29.0.14206865


### PR DESCRIPTION
## Summary
- upgrade Android Gradle Plugin from 9.1.0 to 9.1.1 across the package Android builds
- upgrade the Android sample app/toolchain defaults to Kotlin 2.2.21, NDK 29.0.14206865, and build tools 36.1.0
- add the POST_NOTIFICATIONS permission and optional camera feature declaration required by newer Android lint checks

## Compatibility notes
- checked Gradle 9.5.1/9.4.1 and AGP 9.2.1, but the current React Native Gradle plugin path still compiles with Kotlin 2.1.x metadata and fails against Gradle's newer embedded Kotlin metadata
- checked Kotlin 2.3.21, but current transitive Android modules still compile through Kotlin 2.1.x paths and fail on Kotlin 2.3 metadata
- compile/target SDK stay at Android 36 because Android 37 is still exposed as a codename preview in the SDK repository

## Validation
- JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew help --no-daemon --console=plain
- JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew :app:assembleDebug -PreactNativeArchitectures=arm64-v8a --no-daemon --build-cache --console=plain
- JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew :app:lintDebug --no-daemon --build-cache --console=plain
- bun lint-kotlin
- git diff --check

Harness tests were intentionally not used as a gate for this upgrade.