### PR TITLE
fix: Resolve iOS Metro bundle URL

### DIFF
--- a/apps/simple-camera/ios/Podfile.lock
+++ b/apps/simple-camera/ios/Podfile.lock
@@ -2771,7 +2771,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: b1b6e4d2fa9fd45a48500e7212eea403c30ee5c8
+  React-Core-prebuilt: 0e292a9b21c7ff7a2d50d7db3141213b15222a2a
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189

--- a/apps/simple-camera/ios/SimpleCamera/AppDelegate.swift
+++ b/apps/simple-camera/ios/SimpleCamera/AppDelegate.swift
@@ -18,6 +18,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return args[index + 1]
   }
 
+  private func metroPortFromInfoPlist() -> String {
+    guard let port = Bundle.main.object(forInfoDictionaryKey: "RCTMetroPort") as? String,
+          !port.isEmpty,
+          !port.contains("$(") else {
+      return "8081"
+    }
+    return port
+  }
+
   private func configureMetroFromLaunchContext() {
     let defaults = UserDefaults.standard
     let launchArgJsLocation = valueForLaunchArgument("-RCT_jsLocation")
@@ -29,9 +38,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // apps/simple-camera/rn-harness.config.mjs.
     // Release builds still use the prebundled JS bundle in bundleURL(), so these
     // values do not affect release app startup.
+#if DEBUG && targetEnvironment(simulator)
+    defaults.set(launchArgJsLocation ?? "localhost:\(metroPortFromInfoPlist())", forKey: "RCT_jsLocation")
+#else
     if let jsLocation = launchArgJsLocation {
       defaults.set(jsLocation, forKey: "RCT_jsLocation")
     }
+#endif
 
     if let packagerScheme = launchArgPackagerScheme {
       defaults.set(packagerScheme, forKey: "RCT_packager_scheme")

--- a/apps/simple-camera/ios/SimpleCamera/Info.plist
+++ b/apps/simple-camera/ios/SimpleCamera/Info.plist
@@ -41,6 +41,8 @@
 	<string>VisionCamera needs access to your Location to add GPS tags to captured photos.</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
+	<key>RCTMetroPort</key>
+	<string>$(RCT_METRO_PORT)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Ionicons.ttf</string>


### PR DESCRIPTION
## Summary
- persist the Metro port from the iOS build into Info.plist
- default simulator Debug launches to localhost:<RCTMetroPort> so react-native run-ios --port uses the correct Metro server with RNCore prebuilt
- refresh the React-Core-prebuilt CocoaPods checksum generated by pod install

## Verification
- bun example pods
- bun example ios -- --udid 109A1C99-34FC-4CB6-8562-934E6AEA05DC --port 8082
- adb reverse tcp:8082 tcp:8082 && bun example android -- --port 8082
- bun lint-swift