### PR TITLE
chore: Upgrade Node.js harness runtime to 24

### DIFF
--- a/.github/workflows/harness-android-emulator.yml
+++ b/.github/workflows/harness-android-emulator.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary
- updates the two harness `actions/setup-node` pins from Node.js 20 to 24
- keeps the package `engines.node` floor at `>=20` because the package/runtime contract does not need to become stricter for this workflow-only change

## Source
- Node.js release schedule marks 24.x as Active LTS and 20.x as end-of-life: https://github.com/nodejs/Release/blob/main/README.md
- GitHub macOS 26 runner image also ships Node.js 24.x: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md

## Validation
- `source ~/.nvm/nvm.sh && nvm use 24.16.0 && node --version && npm --version && bun install --frozen-lockfile`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/harness-android-emulator.yml .github/workflows/harness-aws-device.yml`\n- `git diff --check`\n\n## Notes\nHarness tests are allowed to remain red per repo-owner guidance; this PR only updates the runtime used before those harness steps run.