### PR TITLE
fix: Serialize metering KVO updates on queue

### DIFF
--- a/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
+++ b/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
@@ -241,6 +241,15 @@ final class MeteringTask {
       hasEverAdjusted: hasEverAdjusted,
       settledAt: settledAt)
   }
+  private func onMeteringChanged(for mode: MeteringMode, isAdjusting: Bool) {
+    guard !isFinished else { return }
+    if isAdjusting {
+      self.onMeteringAdjusting(for: mode)
+    } else {
+      self.onMeteringSettled(for: mode)
+    }
+    self.update()
+  }
 
   /**
    * Starts metering exposure (AE) to the given `CGPoint`.
@@ -261,13 +270,10 @@ final class MeteringTask {
         \.isAdjustingExposure,
         options: [.new]
       ) { [weak self] _, _ in
-        guard let self else { return }
-        if device.isAdjustingExposure {
-          self.onMeteringAdjusting(for: .ae)
-        } else {
-          self.onMeteringSettled(for: .ae)
+        self?.queue.async { [weak self] in
+          guard let self else { return }
+          self.onMeteringChanged(for: .ae, isAdjusting: self.device.isAdjustingExposure)
         }
-        self.update()
       })
   }
 
@@ -290,13 +296,10 @@ final class MeteringTask {
         \.isAdjustingFocus,
         options: [.new]
       ) { [weak self] _, _ in
-        guard let self else { return }
-        if device.isAdjustingFocus {
-          self.onMeteringAdjusting(for: .af)
-        } else {
-          self.onMeteringSettled(for: .af)
+        self?.queue.async { [weak self] in
+          guard let self else { return }
+          self.onMeteringChanged(for: .af, isAdjusting: self.device.isAdjustingFocus)
         }
-        self.update()
       })
   }
 
@@ -315,13 +318,10 @@ final class MeteringTask {
         \.isAdjustingWhiteBalance,
         options: [.new]
       ) { [weak self] _, _ in
-        guard let self else { return }
-        if device.isAdjustingWhiteBalance {
-          self.onMeteringAdjusting(for: .awb)
-        } else {
-          self.onMeteringSettled(for: .awb)
+        self?.queue.async { [weak self] in
+          guard let self else { return }
+          self.onMeteringChanged(for: .awb, isAdjusting: self.device.isAdjustingWhiteBalance)
         }
-        self.update()
       })
   }
 

--- a/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
+++ b/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
@@ -270,8 +270,8 @@ final class MeteringTask {
         \.isAdjustingExposure,
         options: [.new]
       ) { [weak self] _, _ in
-        self?.queue.async { [weak self] in
-          guard let self else { return }
+        guard let self else { return }
+        self.queue.async {
           self.onMeteringChanged(for: .ae, isAdjusting: self.device.isAdjustingExposure)
         }
       })
@@ -296,8 +296,8 @@ final class MeteringTask {
         \.isAdjustingFocus,
         options: [.new]
       ) { [weak self] _, _ in
-        self?.queue.async { [weak self] in
-          guard let self else { return }
+        guard let self else { return }
+        self.queue.async {
           self.onMeteringChanged(for: .af, isAdjusting: self.device.isAdjustingFocus)
         }
       })
@@ -318,8 +318,8 @@ final class MeteringTask {
         \.isAdjustingWhiteBalance,
         options: [.new]
       ) { [weak self] _, _ in
-        self?.queue.async { [weak self] in
-          guard let self else { return }
+        guard let self else { return }
+        self.queue.async {
           self.onMeteringChanged(for: .awb, isAdjusting: self.device.isAdjustingWhiteBalance)
         }
       })


### PR DESCRIPTION
## What

Dispatch MeteringTask KVO callbacks back onto the camera queue before mutating task state or calling `update()`.

## Why

The poll and timeout timers already run on the camera queue, but KVO callbacks can arrive independently. Routing all AE/AF/AWB state mutations through the same queue keeps `meteringStates` and completion checks serialized.

## Validation

- `git diff --check`
