### PR TITLE
fix: Check white balance mode support before metering

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -235,8 +235,10 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
     if captureDevice.isFocusPointOfInterestSupported {
       modes.append(.af)
     }
-    // White Balance adjusting is always supported, but it's not to a specific point
-    modes.append(.awb)
+    // White Balance adjusting is not point-based, but it still requires a supported auto mode.
+    if captureDevice.isWhiteBalanceModeSupported(.autoWhiteBalance) || captureDevice.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) {
+      modes.append(.awb)
+    }
     return modes
   }
 


### PR DESCRIPTION
## What

Only include AWB in the default iOS metering modes when the capture device supports one of the white-balance modes that `MeteringTask` can actually use.

## Why

`getAllSupportedMeteringModes()` previously always added AWB even though `MeteringTask.getWhiteBalanceMode(...)` can throw if neither `.autoWhiteBalance` nor `.continuousAutoWhiteBalance` is supported. This keeps the default mode list aligned with the actual native capability check.

## Validation

- `git diff --check`
