### PR TITLE
chore: Upgrade GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/harness-android-emulator.yml
+++ b/.github/workflows/harness-android-emulator.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -93,7 +93,7 @@ jobs:
 
       - id: filter
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             android:
@@ -147,7 +147,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -196,7 +196,7 @@ jobs:
         run: test -f ${{ env.HARNESS_ANDROID_APP_BUILD_OUTPUT }}
 
       - name: Upload Android app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.HARNESS_ANDROID_APK_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_ANDROID_APP_BUILD_OUTPUT }}
@@ -217,7 +217,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download Android app artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.HARNESS_ANDROID_APK_ARTIFACT_NAME }}
           path: apps/simple-camera/android/app/build/outputs/apk/debug
@@ -284,7 +284,7 @@ jobs:
 
       - name: Schedule Device Farm Android Automated Test
         id: run-test
-        uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
+        uses: aws-actions/aws-devicefarm-mobile-device-testing@v3
         continue-on-error: true
         with:
           run-settings-json: |
@@ -327,7 +327,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           max-size: 1.5G
           key: ${{ runner.os }}-${{ runner.arch }}-xcode${{ env.HARNESS_XCODE_VERSION }}-ccache-harness-ios
@@ -453,7 +453,7 @@ jobs:
         run: test -f ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
 
       - name: Upload iOS app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.HARNESS_IOS_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
@@ -461,7 +461,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Harness XCTest UI runner IPA
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}
@@ -482,13 +482,13 @@ jobs:
           fetch-depth: 1
 
       - name: Download iOS app artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.HARNESS_IOS_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm
 
       - name: Download Harness XCTest UI runner IPA artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm
@@ -572,7 +572,7 @@ jobs:
 
       - name: Schedule Device Farm iOS Automated Test
         id: run-test
-        uses: aws-actions/aws-devicefarm-mobile-device-testing@v2.3
+        uses: aws-actions/aws-devicefarm-mobile-device-testing@v3
         continue-on-error: true
         with:
           run-settings-json: |


### PR DESCRIPTION
## Summary
- upgrades harness `actions/setup-node` from v4 to v6
- upgrades `dorny/paths-filter` from v3 to v4
- upgrades artifact upload/download actions from v4 to v7/v8
- upgrades AWS Device Farm action from v2.3 to v3
- pins `hendrikmuhs/ccache-action` to latest v1.2.23

## Changelog notes
- `setup-node@v6` changes automatic caching behavior; these workflows do not use setup-node caching.
- `paths-filter@v4` and AWS Device Farm `@v3` move their action runtime to Node 24, which GitHub-hosted runners support.
- `upload-artifact@v7` keeps the current basic `name`/`path` flow and adds optional direct uploads; no workflow changes needed here.
- `download-artifact@v8` errors on artifact digest mismatches by default; this is a stricter integrity check and should be kept.
- `ccache-action@v1.2.23` updates bundled ccache to 4.13.3.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/harness-android-emulator.yml .github/workflows/harness-aws-device.yml`\n- `git diff --check`\n\n## Notes\nHarness tests are allowed to remain red per repo-owner guidance; this PR is limited to workflow dependency versions.