### PR TITLE
chore: report active Harness context on timeout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -whitespace

--- a/bun.lock
+++ b/bun.lock
@@ -228,6 +228,7 @@
   ],
   "patchedDependencies": {
     "react-native@0.85.3": "patches/react-native@0.85.3.patch",
+    "@react-native-harness/jest@1.4.0-rc.1": "patches/@react-native-harness%2Fjest@1.4.0-rc.1.patch",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
     }
   },
   "patchedDependencies": {
-    "react-native@0.85.3": "patches/react-native@0.85.3.patch"
+    "react-native@0.85.3": "patches/react-native@0.85.3.patch",
+    "@react-native-harness/jest@1.4.0-rc.1": "patches/@react-native-harness%2Fjest@1.4.0-rc.1.patch"
   },
   "version": "5.0.11"
 }

--- a/patches/@react-native-harness%2Fjest@1.4.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fjest@1.4.0-rc.1.patch
@@ -1,0 +1,183 @@
+diff --git a/dist/execute-run.js b/dist/execute-run.js
+index 451d85154fdb21b2cb9ac386200250bc456e9c4e..62601d18e516703897b1175e6d4b61c606e8fa43 100644
+--- a/dist/execute-run.js
++++ b/dist/execute-run.js
+@@ -17,12 +17,36 @@ class CancelRun extends Error {
+         this.name = 'CancelRun';
+     }
+ }
+-const buildTestFailure = (err) => {
++const formatActiveHarnessContext = (context) => {
++    if (!context) {
++        return null;
++    }
++    if (context.test) {
++        return `Last started test before the device stopped responding: ${context.test.fullName}`;
++    }
++    if (context.suite) {
++        return `Last started suite before the device stopped responding: ${context.suite.name}`;
++    }
++    if (context.file) {
++        return `Last started test file before the device stopped responding: ${context.file.file}`;
++    }
++    return null;
++};
++const buildTestFailure = (err, activeContext) => {
+     if (err instanceof NativeCrashError ||
+         err instanceof RuntimeDisconnectError ||
+         err instanceof StartupStallError ||
+         err instanceof AppBridgeDisconnectedError ||
+         err instanceof DeviceNotRespondingError) {
++        const activeContextMessage = err instanceof DeviceNotRespondingError
++            ? formatActiveHarnessContext(activeContext)
++            : null;
++        if (activeContextMessage) {
++            return {
++                message: [err.message, '', activeContextMessage].join('\n'),
++                stack: '',
++            };
++        }
+         return { message: err.message, stack: '' };
+     }
+     return err;
+@@ -68,7 +92,27 @@ export const executeRun = async (session, tests, watcher, emitEvent, globalConfi
+     const testFiles = tests.map((t) => path.relative(rootDir, t.path));
+     const summary = createRunSummary();
+     let caseEventChain = Promise.resolve();
++    const activeContextByFile = new Map();
+     const unsubscribe = session.onTestRunnerEvent((event) => {
++        if (event.type === 'file-started') {
++            activeContextByFile.set(event.file, { file: event });
++        }
++        else if (event.type === 'suite-started') {
++            const context = activeContextByFile.get(event.file) ?? {};
++            activeContextByFile.set(event.file, { ...context, suite: event });
++        }
++        else if (event.type === 'test-started') {
++            const context = activeContextByFile.get(event.file) ?? {};
++            activeContextByFile.set(event.file, { ...context, test: event });
++        }
++        else if (event.type === 'test-finished' &&
++            activeContextByFile.get(event.file)?.test?.fullName === event.fullName) {
++            const { test, ...context } = activeContextByFile.get(event.file) ?? {};
++            activeContextByFile.set(event.file, context);
++        }
++        else if (event.type === 'file-finished') {
++            activeContextByFile.delete(event.file);
++        }
+         if (isHarnessCaseEvent(event)) {
+             caseEventChain = caseEventChain.then(() => event.type === 'test-started'
+                 ? emitHarnessTestStarted(emitEvent, event)
+@@ -203,7 +247,7 @@ export const executeRun = async (session, tests, watcher, emitEvent, globalConfi
+                 }
+                 updateRunState({ error: isRuntimeFailure ? undefined : err });
+                 await caseEventChain;
+-                await emitEvent('test-file-failure', test, buildTestFailure(err));
++                await emitEvent('test-file-failure', test, buildTestFailure(err, activeContextByFile.get(relativeTestPath)));
+             }
+         }
+     }
+diff --git a/src/execute-run.ts b/src/execute-run.ts
+index 6d326bbafb7c8632e753acf2b7ce97fcc50aaa0f..97c7ebd35eeb204167b81cd85608a3061d15dc79 100644
+--- a/src/execute-run.ts
++++ b/src/execute-run.ts
+@@ -20,6 +20,8 @@ import {
+ import type { TestCaseResult } from '@jest/test-result';
+ import type {
+   TestRunnerEvents,
++  TestRunnerFileStartedEvent,
++  TestRunnerSuiteStartedEvent,
+   TestRunnerTestFinishedEvent,
+   TestRunnerTestStartedEvent,
+ } from '@react-native-harness/bridge';
+@@ -52,7 +54,32 @@ class CancelRun extends Error {
+   }
+ }
+ 
+-const buildTestFailure = (err: unknown): { message: string; stack: string } => {
++type ActiveHarnessContext = {
++  file?: TestRunnerFileStartedEvent;
++  suite?: TestRunnerSuiteStartedEvent;
++  test?: TestRunnerTestStartedEvent;
++};
++
++const formatActiveHarnessContext = (context?: ActiveHarnessContext | null) => {
++  if (!context) {
++    return null;
++  }
++  if (context.test) {
++    return `Last started test before the device stopped responding: ${context.test.fullName}`;
++  }
++  if (context.suite) {
++    return `Last started suite before the device stopped responding: ${context.suite.name}`;
++  }
++  if (context.file) {
++    return `Last started test file before the device stopped responding: ${context.file.file}`;
++  }
++  return null;
++};
++
++const buildTestFailure = (
++  err: unknown,
++  activeContext?: ActiveHarnessContext | null,
++): { message: string; stack: string } => {
+   if (
+     err instanceof NativeCrashError ||
+     err instanceof RuntimeDisconnectError ||
+@@ -60,6 +87,16 @@ const buildTestFailure = (err: unknown): { message: string; stack: string } => {
+     err instanceof AppBridgeDisconnectedError ||
+     err instanceof DeviceNotRespondingError
+   ) {
++    const activeContextMessage =
++      err instanceof DeviceNotRespondingError
++        ? formatActiveHarnessContext(activeContext)
++        : null;
++    if (activeContextMessage) {
++      return {
++        message: [(err as Error).message, '', activeContextMessage].join('\n'),
++        stack: '',
++      };
++    }
+     return { message: (err as Error).message, stack: '' };
+   }
+   return err as { message: string; stack: string };
+@@ -128,7 +165,26 @@ export const executeRun = async (
+   const testFiles = tests.map((t) => path.relative(rootDir, t.path));
+   const summary = createRunSummary();
+   let caseEventChain = Promise.resolve();
++  const activeContextByFile = new Map<string, ActiveHarnessContext>();
+   const unsubscribe = session.onTestRunnerEvent((event) => {
++    if (event.type === 'file-started') {
++      activeContextByFile.set(event.file, { file: event });
++    } else if (event.type === 'suite-started') {
++      const context = activeContextByFile.get(event.file) ?? {};
++      activeContextByFile.set(event.file, { ...context, suite: event });
++    } else if (event.type === 'test-started') {
++      const context = activeContextByFile.get(event.file) ?? {};
++      activeContextByFile.set(event.file, { ...context, test: event });
++    } else if (
++      event.type === 'test-finished' &&
++      activeContextByFile.get(event.file)?.test?.fullName === event.fullName
++    ) {
++      const { test, ...context } = activeContextByFile.get(event.file) ?? {};
++      activeContextByFile.set(event.file, context);
++    } else if (event.type === 'file-finished') {
++      activeContextByFile.delete(event.file);
++    }
++
+     if (isHarnessCaseEvent(event)) {
+       caseEventChain = caseEventChain.then(() =>
+         event.type === 'test-started'
+@@ -288,7 +344,11 @@ export const executeRun = async (
+ 
+         updateRunState({ error: isRuntimeFailure ? undefined : err });
+         await caseEventChain;
+-        await emitEvent('test-file-failure', test, buildTestFailure(err));
++        await emitEvent(
++          'test-file-failure',
++          test,
++          buildTestFailure(err, activeContextByFile.get(relativeTestPath)),
++        );
+       }
+     }
+   } catch (err) {


### PR DESCRIPTION
## Summary

- Patch `@react-native-harness/jest@1.4.0-rc.1` with the upstream Harness timeout-context change from callstackincubator/react-native-harness#137.
- When a bridge RPC times out, include the last active Harness file/suite/test context in the Jest suite failure message.
- Do not change timeout values, test execution, app lifecycle, retries, native code, or skip behavior.

## Why

Latest main still fails Android with `visioncamera.controller.harness.ts` timing out at file level. The controller file has 19 tests, and Android reports 118 total tests instead of 137, so that whole file produced no completed test cases. Current Harness output cannot tell whether this is stuck in `beforeAll`/suite setup or in a specific controller test.

This diagnostic patch should make the next Android failure name the active suite or test. If it only names `VisionCamera - Controller`, the hang is before the first test starts. If it names an individual test, we can fix that specific native/app path.

## Verification

- `bun install --frozen-lockfile`
- `git diff --check`
- Local compiled-path smoke test: simulated `DeviceNotRespondingError` after `suite-started` and got `Last started suite before the device stopped responding: VisionCamera - Controller`.
- Local compiled-path smoke test: simulated `DeviceNotRespondingError` after `test-started` and got `Last started test before the device stopped responding: VisionCamera - Controller startZoomAnimation() animates the zoom`.
