### PR TITLE
fix: Validate AF and AE metering modes

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -229,10 +229,10 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
    */
   private func getAllSupportedMeteringModes() -> [MeteringMode] {
     var modes: [MeteringMode] = []
-    if captureDevice.isExposurePointOfInterestSupported {
+    if isExposureMeteringSupported {
       modes.append(.ae)
     }
-    if captureDevice.isFocusPointOfInterestSupported {
+    if isFocusMeteringSupported {
       modes.append(.af)
     }
     // White Balance adjusting is not point-based, but it still requires a supported auto mode.
@@ -254,20 +254,50 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
       if device.isFocusPointOfInterestSupported {
         device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
       }
-      if device.isFocusModeSupported(.continuousAutoFocus) {
-        device.focusMode = .continuousAutoFocus
+      if let mode = getResetFocusMode(for: device) {
+        device.focusMode = mode
       }
       // reset AE to center + continuous tracking
       if device.isExposurePointOfInterestSupported {
         device.exposurePointOfInterest = CGPoint(x: 0.5, y: 0.5)
       }
-      if device.isExposureModeSupported(.continuousAutoExposure) {
-        device.exposureMode = .continuousAutoExposure
+      if let mode = getResetExposureMode(for: device) {
+        device.exposureMode = mode
       }
       // reset AWB to continuous tracking
       if device.isWhiteBalanceModeSupported(.continuousAutoWhiteBalance) {
         device.whiteBalanceMode = .continuousAutoWhiteBalance
       }
+    }
+  }
+
+  private var isExposureMeteringSupported: Bool {
+    return captureDevice.isExposurePointOfInterestSupported
+      && (captureDevice.isExposureModeSupported(.autoExpose) || captureDevice.isExposureModeSupported(.continuousAutoExposure))
+  }
+
+  private var isFocusMeteringSupported: Bool {
+    return captureDevice.isFocusPointOfInterestSupported
+      && (captureDevice.isFocusModeSupported(.autoFocus) || captureDevice.isFocusModeSupported(.continuousAutoFocus))
+  }
+
+  private func getResetFocusMode(for device: AVCaptureDevice) -> AVCaptureDevice.FocusMode? {
+    if device.isFocusModeSupported(.continuousAutoFocus) {
+      return .continuousAutoFocus
+    } else if device.isFocusModeSupported(.autoFocus) {
+      return .autoFocus
+    } else {
+      return nil
+    }
+  }
+
+  private func getResetExposureMode(for device: AVCaptureDevice) -> AVCaptureDevice.ExposureMode? {
+    if device.isExposureModeSupported(.continuousAutoExposure) {
+      return .continuousAutoExposure
+    } else if device.isExposureModeSupported(.autoExpose) {
+      return .autoExpose
+    } else {
+      return nil
     }
   }
 
@@ -363,6 +393,10 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
   func setFocusLocked(lensPosition: Double) -> Promise<Void> {
     return captureDevice.withLock(queue) { completion in
       // 1. Ensure values are within valid range
+      guard self.captureDevice.isLockingFocusWithCustomLensPositionSupported else {
+        throw RuntimeError.error(
+          withMessage: "Cannot lock focus - this CameraDevice does not support locking focus to a custom lens position! (See `device.supportsFocusLocking`)")
+      }
       guard lensPosition >= 0 && lensPosition <= 1 else {
         throw RuntimeError.error(
           withMessage: "`lensPosition` is not within 0.0 to 1.0 range! (Received: \(lensPosition))")
@@ -378,6 +412,10 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
 
   func lockCurrentFocus() -> Promise<Void> {
     return captureDevice.withLock(queue) { completion in
+      guard self.captureDevice.isLockingFocusWithCustomLensPositionSupported else {
+        throw RuntimeError.error(
+          withMessage: "Cannot lock focus - this CameraDevice does not support locking focus to a custom lens position! (See `device.supportsFocusLocking`)")
+      }
       self.captureDevice.setFocusModeLocked(lensPosition: AVCaptureDevice.currentLensPosition) {
         _ in
         completion()
@@ -405,6 +443,10 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
     return captureDevice.withLock(queue) { completion in
       let device = self.captureDevice
       // 1. Ensure values are within valid range
+      guard device.isExposureModeSupported(.custom) else {
+        throw RuntimeError.error(
+          withMessage: "Cannot lock exposure - this CameraDevice does not support custom exposure duration/ISO! (See `device.supportsExposureLocking`)")
+      }
       guard
         duration >= device.activeFormat.minExposureDuration.seconds
           && duration <= device.activeFormat.maxExposureDuration.seconds
@@ -433,6 +475,10 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
 
   func lockCurrentExposure() -> Promise<Void> {
     return captureDevice.withLock(queue) { completion in
+      guard self.captureDevice.isExposureModeSupported(.custom) else {
+        throw RuntimeError.error(
+          withMessage: "Cannot lock exposure - this CameraDevice does not support custom exposure duration/ISO! (See `device.supportsExposureLocking`)")
+      }
       self.captureDevice.setExposureModeCustom(
         duration: AVCaptureDevice.currentExposureDuration,
         iso: AVCaptureDevice.currentISO

--- a/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
+++ b/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
@@ -179,36 +179,39 @@ final class MeteringTask {
 
   private func setMeteringValuesToLocked() throws {
     logger.info("Locking AE/AF/AWB values...")
+    let exposureMode: AVCaptureDevice.ExposureMode? = device.isExposureModeSupported(.locked) ? .locked : nil
+    let focusMode: AVCaptureDevice.FocusMode? = device.isFocusModeSupported(.locked) ? .locked : nil
+    let whiteBalanceMode: AVCaptureDevice.WhiteBalanceMode? = device.isWhiteBalanceModeSupported(.locked) ? .locked : nil
     try setMeteringValues(
       focusPoint: nil,
-      exposure: .locked,
-      focus: .locked,
-      whiteBalance: .locked)
+      exposure: exposureMode,
+      focus: focusMode,
+      whiteBalance: whiteBalanceMode)
   }
 
   private func setMeteringValuesToContinuous() throws {
     logger.info("Setting AE/AF/AWB values to continuously auto-focus...")
     try setMeteringValues(
       focusPoint: nil,
-      exposure: .continuousAutoExposure,
-      focus: .continuousAutoFocus,
-      whiteBalance: .continuousAutoWhiteBalance)
+      exposure: getExposureModeIfSupported(responsiveness: .steady),
+      focus: getFocusModeIfSupported(responsiveness: .steady),
+      whiteBalance: getWhiteBalanceModeIfSupported(responsiveness: .steady))
   }
 
   private func resetMeteringValues() throws {
     logger.info("Resetting AE/AF/AWB values to continuously auto-focus at center...")
     try setMeteringValues(
       focusPoint: CGPoint(x: 0.5, y: 0.5),
-      exposure: .continuousAutoExposure,
-      focus: .continuousAutoFocus,
-      whiteBalance: .continuousAutoWhiteBalance)
+      exposure: getExposureModeIfSupported(responsiveness: .steady),
+      focus: getFocusModeIfSupported(responsiveness: .steady),
+      whiteBalance: getWhiteBalanceModeIfSupported(responsiveness: .steady))
   }
 
   private func setMeteringValues(
     focusPoint: CGPoint?,
-    exposure: AVCaptureDevice.ExposureMode,
-    focus: AVCaptureDevice.FocusMode,
-    whiteBalance: AVCaptureDevice.WhiteBalanceMode
+    exposure: AVCaptureDevice.ExposureMode?,
+    focus: AVCaptureDevice.FocusMode?,
+    whiteBalance: AVCaptureDevice.WhiteBalanceMode?
   ) throws {
     try self.device.lockForConfiguration()
     defer { self.device.unlockForConfiguration() }
@@ -218,7 +221,7 @@ final class MeteringTask {
         self.device.exposurePointOfInterest = focusPoint
         logger.debug("AE point = \(focusPoint.debugDescription)")
       }
-      if self.device.isExposureModeSupported(exposure) {
+      if let exposure, self.device.isExposureModeSupported(exposure) {
         self.device.exposureMode = exposure
         logger.debug("AE = \(exposure.rawValue)")
       }
@@ -229,14 +232,14 @@ final class MeteringTask {
         self.device.focusPointOfInterest = focusPoint
         logger.debug("AF point = \(focusPoint.debugDescription)")
       }
-      if self.device.isFocusModeSupported(focus) {
+      if let focus, self.device.isFocusModeSupported(focus) {
         self.device.focusMode = focus
         logger.debug("AF = \(focus.rawValue)")
       }
     }
     // Lock AWB
     if meteringStates.keys.contains(.awb) {
-      if self.device.isWhiteBalanceModeSupported(whiteBalance) {
+      if let whiteBalance, self.device.isWhiteBalanceModeSupported(whiteBalance) {
         self.device.whiteBalanceMode = whiteBalance
         logger.debug("AWB = \(whiteBalance.rawValue)")
       }
@@ -340,6 +343,15 @@ final class MeteringTask {
   private func getExposureMode(responsiveness: FocusResponsiveness) throws
     -> AVCaptureDevice.ExposureMode
   {
+    guard let mode = getExposureModeIfSupported(responsiveness: responsiveness) else {
+      throw RuntimeError.error(withMessage: "Metering Mode `AE` is not supported on this device!")
+    }
+    return mode
+  }
+
+  private func getExposureModeIfSupported(responsiveness: FocusResponsiveness)
+    -> AVCaptureDevice.ExposureMode?
+  {
     if responsiveness == .snappy {
       if device.isExposureModeSupported(.autoExpose) {
         // Use snappy AE if supported
@@ -357,10 +369,17 @@ final class MeteringTask {
         return .autoExpose
       }
     }
-    throw RuntimeError.error(withMessage: "Metering Mode `AF` is not supported on this device!")
+    return nil
   }
 
   private func getFocusMode(responsiveness: FocusResponsiveness) throws -> AVCaptureDevice.FocusMode {
+    guard let mode = getFocusModeIfSupported(responsiveness: responsiveness) else {
+      throw RuntimeError.error(withMessage: "Metering Mode `AF` is not supported on this device!")
+    }
+    return mode
+  }
+
+  private func getFocusModeIfSupported(responsiveness: FocusResponsiveness) -> AVCaptureDevice.FocusMode? {
     if responsiveness == .snappy {
       if device.isFocusModeSupported(.autoFocus) {
         // Use snappy AF if supported
@@ -378,11 +397,20 @@ final class MeteringTask {
         return .autoFocus
       }
     }
-    throw RuntimeError.error(withMessage: "Metering Mode `AF` is not supported on this device!")
+    return nil
   }
 
   private func getWhiteBalanceMode(responsiveness: FocusResponsiveness) throws
     -> AVCaptureDevice.WhiteBalanceMode
+  {
+    guard let mode = getWhiteBalanceModeIfSupported(responsiveness: responsiveness) else {
+      throw RuntimeError.error(withMessage: "Metering Mode `AWB` is not supported on this device!")
+    }
+    return mode
+  }
+
+  private func getWhiteBalanceModeIfSupported(responsiveness: FocusResponsiveness)
+    -> AVCaptureDevice.WhiteBalanceMode?
   {
     if responsiveness == .snappy {
       if device.isWhiteBalanceModeSupported(.autoWhiteBalance) {
@@ -401,6 +429,6 @@ final class MeteringTask {
         return .autoWhiteBalance
       }
     }
-    throw RuntimeError.error(withMessage: "Metering Mode `AWB` is not supported on this device!")
+    return nil
   }
 }


### PR DESCRIPTION
## What changed

This follows up the AWB support check by validating the AF and AE paths before using AVFoundation modes:

- only include AE in default metering modes when exposure point-of-interest and an auto exposure mode are supported
- only include AF in default metering modes when focus point-of-interest and an auto focus mode are supported
- reset focus/exposure with continuous-auto when available, otherwise fall back to one-shot auto
- guard custom focus/exposure locking APIs before calling AVFoundation locking methods
- keep MeteringTask post-metering locked/continuous/reset transitions on supported modes only

## Why

The supported-device flags already model these capabilities, but some iOS controller paths still assumed specific AF/AE modes were available. This keeps the default and reset/lock paths consistent with the device's advertised AVFoundation support.

## Validation

- `git diff --check`
- `xcrun swiftc -parse packages/react-native-vision-camera/ios/Hybrid\ Objects/HybridCameraController.swift packages/react-native-vision-camera/ios/Utils/MeteringTask.swift`

Attempted local iOS build:

- `xcodebuild -workspace apps/simple-camera/ios/SimpleCamera.xcworkspace -scheme VisionCamera -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`
- blocked before VisionCamera Swift compilation by React Native script failure: `replace_hermes_version.js` throws `TypeError: yargs.option is not a function` in the Hermes replacement phase.