### PR TITLE
chore: Remove unused metering progress flag

### DIFF
--- a/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
+++ b/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
@@ -42,7 +42,6 @@ final class MeteringTask {
   private var onError: ((Error) -> Void)? = nil
 
   private struct MeteringProgress {
-    var hasEverAdjusted: Bool
     var settledAt: Date? = nil
   }
   private enum MeteringError: Error, CustomStringConvertible {
@@ -229,17 +228,14 @@ final class MeteringTask {
   }
 
   private func onMeteringRequested(for mode: MeteringMode) {
-    self.meteringStates[mode] = MeteringProgress(hasEverAdjusted: false)
+    self.meteringStates[mode] = MeteringProgress()
   }
   private func onMeteringAdjusting(for mode: MeteringMode) {
-    self.meteringStates[mode] = MeteringProgress(hasEverAdjusted: true)
+    self.meteringStates[mode] = MeteringProgress()
   }
   private func onMeteringSettled(for mode: MeteringMode) {
-    let hasEverAdjusted = self.meteringStates[mode]?.hasEverAdjusted ?? false
     let settledAt = self.meteringStates[mode]?.settledAt ?? .now
-    self.meteringStates[mode] = MeteringProgress(
-      hasEverAdjusted: hasEverAdjusted,
-      settledAt: settledAt)
+    self.meteringStates[mode] = MeteringProgress(settledAt: settledAt)
   }
 
   /**


### PR DESCRIPTION
## What

Remove the unused `hasEverAdjusted` field from `MeteringTask.MeteringProgress`.

## Why

The value was written on requested/adjusting/settled transitions, but completion logic only depends on `settledAt`. This keeps the state model smaller without changing behavior.

## Validation

- `git diff --check`
