### PR TITLE
docs: Fix code ellipsis ligature

### DIFF
--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -39,6 +39,14 @@ article > .prose.flex-1 > h2#properties {
   @apply border-t border-fd-border/60 pt-8 mt-6;
 }
 
+/* Keep code glyph-for-glyph; Geist Mono renders sequences like `...` as ligatures. */
+.prose code {
+  font-variant-ligatures: none;
+  font-feature-settings:
+    "liga" 0,
+    "calt" 0;
+}
+
 /* Wrap long inline code/API symbols on narrow screens without overflowing. */
 article .prose :not(pre) > code {
   white-space: normal;


### PR DESCRIPTION
## Summary

- Disable font ligatures for prose code in the docs.
- Keep `...` placeholders rendering as three literal dots instead of an ellipsis-like glyph in highlighted code blocks.

## Root Cause

Geist Mono applies ligatures for sequences like `...`, so TypeScript snippets such as `const photo = ...` were visually collapsed in the rendered docs.

## Validation

- `git diff --check`
- `PATH=/Users/mrousavy/Projects/react-native-vision-camera/node_modules/.bin:$PATH bun docs lint` (passes with existing warnings)