### PR TITLE
chore: Tighten Harness CI timeouts

### DIFF
--- a/apps/simple-camera/rn-harness.config.mjs
+++ b/apps/simple-camera/rn-harness.config.mjs
@@ -70,9 +70,10 @@ const iosAppLaunchOptions = iosMetroHostPort
   : undefined
 
 const isCI = process.env.CI === 'true'
-const bundleStartTimeout = isCI ? 90_000 : 15_000
-const bridgeTimeout = isCI ? 120_000 : 45_000
-const maxAppRestarts = isCI ? 4 : 2
+const bundleStartTimeout = isCI ? 30_000 : 15_000
+const bridgeTimeout = 45_000
+const platformReadyTimeout = 60_000
+const maxAppRestarts = isCI ? 1 : 2
 
 const useEmulator = androidDeviceMode === 'emulator'
 
@@ -113,6 +114,7 @@ const config = {
   defaultRunner: 'android',
   bridgeTimeout,
   bundleStartTimeout,
+  platformReadyTimeout,
   maxAppRestarts,
   detectNativeCrashes: true,
   resetEnvironmentBetweenTestFiles: true,


### PR DESCRIPTION
## What changed

Tightens the official React Native Harness timeout settings used by the simple-camera CI runs:

- `bridgeTimeout`: 120s -> 45s
- `bundleStartTimeout`: 90s -> 30s in CI
- `platformReadyTimeout`: explicit 60s instead of Harness default 300s
- `maxAppRestarts`: 4 -> 1 in CI, local stays at 2

This intentionally does not add any shell-level watchdogs or custom Device Farm timeout wrappers. The PR only uses Harness config APIs and builds on the 1.4.0 RC/native crash reporting branch.

## Why

Recent Device Farm runs show the expensive failures are mostly dead Harness waits:

- latest #3969 iOS (`79059231605`): controller file hit `The device did not respond within the timeout period`, Jest time 327s
- latest main iOS (`79058555838`): same controller timeout, Jest time 350s
- latest main Android (`79058742447`): same controller timeout, Jest time 293s
- latest #3969 Android (`79059266409`): controller passed, Jest time 174s

When controller actually runs, the individual tests are seconds-long. The long failures are timeout waits, so reducing `bridgeTimeout` from 120s to 45s should save about 75s per unresponsive test file without cutting into the observed successful controller/photo/video execution times.

## Validation

- `git diff --check`
- `CI=true bun -e "import config from './apps/simple-camera/rn-harness.config.mjs'; if (config.bridgeTimeout !== 45000 || config.bundleStartTimeout !== 30000 || config.platformReadyTimeout !== 60000 || config.maxAppRestarts !== 1 || config.detectNativeCrashes !== true) throw new Error(JSON.stringify(config)); console.log('Harness CI timeout config ok')"`
