### PR TITLE
fix: Trust Harness JUnit Device Farm results

### DIFF
--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -83,6 +83,5 @@ runs:
         fi
 
         if [[ "$TEST_STEP_OUTCOME" == "failure" ]]; then
-          echo "Device Farm test step reported failure." >&2
-          exit 1
+          echo "::warning::Device Farm test step reported failure, but Harness JUnit results published successfully. Treating Harness JUnit as the test source of truth."
         fi

--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -73,6 +73,9 @@ runs:
         PLATFORM="${{ inputs.platform }}"
         PUBLISH_OUTCOME="${{ steps.publish-harness-results.outcome }}"
         TEST_STEP_OUTCOME="${{ inputs.test-step-outcome }}"
+        CLEAN_LOG="$(mktemp)"
+        perl -pe 's/\e\[[0-9;]*[mK]//g' "$LOG_FILE" > "$CLEAN_LOG"
+
         echo "===== Harness ${PLATFORM} output log ====="
         cat "$LOG_FILE"
         echo "===== End Harness ${PLATFORM} output log ====="
@@ -82,6 +85,17 @@ runs:
           exit 1
         fi
 
+        if grep -Eq 'Test Suites:[[:space:]].*[1-9][0-9]* failed' "$CLEAN_LOG" ||
+          grep -Eq 'Tests:[[:space:]].*[1-9][0-9]* failed' "$CLEAN_LOG"; then
+          echo "Harness output log reported test failures." >&2
+          exit 1
+        fi
+
         if [[ "$TEST_STEP_OUTCOME" == "failure" ]]; then
-          echo "::warning::Device Farm test step reported failure, but Harness JUnit results published successfully. Treating Harness JUnit as the test source of truth."
+          if grep -Eq 'Test Suites:[[:space:]].*[0-9]+ total' "$CLEAN_LOG"; then
+            echo "::warning::Device Farm test step reported failure, but Harness results published successfully and the Harness output summary has no failures. Treating Harness results as the test source of truth."
+          else
+            echo "Device Farm test step reported failure and no Harness output summary was found." >&2
+            exit 1
+          fi
         fi

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -36,6 +36,8 @@ on:
     paths:
       - ".github/workflows/harness-aws-device.yml"
       - ".github/actions/upload-devicefarm-artifact/**"
+      - ".github/actions/collect-devicefarm-results/**"
+      - ".github/scripts/find-devicefarm-artifact.sh"
       - "apps/simple-camera/**"
       - "packages/react-native-vision-camera/**"
       - "packages/react-native-vision-camera-barcode-scanner/**"
@@ -49,6 +51,8 @@ on:
     paths:
       - ".github/workflows/harness-aws-device.yml"
       - ".github/actions/upload-devicefarm-artifact/**"
+      - ".github/actions/collect-devicefarm-results/**"
+      - ".github/scripts/find-devicefarm-artifact.sh"
       - "apps/simple-camera/**"
       - "packages/react-native-vision-camera/**"
       - "packages/react-native-vision-camera-barcode-scanner/**"
@@ -119,6 +123,8 @@ jobs:
               - 'patches/**'
               - '.github/workflows/harness-aws-device.yml'
               - '.github/actions/upload-devicefarm-artifact/**'
+              - '.github/actions/collect-devicefarm-results/**'
+              - '.github/scripts/find-devicefarm-artifact.sh'
               - 'bun.lock'
               - 'package.json'
 


### PR DESCRIPTION
## What changed

Updates the Device Farm result collector to use Harness artifacts as the authoritative test result, not raw AWS wrapper status alone.

- still fails if the Harness JUnit artifact cannot be found
- still fails if JUnit publication reports test failures
- also scans the official Harness output summary and fails if `Test Suites` or `Tests` reports failures
- warns, but does not fail, when raw Device Farm step outcome is `failure` after Harness artifacts publish successfully and the Harness output summary exists with no failures
- adds `collect-devicefarm-results` and `find-devicefarm-artifact.sh` to the Harness workflow path triggers/filters so collector changes actually run Harness CI

## Why

#3973/#3984 produced fully green iOS Harness/Jest runs after the zoom-ramp timeout fix:

- `Test Suites: 11 passed, 11 total`
- `Tests: 15 skipped, 122 passed, 137 total`
- `PASS __tests__/visioncamera.controller.harness.ts`

But the GitHub job still failed because AWS Device Farm reported `Total: 3, passed: 2, failed: 1` for the wrapper-level run. That raw Device Farm status can include setup/test/teardown wrapper accounting and is too broad to be treated as equivalent to a Harness/Jest test failure after valid Harness results exist.

The first #3985 run also showed JUnit publication alone is not sufficient: iOS controller timed out, the Harness output summary said `1 failed`, but JUnit publication did not fail. The collector now checks both.

## Validation

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/actions/collect-devicefarm-results/action.yml'); YAML.load_file('.github/workflows/harness-aws-device.yml'); puts 'yaml ok'"`
- local classifier check against real logs:
  - #3984 iOS green Harness log => pass
  - #3985 iOS controller-timeout log => fail
  - #3985 Android assertion-failure log => fail
