### PR TITLE
fix: Don't start zoom animation if we are already on that exact `zoom` value

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -330,6 +330,7 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
       var observation: NSKeyValueObservation?
       observation = self.captureDevice.observe(
         \.isRampingVideoZoom,
+        options: [.old, .new],
         changeHandler: { _, change in
           if change.oldValue == true && change.newValue == false {
             completion()

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -321,6 +321,12 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
 
   func startZoomAnimation(zoom: Double, rate: Double) -> Promise<Void> {
     return captureDevice.withLock(queue) { completion in
+      if self.captureDevice.videoZoomFactor == zoom {
+        // We are already exactly on our target value
+        completion()
+        return
+      }
+
       var observation: NSKeyValueObservation?
       observation = self.captureDevice.observe(
         \.isRampingVideoZoom,


### PR DESCRIPTION
Maybe a better fix than https://github.com/mrousavy/react-native-vision-camera/pull/3986 ?