### PR TITLE
chore: diagnose iOS Harness XCTest wrapper failure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+patches/*.patch -whitespace

--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -117,20 +117,6 @@ runs:
         fi
 
         if [[ "$TEST_STEP_OUTCOME" == "failure" ]]; then
-          if [[ "$PLATFORM" != "ios" ]]; then
-            echo "Device Farm ${PLATFORM} test step reported failure." >&2
-            exit 1
-          fi
-
-          if [[ -z "$XCODEBUILD_LOG" ]]; then
-            echo "Device Farm iOS test step reported failure and no XCTest log was found." >&2
-            exit 1
-          fi
-
-          if ! grep -Fq "** TEST EXECUTE SUCCEEDED **" "$XCODEBUILD_LOG"; then
-            echo "Device Farm iOS test step reported failure and XCTest did not report success." >&2
-            exit 1
-          fi
-
-          echo "Device Farm iOS test step reported failure, but Harness JUnit and XCTest logs passed. Treating Harness results as authoritative." >&2
+          echo "Device Farm ${PLATFORM} test step reported failure." >&2
+          exit 1
         fi

--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -51,6 +51,33 @@ runs:
           "$WORKSPACE_LOG"
         echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
 
+    - name: Find Harness xcodebuild log
+      id: find-xcodebuild-log
+      if: inputs.platform == 'ios'
+      shell: bash
+      run: |
+        set -euo pipefail
+        ARTIFACT_DIR="${{ inputs.artifact-folder }}"
+        PLATFORM="${{ inputs.platform }}"
+        WORKSPACE_LOG=".github/test-results/harness-xcodebuild-${PLATFORM}.log"
+        FOUND_FILE="$(find "$ARTIFACT_DIR" -type f -name 'xcodebuild.log' | head -n 1 || true)"
+
+        if [[ -z "$FOUND_FILE" ]]; then
+          EXTRACT_DIR="$(mktemp -d)"
+
+          while IFS= read -r ZIP_FILE; do
+            unzip -o -qq "$ZIP_FILE" -d "$EXTRACT_DIR" || true
+          done < <(find "$ARTIFACT_DIR" -type f -name '*.zip')
+
+          FOUND_FILE="$(find "$EXTRACT_DIR" -type f -name 'xcodebuild.log' | head -n 1 || true)"
+        fi
+
+        if [[ -n "$FOUND_FILE" ]]; then
+          mkdir -p "$(dirname "$WORKSPACE_LOG")"
+          cp "$FOUND_FILE" "$WORKSPACE_LOG"
+          echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Publish Harness test results
       id: publish-harness-results
       if: steps.find-harness-junit.outputs.junit_file != ''
@@ -77,12 +104,33 @@ runs:
         cat "$LOG_FILE"
         echo "===== End Harness ${PLATFORM} output log ====="
 
+        XCODEBUILD_LOG="${{ steps.find-xcodebuild-log.outputs.log_file }}"
+        if [[ -n "$XCODEBUILD_LOG" && ( "$TEST_STEP_OUTCOME" == "failure" || "$PUBLISH_OUTCOME" == "failure" ) ]]; then
+          echo "===== Harness ${PLATFORM} xcodebuild log ====="
+          cat "$XCODEBUILD_LOG"
+          echo "===== End Harness ${PLATFORM} xcodebuild log ====="
+        fi
+
         if [[ "$PUBLISH_OUTCOME" == "failure" ]]; then
           echo "Harness test result publication reported failures." >&2
           exit 1
         fi
 
         if [[ "$TEST_STEP_OUTCOME" == "failure" ]]; then
-          echo "Device Farm test step reported failure." >&2
-          exit 1
+          if [[ "$PLATFORM" != "ios" ]]; then
+            echo "Device Farm ${PLATFORM} test step reported failure." >&2
+            exit 1
+          fi
+
+          if [[ -z "$XCODEBUILD_LOG" ]]; then
+            echo "Device Farm iOS test step reported failure and no XCTest log was found." >&2
+            exit 1
+          fi
+
+          if ! grep -Fq "** TEST EXECUTE SUCCEEDED **" "$XCODEBUILD_LOG"; then
+            echo "Device Farm iOS test step reported failure and XCTest did not report success." >&2
+            exit 1
+          fi
+
+          echo "Device Farm iOS test step reported failure, but Harness JUnit and XCTest logs passed. Treating Harness results as authoritative." >&2
         fi

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -79,4 +79,5 @@ phases:
 
 artifacts:
   - $WORKING_DIRECTORY/harness-artifacts
+  - $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness/logs
   - $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness/crash-reports

--- a/bun.lock
+++ b/bun.lock
@@ -227,6 +227,7 @@
     "@shopify/react-native-skia",
   ],
   "patchedDependencies": {
+    "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     }
   },
   "patchedDependencies": {
+    "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch"
   },
   "version": "5.0.11"

--- a/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
@@ -1,0 +1,308 @@
+diff --git a/dist/xctest-agent-client.d.ts b/dist/xctest-agent-client.d.ts
+index 6f89667..1db236c 100644
+--- a/dist/xctest-agent-client.d.ts
++++ b/dist/xctest-agent-client.d.ts
+@@ -4,13 +4,14 @@ export type XCTestAgentPermissionsConfiguration = {
+ };
+ type XCTestAgentHealthResponse = {
+     permissions: XCTestAgentPermissionsConfiguration;
+-    status: 'ok';
++    status: 'ok' | 'shutting-down';
+ };
+ export type XCTestAgentClient = {
+     configurePermissions: (permissions: XCTestAgentPermissionsConfiguration) => Promise<XCTestAgentPermissionsConfiguration>;
+     dispose: () => Promise<void>;
+     getPermissionsConfig: () => Promise<XCTestAgentPermissionsConfiguration>;
+     health: () => Promise<XCTestAgentHealthResponse>;
++    shutdown: () => Promise<void>;
+ };
+ export declare const createXCTestAgentClient: (transport: XCTestAgentTransport) => XCTestAgentClient;
+ export {};
+diff --git a/dist/xctest-agent-client.js b/dist/xctest-agent-client.js
+index 4a70bba..bef9965 100644
+--- a/dist/xctest-agent-client.js
++++ b/dist/xctest-agent-client.js
+@@ -29,6 +29,12 @@ export const createXCTestAgentClient = (transport) => {
+             });
+             return response.permissions;
+         },
++        shutdown: async () => {
++            await requestJson({
++                method: 'POST',
++                path: '/shutdown',
++            });
++        },
+         dispose: async () => {
+             await transport.dispose();
+         },
+diff --git a/dist/xctest-agent.js b/dist/xctest-agent.js
+index 7ee0ac9..43d9a3a 100644
+--- a/dist/xctest-agent.js
++++ b/dist/xctest-agent.js
+@@ -16,7 +16,7 @@ const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV = 'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID
+ const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
+ const XCTEST_AGENT_DERIVED_DATA_PATH_ENV = 'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+-const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
++const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 30_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+ const HARNESS_DIRNAME = '.harness';
+ const XCTEST_AGENT_BUILD_DIRNAME = 'xctest-agent';
+@@ -438,6 +438,29 @@ const waitForShutdown = async (options) => {
+     ]);
+     return result !== timedOut;
+ };
++const waitForGracefulShutdown = async (options) => {
++    let requestError = null;
++    const timedOut = Symbol('timedOut');
++    const result = await Promise.race([
++        (async () => {
++            try {
++                await options.client.shutdown();
++            }
++            catch (error) {
++                requestError = error;
++            }
++            return await waitForShutdown({
++                processTask: options.processTask,
++                shutdownTimeoutMs: options.shutdownTimeoutMs,
++            });
++        })(),
++        delay(options.shutdownTimeoutMs).then(() => timedOut),
++    ]);
++    return {
++        didStop: result !== timedOut && result === true,
++        requestError,
++    };
++};
+ const waitForChildProcessExit = async (subprocess) => {
+     const childProcess = await subprocess.nodeChildProcess;
+     if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+@@ -670,6 +693,28 @@ export const createXCTestAgentController = (options) => {
+         agentClient = null;
+         processTask = null;
+         xctestAgentLogger.info('Stopping XCTest agent session for %s target', target.kind);
++        if (currentClient) {
++            try {
++                xctestAgentLogger.info('Requesting XCTest agent graceful shutdown for %s target', target.kind);
++                const gracefulShutdown = await waitForGracefulShutdown({
++                    client: currentClient,
++                    processTask: currentProcessTask,
++                    shutdownTimeoutMs,
++                });
++                if (gracefulShutdown.didStop) {
++                    xctestAgentLogger.info('XCTest agent session for %s target stopped gracefully', target.kind);
++                    await currentClient.dispose();
++                    return;
++                }
++                if (gracefulShutdown.requestError) {
++                    xctestAgentLogger.warn('XCTest agent graceful shutdown request failed for %s: %s', target.kind, getErrorMessage(gracefulShutdown.requestError));
++                }
++                xctestAgentLogger.warn('XCTest agent session for %s target did not stop gracefully after %dms; terminating xcodebuild', target.kind, shutdownTimeoutMs);
++            }
++            catch (error) {
++                xctestAgentLogger.warn('XCTest agent graceful shutdown failed for %s: %s', target.kind, getErrorMessage(error));
++            }
++        }
+         await currentClient?.dispose();
+         await stopProcess({
+             process: currentProcess,
+diff --git a/src/xctest-agent-client.ts b/src/xctest-agent-client.ts
+index 93f28b5..ca53d4c 100644
+--- a/src/xctest-agent-client.ts
++++ b/src/xctest-agent-client.ts
+@@ -9,7 +9,7 @@ export type XCTestAgentPermissionsConfiguration = {
+ 
+ type XCTestAgentHealthResponse = {
+   permissions: XCTestAgentPermissionsConfiguration;
+-  status: 'ok';
++  status: 'ok' | 'shutting-down';
+ };
+ 
+ type XCTestAgentPermissionsResponse = {
+@@ -23,6 +23,7 @@ export type XCTestAgentClient = {
+   dispose: () => Promise<void>;
+   getPermissionsConfig: () => Promise<XCTestAgentPermissionsConfiguration>;
+   health: () => Promise<XCTestAgentHealthResponse>;
++  shutdown: () => Promise<void>;
+ };
+ 
+ export const createXCTestAgentClient = (
+@@ -67,6 +68,12 @@ export const createXCTestAgentClient = (
+ 
+       return response.permissions;
+     },
++    shutdown: async () => {
++      await requestJson<XCTestAgentHealthResponse>({
++        method: 'POST',
++        path: '/shutdown',
++      });
++    },
+     dispose: async () => {
+       await transport.dispose();
+     },
+diff --git a/src/xctest-agent.ts b/src/xctest-agent.ts
+index 00e3034..de9c030 100644
+--- a/src/xctest-agent.ts
++++ b/src/xctest-agent.ts
+@@ -31,7 +31,7 @@ const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
+ const XCTEST_AGENT_DERIVED_DATA_PATH_ENV =
+   'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+-const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
++const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 30_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+ const HARNESS_DIRNAME = '.harness';
+ const XCTEST_AGENT_BUILD_DIRNAME = 'xctest-agent';
+@@ -776,6 +776,36 @@ const waitForShutdown = async (options: {
+   return result !== timedOut;
+ };
+ 
++const waitForGracefulShutdown = async (options: {
++  client: ReturnType<typeof createXCTestAgentClient>;
++  processTask: Promise<void> | null;
++  shutdownTimeoutMs: number;
++}): Promise<{ didStop: boolean; requestError: unknown | null }> => {
++  let requestError: unknown | null = null;
++  const timedOut = Symbol('timedOut');
++
++  const result = await Promise.race([
++    (async () => {
++      try {
++        await options.client.shutdown();
++      } catch (error) {
++        requestError = error;
++      }
++
++      return await waitForShutdown({
++        processTask: options.processTask,
++        shutdownTimeoutMs: options.shutdownTimeoutMs,
++      });
++    })(),
++    delay(options.shutdownTimeoutMs).then(() => timedOut),
++  ]);
++
++  return {
++    didStop: result !== timedOut && result === true,
++    requestError,
++  };
++};
++
+ const waitForChildProcessExit = async (subprocess: Subprocess) => {
+   const childProcess = await subprocess.nodeChildProcess;
+ 
+@@ -1113,6 +1143,50 @@ export const createXCTestAgentController = (options: {
+       target.kind
+     );
+ 
++    if (currentClient) {
++      try {
++        xctestAgentLogger.info(
++          'Requesting XCTest agent graceful shutdown for %s target',
++          target.kind
++        );
++
++        const gracefulShutdown = await waitForGracefulShutdown({
++          client: currentClient,
++          processTask: currentProcessTask,
++          shutdownTimeoutMs,
++        });
++
++        if (gracefulShutdown.didStop) {
++          xctestAgentLogger.info(
++            'XCTest agent session for %s target stopped gracefully',
++            target.kind
++          );
++          await currentClient.dispose();
++          return;
++        }
++
++        if (gracefulShutdown.requestError) {
++          xctestAgentLogger.warn(
++            'XCTest agent graceful shutdown request failed for %s: %s',
++            target.kind,
++            getErrorMessage(gracefulShutdown.requestError)
++          );
++        }
++
++        xctestAgentLogger.warn(
++          'XCTest agent session for %s target did not stop gracefully after %dms; terminating xcodebuild',
++          target.kind,
++          shutdownTimeoutMs
++        );
++      } catch (error) {
++        xctestAgentLogger.warn(
++          'XCTest agent graceful shutdown failed for %s: %s',
++          target.kind,
++          getErrorMessage(error)
++        );
++      }
++    }
++
+     await currentClient?.dispose();
+     await stopProcess({
+       process: currentProcess,
+diff --git a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
+index 31abf4b..a7ccf68 100644
+--- a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
++++ b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
+@@ -4,6 +4,7 @@ import Network
+ final class HarnessXCTestAgentState {
+   private let lock = NSLock()
+   private var _permissions: PermissionPromptConfiguration
++  private var _shouldShutdown = false
+ 
+   init(permissions: PermissionPromptConfiguration) {
+     _permissions = permissions
+@@ -20,6 +21,18 @@ final class HarnessXCTestAgentState {
+     _permissions = permissions
+     lock.unlock()
+   }
++
++  var shouldShutdown: Bool {
++    lock.lock()
++    defer { lock.unlock() }
++    return _shouldShutdown
++  }
++
++  func requestShutdown() {
++    lock.lock()
++    _shouldShutdown = true
++    lock.unlock()
++  }
+ }
+ 
+ private struct XCTestAgentHealthResponse: Codable {
+@@ -250,6 +263,15 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+       return jsonResponse(XCTestAgentPermissionsResponse(permissions: state.permissions))
+     case ("GET", "/permissions"):
+       return jsonResponse(XCTestAgentPermissionsResponse(permissions: state.permissions))
++    case ("POST", "/shutdown"):
++      log("shutdown requested")
++      state.requestShutdown()
++      return jsonResponse(
++        XCTestAgentHealthResponse(
++          permissions: state.permissions,
++          status: "shutting-down"
++        )
++      )
+     default:
+       return XCTestAgentResponse(body: Data("{\"error\":\"not found\"}".utf8), statusCode: 404)
+     }
+@@ -301,7 +323,7 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+ 
+     let sessionDeadline = Date().addingTimeInterval(Constants.defaultSessionDuration)
+ 
+-    while Date() < sessionDeadline {
++    while Date() < sessionDeadline && !state.shouldShutdown {
+       observeTargetApplication()
+ 
+       for capability in capabilities {
+@@ -313,6 +335,6 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+       )
+     }
+ 
+-    log("testAgentSession completed")
++    log("testAgentSession completed (shutdownRequested=\(state.shouldShutdown))")
+   }
+ }


### PR DESCRIPTION
## Summary

- Patch `@react-native-harness/platform-apple@1.4.0-rc.1` so the bundled XCTest agent exposes `POST /shutdown` and the controller asks it to stop gracefully before falling back to process termination.
- Export and print Harness XCTest `xcodebuild.log` from AWS Device Farm artifacts when iOS fails.
- Keep Device Farm wrapper failures red; the collect action no longer treats successful JUnit/xcodebuild output as enough to override AWS failure.

## Current evidence

On #3990 run `26879854202`, iOS Harness/Jest ran all tests successfully, including `visioncamera.controller.harness.ts`:

- `Test Suites: 11 passed, 11 total`
- `Tests: 15 skipped, 122 passed, 137 total`
- Harness logged `Requesting XCTest agent graceful shutdown` and `XCTest agent session for device target stopped gracefully`.
- The exported `xcodebuild.log` contained `** TEST EXECUTE SUCCEEDED **`.

AWS Device Farm still reported the iOS test step as failed: `Total: 3, passed: 2, failed: 1`. So this PR is not a final green-CI fix yet; it preserves the failure and gives us the logs needed to diagnose the remaining wrapper-level failure.

## Verification

- `bun install --frozen-lockfile`
- `git diff --check`
- CI evidence from run `26879854202` showed the graceful shutdown log lines and exported xcodebuild success, while AWS still reported a Device Farm wrapper failure.

Local `xcodebuild` verification is blocked on this machine by an Xcode/CoreSimulator mismatch before compilation: `CoreSimulator is out of date` / missing local iOS 26.5 device support.
