### PR TITLE
fix: Seed metering state from current device state

### DIFF
--- a/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
+++ b/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
@@ -241,6 +241,15 @@ final class MeteringTask {
       hasEverAdjusted: hasEverAdjusted,
       settledAt: settledAt)
   }
+  private func seedMeteringState(for mode: MeteringMode, isAdjusting: Bool) {
+    guard !isFinished else { return }
+    if isAdjusting {
+      self.onMeteringAdjusting(for: mode)
+    } else {
+      self.onMeteringSettled(for: mode)
+    }
+    self.update()
+  }
 
   /**
    * Starts metering exposure (AE) to the given `CGPoint`.
@@ -269,6 +278,7 @@ final class MeteringTask {
         }
         self.update()
       })
+    self.seedMeteringState(for: .ae, isAdjusting: device.isAdjustingExposure)
   }
 
   /**
@@ -298,6 +308,7 @@ final class MeteringTask {
         }
         self.update()
       })
+    self.seedMeteringState(for: .af, isAdjusting: device.isAdjustingFocus)
   }
 
   /**
@@ -323,6 +334,7 @@ final class MeteringTask {
         }
         self.update()
       })
+    self.seedMeteringState(for: .awb, isAdjusting: device.isAdjustingWhiteBalance)
   }
 
   private func getExposureMode(responsiveness: FocusResponsiveness) throws


### PR DESCRIPTION
## What

Seed each iOS MeteringTask state from the current `AVCaptureDevice.isAdjusting...` value immediately after installing the KVO observer.

## Why

KVO is still used for transitions, but if AVFoundation decides no adjustment is needed and the `isAdjusting...` value remains `false`, there may be no transition to observe. Seeding the current value lets that no-op case enter the normal 120ms settled window instead of waiting until the hard timeout.

This PR is intentionally isolated from the observer-order, timeout, KVO queue, and cleanup PRs so CI behavior can be compared independently.

## Validation

- `git diff --check`
