### PR TITLE
chore: Upgrade Xcode CI to 26.5

### DIFF
--- a/.github/workflows/build-ios-release.yml
+++ b/.github/workflows/build-ios-release.yml
@@ -25,8 +25,8 @@ jobs:
           bundler-cache: true
           working-directory: apps/simple-camera
 
-      - name: Select Xcode 26.2
-        run: sudo xcode-select -s "/Applications/Xcode_26.2.app/Contents/Developer"
+      - name: Select Xcode 26.5
+        run: sudo xcode-select -s "/Applications/Xcode_26.5.app/Contents/Developer"
       - name: Install Pods
         working-directory: apps/simple-camera
         run: bun pods

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -61,7 +61,7 @@ env:
   USE_CCACHE: 1
   HARNESS_AWS_REGION: us-west-2
   HARNESS_DEVICE_FARM_PROJECT_ARN: arn:aws:devicefarm:us-west-2:633665345122:project:210b1942-012b-4653-9673-f3ff91c5e649
-  HARNESS_XCODE_VERSION: "26.2"
+  HARNESS_XCODE_VERSION: "26.5"
   HARNESS_PROJECT_ROOT: apps/simple-camera
   HARNESS_ANDROID_APP_BUILD_OUTPUT: apps/simple-camera/android/app/build/outputs/apk/debug/app-debug.apk
   HARNESS_IOS_APP_BUILD_OUTPUT: apps/simple-camera/ios/build/devicefarm/SimpleCamera.ipa


### PR DESCRIPTION
## Summary
- selects Xcode 26.5 for the release iOS workflow
- updates the AWS Device Farm iOS harness Xcode selector/cache key from 26.2 to 26.5
- keeps Ruby/CocoaPods changes isolated; CocoaPods is handled in #3951 and Ruby should be reconsidered after that lands
- keeps `SWIFT_VERSION = 5.0`; the Swift compiler comes from the selected Xcode, while a Swift 6 language-mode migration is a separate source-compatibility change

## Source
- GitHub macOS 26 runner image lists Xcode 26.5 at `/Applications/Xcode_26.5.app` and iOS/macOS SDK 26.5: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/build-ios-release.yml .github/workflows/harness-aws-device.yml`\n- `git diff --check`\n- local machine is Xcode 26.3 / iOS SDK 26.2, so the actual Xcode 26.5 build must run in CI\n\n## Notes\nHarness tests are allowed to remain red per repo-owner guidance; release build workflow syntax is the relevant check for this PR.