### PR TITLE
fix: Sync iOS Podfile lockfile

### DIFF
--- a/apps/simple-camera/ios/Podfile.lock
+++ b/apps/simple-camera/ios/Podfile.lock
@@ -2771,7 +2771,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: b1b6e4d2fa9fd45a48500e7212eea403c30ee5c8
+  React-Core-prebuilt: 0e292a9b21c7ff7a2d50d7db3141213b15222a2a
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189


### PR DESCRIPTION
## Summary
- sync the generated `React-Core-prebuilt` checksum in the iOS example `Podfile.lock`
- remove the need for local `pod install` to dirty the checkout before building

## Why
After the React Native upgrade, a fresh `bun example pods` produces a different `React-Core-prebuilt` checksum than the one committed on `main`. With the committed lockfile, `bun example ios` can fail before launch with CocoaPods' "sandbox is not in sync with the Podfile.lock" error.

## Validation
- `bun install --frozen-lockfile`
- cleared Metro temp cache and started `bun example start -- --port 8081 --reset-cache`
- `bun example pods`
- `bun example ios -- --udid 109A1C99-34FC-4CB6-8562-934E6AEA05DC --port 8081`
- `bun example android -- --port 8081`
- confirmed Metro/logcat logged `Running "SimpleCamera"` for both iOS and Android
