### PR TITLE
chore: Tighten Harness CI timeouts

### DIFF
--- a/apps/simple-camera/rn-harness.config.mjs
+++ b/apps/simple-camera/rn-harness.config.mjs
@@ -70,9 +70,10 @@ const iosAppLaunchOptions = iosMetroHostPort
   : undefined
 
 const isCI = process.env.CI === 'true'
-const bundleStartTimeout = isCI ? 90_000 : 15_000
-const bridgeTimeout = isCI ? 120_000 : 45_000
-const maxAppRestarts = isCI ? 4 : 2
+const bundleStartTimeout = isCI ? 30_000 : 15_000
+const bridgeTimeout = 45_000
+const platformReadyTimeout = 60_000
+const maxAppRestarts = isCI ? 1 : 2
 
 const useEmulator = androidDeviceMode === 'emulator'
 
@@ -113,6 +114,7 @@ const config = {
   defaultRunner: 'android',
   bridgeTimeout,
   bundleStartTimeout,
+  platformReadyTimeout,
   maxAppRestarts,
   detectNativeCrashes: true,
   resetEnvironmentBetweenTestFiles: true,


### PR DESCRIPTION
## What changed

Cherry-picks the Harness timeout config from #3981 onto `main`.

- `bridgeTimeout`: 120s -> 45s
- `bundleStartTimeout`: 90s -> 30s in CI
- `platformReadyTimeout`: explicit 60s instead of Harness default 300s
- `maxAppRestarts`: 4 -> 1 in CI, local stays at 2

This only uses official Harness config APIs. No shell-level timeout/watchdog logic.

## Why

#3981 was accidentally merged into `chore/harness-crash-reporting-draft`, not `main`. Current `main` still has the old 120s bridge timeout and 90s bundle timeout, so the in-progress `main` Harness run is not testing the shorter timeout config.

The log-based validation from recent Harness runs still applies: when controller actually runs, the work is seconds-long; the costly failures are dead Harness waits where `runTests(controllerFile)` never returns. Lowering `bridgeTimeout` should reduce that waste without cutting into observed successful test-file execution.

## Validation

- `git diff --check HEAD~1..HEAD`
- `CI=true bun -e "import config from './apps/simple-camera/rn-harness.config.mjs'; if (config.bridgeTimeout !== 45000 || config.bundleStartTimeout !== 30000 || config.platformReadyTimeout !== 60000 || config.maxAppRestarts !== 1 || config.detectNativeCrashes !== true) throw new Error(JSON.stringify(config)); console.log('Harness CI timeout config ok')"`
