### PR TITLE
fix: wait for Android exposure capture readiness

### DIFF
--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -5,9 +5,18 @@ inputs:
   artifact-folder:
     description: Device Farm artifact folder produced by the test action
     required: true
+  aws-region:
+    description: AWS region where the Device Farm run was scheduled
+    required: false
+  console-url:
+    description: AWS Device Farm console URL for the run
+    required: false
   platform:
     description: Platform label used in filenames and log output
     required: true
+  run-arn:
+    description: AWS Device Farm run ARN
+    required: false
   test-step-outcome:
     description: Outcome of the upstream Device Farm execution step
     required: false
@@ -23,6 +32,77 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Print Device Farm result tree
+      if: inputs.run-arn != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        RUN_ARN="${{ inputs.run-arn }}"
+        AWS_REGION="${{ inputs.aws-region }}"
+        CONSOLE_URL="${{ inputs.console-url }}"
+
+        echo "===== Device Farm run ====="
+        echo "Run ARN: $RUN_ARN"
+        if [[ -n "$CONSOLE_URL" ]]; then
+          echo "Console URL: $CONSOLE_URL"
+        fi
+
+        if [[ -z "$AWS_REGION" ]]; then
+          echo "No AWS region was provided; skipping Device Farm result tree." >&2
+          exit 0
+        fi
+
+        if ! command -v aws >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+          echo "aws and jq are required to print the Device Farm result tree." >&2
+          exit 0
+        fi
+
+        JOBS_JSON="$(aws devicefarm list-jobs --region "$AWS_REGION" --arn "$RUN_ARN" --output json || true)"
+        if [[ -z "$JOBS_JSON" ]]; then
+          echo "Could not list Device Farm jobs." >&2
+          exit 0
+        fi
+
+        echo "Jobs:"
+        jq -r '
+          .jobs[]
+          | "- \(.name): status=\(.status) result=\(.result // "UNKNOWN") counters=\(.counters)"
+        ' <<< "$JOBS_JSON"
+
+        while IFS= read -r JOB_ARN; do
+          [[ -z "$JOB_ARN" ]] && continue
+
+          SUITES_JSON="$(aws devicefarm list-suites --region "$AWS_REGION" --arn "$JOB_ARN" --output json || true)"
+          if [[ -z "$SUITES_JSON" ]]; then
+            echo "Could not list suites for job $JOB_ARN." >&2
+            continue
+          fi
+
+          echo "Suites for job $JOB_ARN:"
+          jq -r '
+            .suites[]
+            | "- \(.name): status=\(.status) result=\(.result // "UNKNOWN") counters=\(.counters)"
+          ' <<< "$SUITES_JSON"
+
+          while IFS= read -r SUITE_ARN; do
+            [[ -z "$SUITE_ARN" ]] && continue
+
+            TESTS_JSON="$(aws devicefarm list-tests --region "$AWS_REGION" --arn "$SUITE_ARN" --output json || true)"
+            if [[ -z "$TESTS_JSON" ]]; then
+              echo "Could not list tests for suite $SUITE_ARN." >&2
+              continue
+            fi
+
+            jq -r '
+              .tests[]
+              | "  - \(.name): status=\(.status) result=\(.result // "UNKNOWN") counters=\(.counters)"
+                + (if (.message // "") != "" then " message=\(.message)" else "" end)
+            ' <<< "$TESTS_JSON"
+          done < <(jq -r '.suites[].arn' <<< "$SUITES_JSON")
+        done < <(jq -r '.jobs[].arn' <<< "$JOBS_JSON")
+        echo "===== End Device Farm run ====="
+
     - name: Find Harness JUnit result
       id: find-harness-junit
       shell: bash
@@ -31,11 +111,14 @@ runs:
         ARTIFACT_DIR="${{ inputs.artifact-folder }}"
         PLATFORM="${{ inputs.platform }}"
         WORKSPACE_JUNIT=".github/test-results/harness-results-${PLATFORM}.junit.xml"
-        bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
+        if bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
           "$ARTIFACT_DIR" \
           'harness-results.junit.xml' \
-          "$WORKSPACE_JUNIT"
-        echo "junit_file=$WORKSPACE_JUNIT" >> "$GITHUB_OUTPUT"
+          "$WORKSPACE_JUNIT"; then
+          echo "junit_file=$WORKSPACE_JUNIT" >> "$GITHUB_OUTPUT"
+        else
+          echo "junit_file=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Find Harness output log
       id: find-harness-log
@@ -45,11 +128,14 @@ runs:
         ARTIFACT_DIR="${{ inputs.artifact-folder }}"
         PLATFORM="${{ inputs.platform }}"
         WORKSPACE_LOG=".github/test-results/harness-output-${PLATFORM}.log"
-        bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
+        if bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
           "$ARTIFACT_DIR" \
           'harness-output.log' \
-          "$WORKSPACE_LOG"
-        echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+          "$WORKSPACE_LOG"; then
+          echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+        else
+          echo "log_file=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Publish Harness test results
       id: publish-harness-results
@@ -71,11 +157,67 @@ runs:
         set -euo pipefail
         LOG_FILE="${{ steps.find-harness-log.outputs.log_file }}"
         PLATFORM="${{ inputs.platform }}"
+        if [[ -n "$LOG_FILE" ]]; then
+          echo "===== Harness ${PLATFORM} output log ====="
+          cat "$LOG_FILE"
+          echo "===== End Harness ${PLATFORM} output log ====="
+        else
+          echo "No Harness ${PLATFORM} output log was found in Device Farm artifacts."
+        fi
+
+    - name: Print Device Farm raw artifacts
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ARTIFACT_DIR="${{ inputs.artifact-folder }}"
+        TEST_STEP_OUTCOME="${{ inputs.test-step-outcome }}"
+        JUNIT_FILE="${{ steps.find-harness-junit.outputs.junit_file }}"
+        LOG_FILE="${{ steps.find-harness-log.outputs.log_file }}"
+
+        if [[ "$TEST_STEP_OUTCOME" != "failure" && -n "$JUNIT_FILE" && -n "$LOG_FILE" ]]; then
+          exit 0
+        fi
+
+        if [[ -z "$ARTIFACT_DIR" || ! -d "$ARTIFACT_DIR" ]]; then
+          echo "Device Farm artifact folder missing: '$ARTIFACT_DIR'" >&2
+          exit 0
+        fi
+
+        echo "===== Device Farm artifact files ====="
+        find "$ARTIFACT_DIR" -type f | sort
+        echo "===== End Device Farm artifact files ====="
+
+        while IFS= read -r FILE; do
+          NAME="$(basename "$FILE")"
+          case "$NAME" in
+            *"Test spec output.txt"|*"Test spec timestamped output.txt"|*"Customer Artifacts Log.txt")
+              echo "===== $NAME ====="
+              cat "$FILE"
+              echo "===== End $NAME ====="
+              ;;
+            *"Logcat.logcat"|*"Syslog.log"|*"xcodebuild.log")
+              echo "===== Last 400 lines of $NAME ====="
+              tail -n 400 "$FILE"
+              echo "===== End $NAME ====="
+              ;;
+          esac
+        done < <(find "$ARTIFACT_DIR" -type f | sort)
+
+    - name: Validate Device Farm result
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
         PUBLISH_OUTCOME="${{ steps.publish-harness-results.outcome }}"
         TEST_STEP_OUTCOME="${{ inputs.test-step-outcome }}"
-        echo "===== Harness ${PLATFORM} output log ====="
-        cat "$LOG_FILE"
-        echo "===== End Harness ${PLATFORM} output log ====="
+        JUNIT_FILE="${{ steps.find-harness-junit.outputs.junit_file }}"
+
+        if [[ -z "$JUNIT_FILE" ]]; then
+          echo "Harness JUnit result was not found in Device Farm artifacts." >&2
+          exit 1
+        fi
 
         if [[ "$PUBLISH_OUTCOME" == "failure" ]]; then
           echo "Harness test result publication reported failures." >&2

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -308,7 +308,10 @@ jobs:
         uses: ./.github/actions/collect-devicefarm-results
         with:
           artifact-folder: ${{ steps.run-test.outputs.artifact-folder }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          console-url: ${{ steps.run-test.outputs.console-url }}
           platform: android
+          run-arn: ${{ steps.run-test.outputs.arn }}
           test-step-outcome: ${{ steps.run-test.outcome }}
 
   build-ios:
@@ -596,5 +599,8 @@ jobs:
         uses: ./.github/actions/collect-devicefarm-results
         with:
           artifact-folder: ${{ steps.run-test.outputs.artifact-folder }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          console-url: ${{ steps.run-test.outputs.console-url }}
           platform: ios
+          run-arn: ${{ steps.run-test.outputs.arn }}
           test-step-outcome: ${{ steps.run-test.outcome }}

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -73,6 +73,8 @@ env:
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME: harness-xctest-agent-ipa
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH: apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentUITests.ipa
   HARNESS_IOS_XCTEST_UI_TEST_PACKAGE_OUTPUT: apps/simple-camera/ios/build/devicefarm/HarnessXCTestUITestPackage.zip
+  HARNESS_IOS_BUN_ARTIFACT_NAME: harness-ios-bun
+  HARNESS_IOS_BUN_ARTIFACT_PATH: apps/simple-camera/ios/build/devicefarm/bun/bun
   HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME: react-native-vision-camera.zip
   HARNESS_ANDROID_DEVICE_FARM_TEST_PACKAGE_OUTPUT: apps/simple-camera/android/build/devicefarm/AndroidTestPackage.zip
   HARNESS_ANDROID_BUNDLE_ID: com.margelo.nitro.camera.example.simple
@@ -218,6 +220,8 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: oven-sh/setup-bun@v2
+
       - name: Download Android app artifact
         uses: actions/download-artifact@v8
         with:
@@ -241,6 +245,18 @@ jobs:
             --format=zip \
             --output "$PACKAGE_PATH" \
             HEAD
+
+          BUN_BIN="$(command -v bun)"
+          BUN_PACKAGE_ROOT="$(mktemp -d)"
+          mkdir -p "$BUN_PACKAGE_ROOT/.devicefarm/bin"
+          cp "$BUN_BIN" "$BUN_PACKAGE_ROOT/.devicefarm/bin/bun"
+          chmod +x "$BUN_PACKAGE_ROOT/.devicefarm/bin/bun"
+          "$BUN_PACKAGE_ROOT/.devicefarm/bin/bun" --version
+
+          (
+            cd "$BUN_PACKAGE_ROOT"
+            zip -qry "$GITHUB_WORKSPACE/$PACKAGE_PATH" .devicefarm
+          )
 
           unzip -tq "$PACKAGE_PATH"
 
@@ -473,6 +489,26 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Stage Bun runtime for Device Farm
+        run: |
+          set -euo pipefail
+
+          BUN_BIN="$(command -v bun)"
+          BUN_RUNTIME="${{ env.HARNESS_IOS_BUN_ARTIFACT_PATH }}"
+
+          mkdir -p "$(dirname "$BUN_RUNTIME")"
+          cp "$BUN_BIN" "$BUN_RUNTIME"
+          chmod +x "$BUN_RUNTIME"
+          "$BUN_RUNTIME" --version
+
+      - name: Upload Bun runtime artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.HARNESS_IOS_BUN_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_IOS_BUN_ARTIFACT_PATH }}
+          if-no-files-found: error
+          retention-days: 7
+
   test-ios:
     name: Test iOS
     runs-on: ubuntu-latest
@@ -498,6 +534,12 @@ jobs:
           name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm
 
+      - name: Download Bun runtime artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.HARNESS_IOS_BUN_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm/bun
+
       - name: Verify iOS app artifact
         run: test -f ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
 
@@ -512,6 +554,7 @@ jobs:
           PACKAGE_ROOT="$(mktemp -d)"
           REPO_ARCHIVE="$PACKAGE_ROOT/${{ env.HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME }}"
           RUNNER_IPA="$PACKAGE_ROOT/$(basename "${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}")"
+          BUN_BIN="${{ env.HARNESS_IOS_BUN_ARTIFACT_PATH }}"
 
           rm -f "$PACKAGE_PATH"
           mkdir -p "$(dirname "$PACKAGE_PATH")"
@@ -520,6 +563,17 @@ jobs:
             --format=zip \
             --output "$REPO_ARCHIVE" \
             HEAD
+
+          if [[ -f "$BUN_BIN" ]]; then
+            BUN_PACKAGE_ROOT="$(mktemp -d)"
+            mkdir -p "$BUN_PACKAGE_ROOT/.devicefarm/bin"
+            cp "$BUN_BIN" "$BUN_PACKAGE_ROOT/.devicefarm/bin/bun"
+            chmod +x "$BUN_PACKAGE_ROOT/.devicefarm/bin/bun"
+            (
+              cd "$BUN_PACKAGE_ROOT"
+              zip -qry "$REPO_ARCHIVE" .devicefarm
+            )
+          fi
 
           cp "${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}" "$RUNNER_IPA"
 

--- a/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpec.yml
@@ -7,8 +7,36 @@ phases:
     commands:
       - devicefarm-cli use node 20
       - node -v
-      - curl -fsSL https://bun.com/install | bash
-      - ~/.bun/bin/bun install
+      - |
+        set -euo pipefail
+
+        install_bun() {
+          if [ -f ".devicefarm/bin/bun" ]; then
+            mkdir -p "$HOME/.bun/bin"
+            cp ".devicefarm/bin/bun" "$HOME/.bun/bin/bun"
+            chmod +x "$HOME/.bun/bin/bun"
+            if "$HOME/.bun/bin/bun" --version; then
+              return 0
+            fi
+            rm -f "$HOME/.bun/bin/bun"
+          fi
+
+          for attempt in 1 2 3; do
+            if curl -fsSL https://bun.com/install | bash; then
+              "$HOME/.bun/bin/bun" --version
+              return 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              return 1
+            fi
+
+            sleep "$((attempt * 5))"
+          done
+        }
+
+        install_bun
+      - ~/.bun/bin/bun install --frozen-lockfile
 
       - adb wait-for-device
       - adb devices -l

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -8,7 +8,6 @@ phases:
       - devicefarm-cli use node 20
       - node -v
       - xcodebuild -version
-      - curl -fsSL https://bun.com/install | bash
       - xcrun devicectl list devices
 
       # The XCTEST_UI package contains the Harness XCTest runner IPA and a
@@ -25,6 +24,33 @@ phases:
         unzip -q "$REPO_ARCHIVE" -d "$HARNESS_REPO_ROOT"
 
         cd "$HARNESS_REPO_ROOT"
+
+        install_bun() {
+          if [ -f ".devicefarm/bin/bun" ]; then
+            mkdir -p "$HOME/.bun/bin"
+            cp ".devicefarm/bin/bun" "$HOME/.bun/bin/bun"
+            chmod +x "$HOME/.bun/bin/bun"
+            if "$HOME/.bun/bin/bun" --version; then
+              return 0
+            fi
+            rm -f "$HOME/.bun/bin/bun"
+          fi
+
+          for attempt in 1 2 3; do
+            if curl -fsSL https://bun.com/install | bash; then
+              "$HOME/.bun/bin/bun" --version
+              return 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              return 1
+            fi
+
+            sleep "$((attempt * 5))"
+          done
+        }
+
+        install_bun
         ~/.bun/bin/bun install --frozen-lockfile
 
   test:

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -2,12 +2,16 @@ package com.margelo.nitro.camera.hybrids
 
 import android.animation.Animator
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraState
 import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.LowLightBoostState
 import androidx.camera.core.MeteringPoint
 import androidx.camera.core.TorchState
+import androidx.camera.core.impl.CameraCaptureCallback
+import androidx.camera.core.impl.CameraCaptureResult
+import androidx.camera.core.impl.CameraInfoInternal
 import com.google.common.util.concurrent.ListenableFuture
 import com.margelo.nitro.camera.CameraControllerConfiguration
 import com.margelo.nitro.camera.ExposureMode
@@ -31,12 +35,17 @@ import com.margelo.nitro.camera.hybrids.metering.HybridMeteringPoint
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.resolve
 import com.margelo.nitro.core.resolved
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
 class HybridCameraController(
   val camera: Camera,
 ) : HybridCameraControllerSpec() {
   override val device: HybridCameraDeviceSpec = HybridCameraDevice(camera.cameraInfo)
+  private val directExecutor = Executor { runnable -> runnable.run() }
   private val cameraState: CameraState?
     get() = camera.cameraInfo.cameraState.value
   private var zoomAnimator: ValueAnimator? = null
@@ -191,8 +200,16 @@ class HybridCameraController(
 
   override fun setExposureBias(exposure: Double): Promise<Unit> {
     return Promise.async {
+      val exposureIndex = exposure.toInt()
+      val exposureState = camera.cameraInfo.exposureState
+      if (exposureState.isExposureCompensationSupported &&
+        exposureState.exposureCompensationRange.contains(exposureIndex) &&
+        exposureState.exposureCompensationIndex != exposureIndex
+      ) {
+        awaitCaptureResultBeforeExposureBias()
+      }
       camera.cameraControl
-        .setExposureCompensationIndex(exposure.toInt())
+        .setExposureCompensationIndex(exposureIndex)
         .await()
     }
   }
@@ -345,5 +362,40 @@ class HybridCameraController(
       "Locking White Balance Gains is not yet supported on Android! " +
         "You can use AWB focus (`focusTo(..., ['AWB'])`) instead.",
     )
+  }
+
+  @SuppressLint("RestrictedApi")
+  private suspend fun awaitCaptureResultBeforeExposureBias() {
+    if (!isConnected) return
+    val cameraInfo = camera.cameraInfo as? CameraInfoInternal ?: return
+    val result = CompletableDeferred<Unit>()
+    val callback =
+      object : CameraCaptureCallback() {
+        override fun onCaptureCompleted(
+          captureConfigId: Int,
+          cameraCaptureResult: CameraCaptureResult,
+        ) {
+          result.complete(Unit)
+        }
+      }
+
+    cameraInfo.addSessionCaptureCallback(directExecutor, callback)
+    try {
+      withTimeout(EXPOSURE_BIAS_CAPTURE_RESULT_TIMEOUT_MS) {
+        result.await()
+      }
+    } catch (error: TimeoutCancellationException) {
+      throw Error(
+        "Timed out waiting for CameraController to receive a capture result before setting exposure bias after " +
+          "${EXPOSURE_BIAS_CAPTURE_RESULT_TIMEOUT_MS}ms.",
+        error,
+      )
+    } finally {
+      cameraInfo.removeSessionCaptureCallback(callback)
+    }
+  }
+
+  private companion object {
+    private const val EXPOSURE_BIAS_CAPTURE_RESULT_TIMEOUT_MS = 5_000L
   }
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
@@ -6,9 +6,6 @@ import androidx.annotation.UiThread
 import androidx.camera.core.Camera
 import androidx.camera.core.ConcurrentCamera
 import androidx.camera.core.UseCaseGroup
-import androidx.camera.core.impl.CameraCaptureCallback
-import androidx.camera.core.impl.CameraCaptureResult
-import androidx.camera.core.impl.CameraInfoInternal
 import androidx.camera.lifecycle.ProcessCameraProvider
 import com.facebook.react.bridge.ReactApplicationContext
 import com.margelo.nitro.NitroModules
@@ -33,10 +30,6 @@ import com.margelo.nitro.core.Promise
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.withTimeout
-import java.util.concurrent.Executor
 
 @Suppress("unused")
 class HybridCameraSession(
@@ -47,7 +40,6 @@ class HybridCameraSession(
     get() = NitroModules.applicationContext ?: throw Error("No Context!")
   private val lifecycleOwner = CustomLifecycle(context)
   private val uiScope = CoroutineScope(Dispatchers.Main)
-  private val directExecutor = Executor { runnable -> runnable.run() }
 
   override val isRunning: Boolean
     get() = activeSession?.isRunning ?: false
@@ -59,11 +51,6 @@ class HybridCameraSession(
   private var onInterruptionStartedListeners = arrayListOf<(InterruptionReason) -> Unit>()
   private var onInterruptionEndedListeners = arrayListOf<() -> Unit>()
   private var startWaiters = arrayListOf<CompletableDeferred<Unit>>()
-
-  private data class CaptureResultWaiter(
-    val result: CompletableDeferred<Unit>,
-    val cleanup: () -> Unit,
-  )
 
   @SuppressLint("RestrictedApi")
   override fun configure(
@@ -152,7 +139,6 @@ class HybridCameraSession(
 
   override fun start(): Promise<Unit> {
     return Promise.async(uiScope) {
-      val captureResultWaiters = createFirstCaptureResultWaiters()
       val startWaiter =
         if (activeSession?.isRunning == false) {
           CompletableDeferred<Unit>().also { startWaiters.add(it) }
@@ -168,10 +154,8 @@ class HybridCameraSession(
 
       try {
         startWaiter?.await()
-        awaitFirstCaptureResults(captureResultWaiters)
       } finally {
         startWaiter?.let { startWaiters.remove(it) }
-        captureResultWaiters.forEach { waiter -> waiter.cleanup() }
       }
     }
   }
@@ -204,46 +188,6 @@ class HybridCameraSession(
     }
     if (initialExposureBias != null) {
       camera.cameraControl.setExposureCompensationIndex(initialExposureBias.toInt())
-    }
-  }
-
-  @SuppressLint("RestrictedApi")
-  private fun createFirstCaptureResultWaiters(): List<CaptureResultWaiter> {
-    val session = activeSession ?: return emptyList()
-    return session.cameras.mapNotNull { camera ->
-      val cameraInfo = camera.cameraInfo as? CameraInfoInternal ?: return@mapNotNull null
-      val result = CompletableDeferred<Unit>()
-      val callback =
-        object : CameraCaptureCallback() {
-          override fun onCaptureCompleted(
-            captureConfigId: Int,
-            cameraCaptureResult: CameraCaptureResult,
-          ) {
-            result.complete(Unit)
-          }
-        }
-
-      cameraInfo.addSessionCaptureCallback(directExecutor, callback)
-      CaptureResultWaiter(
-        result = result,
-        cleanup = { cameraInfo.removeSessionCaptureCallback(callback) },
-      )
-    }
-  }
-
-  private suspend fun awaitFirstCaptureResults(waiters: List<CaptureResultWaiter>) {
-    if (waiters.isEmpty()) return
-
-    try {
-      withTimeout(CAMERA_START_CAPTURE_RESULT_TIMEOUT_MS) {
-        waiters.map { waiter -> waiter.result }.awaitAll()
-      }
-    } catch (error: TimeoutCancellationException) {
-      throw Error(
-        "Timed out waiting for CameraSession to produce a capture result after " +
-          "${CAMERA_START_CAPTURE_RESULT_TIMEOUT_MS}ms.",
-        error,
-      )
     }
   }
 
@@ -308,9 +252,5 @@ class HybridCameraSession(
     return ListenerSubscription {
       onInterruptionEndedListeners.remove(onInterruptionEnded)
     }
-  }
-
-  private companion object {
-    private const val CAMERA_START_CAPTURE_RESULT_TIMEOUT_MS = 5_000L
   }
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.util.Log
 import androidx.annotation.UiThread
 import androidx.camera.core.Camera
-import androidx.camera.core.CameraState
 import androidx.camera.core.ConcurrentCamera
 import androidx.camera.core.UseCaseGroup
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -52,8 +51,6 @@ class HybridCameraSession(
   private var onInterruptionStartedListeners = arrayListOf<(InterruptionReason) -> Unit>()
   private var onInterruptionEndedListeners = arrayListOf<() -> Unit>()
   private var startWaiters = arrayListOf<CompletableDeferred<Unit>>()
-  private var stopWaiters = arrayListOf<CompletableDeferred<Unit>>()
-  private var currentCameraState = CameraState.Type.CLOSED
 
   @SuppressLint("RestrictedApi")
   override fun configure(
@@ -165,24 +162,7 @@ class HybridCameraSession(
 
   override fun stop(): Promise<Unit> {
     return Promise.async(uiScope) {
-      val stopWaiter =
-        if (activeSession?.isRunning == true) {
-          CompletableDeferred<Unit>().also { stopWaiters.add(it) }
-        } else {
-          null
-        }
-
       lifecycleOwner.setActive(false)
-
-      if (activeSession?.isRunning == false) {
-        stopWaiter?.complete(Unit)
-      }
-
-      try {
-        stopWaiter?.await()
-      } finally {
-        stopWaiter?.let { stopWaiters.remove(it) }
-      }
     }
   }
 
@@ -220,16 +200,12 @@ class HybridCameraSession(
   }
 
   override fun onStopped() {
-    stopWaiters.forEach { waiter -> waiter.complete(Unit) }
-    stopWaiters.clear()
     onStoppedListeners.forEach { listener -> listener() }
   }
 
   override fun onError(error: Throwable) {
     startWaiters.forEach { waiter -> waiter.completeExceptionally(error) }
     startWaiters.clear()
-    stopWaiters.forEach { waiter -> waiter.completeExceptionally(error) }
-    stopWaiters.clear()
     onErrorListeners.forEach { listener -> listener(error) }
   }
 

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
@@ -28,6 +28,7 @@ import com.margelo.nitro.camera.session.toConfig
 import com.margelo.nitro.camera.utils.CustomLifecycle
 import com.margelo.nitro.camera.utils.DirectByteBufferPool
 import com.margelo.nitro.core.Promise
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
@@ -50,6 +51,8 @@ class HybridCameraSession(
   private var onErrorListeners = arrayListOf<(Throwable) -> Unit>()
   private var onInterruptionStartedListeners = arrayListOf<(InterruptionReason) -> Unit>()
   private var onInterruptionEndedListeners = arrayListOf<() -> Unit>()
+  private var startWaiters = arrayListOf<CompletableDeferred<Unit>>()
+  private var stopWaiters = arrayListOf<CompletableDeferred<Unit>>()
   private var currentCameraState = CameraState.Type.CLOSED
 
   @SuppressLint("RestrictedApi")
@@ -139,13 +142,47 @@ class HybridCameraSession(
 
   override fun start(): Promise<Unit> {
     return Promise.async(uiScope) {
+      val startWaiter =
+        if (activeSession?.isRunning == false) {
+          CompletableDeferred<Unit>().also { startWaiters.add(it) }
+        } else {
+          null
+        }
+
       lifecycleOwner.setActive(true)
+
+      if (activeSession?.isRunning == true) {
+        startWaiter?.complete(Unit)
+      }
+
+      try {
+        startWaiter?.await()
+      } finally {
+        startWaiter?.let { startWaiters.remove(it) }
+      }
     }
   }
 
   override fun stop(): Promise<Unit> {
     return Promise.async(uiScope) {
+      val stopWaiter =
+        if (activeSession?.isRunning == true) {
+          CompletableDeferred<Unit>().also { stopWaiters.add(it) }
+        } else {
+          null
+        }
+
       lifecycleOwner.setActive(false)
+
+      if (activeSession?.isRunning == false) {
+        stopWaiter?.complete(Unit)
+      }
+
+      try {
+        stopWaiter?.await()
+      } finally {
+        stopWaiter?.let { stopWaiters.remove(it) }
+      }
     }
   }
 
@@ -177,14 +214,22 @@ class HybridCameraSession(
   // pragma MARK: Lifecycle Changed Callbacks
 
   override fun onStarted() {
+    startWaiters.forEach { waiter -> waiter.complete(Unit) }
+    startWaiters.clear()
     onStartedListeners.forEach { listener -> listener() }
   }
 
   override fun onStopped() {
+    stopWaiters.forEach { waiter -> waiter.complete(Unit) }
+    stopWaiters.clear()
     onStoppedListeners.forEach { listener -> listener() }
   }
 
   override fun onError(error: Throwable) {
+    startWaiters.forEach { waiter -> waiter.completeExceptionally(error) }
+    startWaiters.clear()
+    stopWaiters.forEach { waiter -> waiter.completeExceptionally(error) }
+    stopWaiters.clear()
     onErrorListeners.forEach { listener -> listener(error) }
   }
 

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt
@@ -6,6 +6,9 @@ import androidx.annotation.UiThread
 import androidx.camera.core.Camera
 import androidx.camera.core.ConcurrentCamera
 import androidx.camera.core.UseCaseGroup
+import androidx.camera.core.impl.CameraCaptureCallback
+import androidx.camera.core.impl.CameraCaptureResult
+import androidx.camera.core.impl.CameraInfoInternal
 import androidx.camera.lifecycle.ProcessCameraProvider
 import com.facebook.react.bridge.ReactApplicationContext
 import com.margelo.nitro.NitroModules
@@ -30,6 +33,10 @@ import com.margelo.nitro.core.Promise
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.Executor
 
 @Suppress("unused")
 class HybridCameraSession(
@@ -40,6 +47,7 @@ class HybridCameraSession(
     get() = NitroModules.applicationContext ?: throw Error("No Context!")
   private val lifecycleOwner = CustomLifecycle(context)
   private val uiScope = CoroutineScope(Dispatchers.Main)
+  private val directExecutor = Executor { runnable -> runnable.run() }
 
   override val isRunning: Boolean
     get() = activeSession?.isRunning ?: false
@@ -51,6 +59,11 @@ class HybridCameraSession(
   private var onInterruptionStartedListeners = arrayListOf<(InterruptionReason) -> Unit>()
   private var onInterruptionEndedListeners = arrayListOf<() -> Unit>()
   private var startWaiters = arrayListOf<CompletableDeferred<Unit>>()
+
+  private data class CaptureResultWaiter(
+    val result: CompletableDeferred<Unit>,
+    val cleanup: () -> Unit,
+  )
 
   @SuppressLint("RestrictedApi")
   override fun configure(
@@ -139,6 +152,7 @@ class HybridCameraSession(
 
   override fun start(): Promise<Unit> {
     return Promise.async(uiScope) {
+      val captureResultWaiters = createFirstCaptureResultWaiters()
       val startWaiter =
         if (activeSession?.isRunning == false) {
           CompletableDeferred<Unit>().also { startWaiters.add(it) }
@@ -154,8 +168,10 @@ class HybridCameraSession(
 
       try {
         startWaiter?.await()
+        awaitFirstCaptureResults(captureResultWaiters)
       } finally {
         startWaiter?.let { startWaiters.remove(it) }
+        captureResultWaiters.forEach { waiter -> waiter.cleanup() }
       }
     }
   }
@@ -188,6 +204,46 @@ class HybridCameraSession(
     }
     if (initialExposureBias != null) {
       camera.cameraControl.setExposureCompensationIndex(initialExposureBias.toInt())
+    }
+  }
+
+  @SuppressLint("RestrictedApi")
+  private fun createFirstCaptureResultWaiters(): List<CaptureResultWaiter> {
+    val session = activeSession ?: return emptyList()
+    return session.cameras.mapNotNull { camera ->
+      val cameraInfo = camera.cameraInfo as? CameraInfoInternal ?: return@mapNotNull null
+      val result = CompletableDeferred<Unit>()
+      val callback =
+        object : CameraCaptureCallback() {
+          override fun onCaptureCompleted(
+            captureConfigId: Int,
+            cameraCaptureResult: CameraCaptureResult,
+          ) {
+            result.complete(Unit)
+          }
+        }
+
+      cameraInfo.addSessionCaptureCallback(directExecutor, callback)
+      CaptureResultWaiter(
+        result = result,
+        cleanup = { cameraInfo.removeSessionCaptureCallback(callback) },
+      )
+    }
+  }
+
+  private suspend fun awaitFirstCaptureResults(waiters: List<CaptureResultWaiter>) {
+    if (waiters.isEmpty()) return
+
+    try {
+      withTimeout(CAMERA_START_CAPTURE_RESULT_TIMEOUT_MS) {
+        waiters.map { waiter -> waiter.result }.awaitAll()
+      }
+    } catch (error: TimeoutCancellationException) {
+      throw Error(
+        "Timed out waiting for CameraSession to produce a capture result after " +
+          "${CAMERA_START_CAPTURE_RESULT_TIMEOUT_MS}ms.",
+        error,
+      )
     }
   }
 
@@ -252,5 +308,9 @@ class HybridCameraSession(
     return ListenerSubscription {
       onInterruptionEndedListeners.remove(onInterruptionEnded)
     }
+  }
+
+  private companion object {
+    private const val CAMERA_START_CAPTURE_RESULT_TIMEOUT_MS = 5_000L
   }
 }


### PR DESCRIPTION
## Summary

This keeps Android `CameraSession.start()` scoped to CameraX camera-state readiness, and moves capture-result readiness to the controller operation that actually needs it: supported, in-range, state-changing `setExposureBias(...)` calls.

It also keeps the Device Farm/Harness CI hardening from earlier commits:

- package Bun into Device Farm test packages instead of relying on network install inside Device Farm
- print Device Farm diagnostics when Harness artifacts are missing

## Why

The Harness diagnostic run for `visioncamera.controller.harness.ts` showed the Android bridge timeout happened while the controller test was running:

```text
Last started test before the device stopped responding: VisionCamera - Controller sets exposure bias to min/max when the device supports it
```

CameraX exposure compensation futures complete from capture results. Waiting only for `CameraState.OPEN` is not always strong enough: the camera can be open while the capture-result pipeline has not yet produced the metadata CameraX uses to complete `setExposureCompensationIndex(...)`.

A previous attempt waited for the first capture result in every `CameraSession.start()`. That made the controller suite pass once, but it was too broad: valid multi-output starts can have no consumer attached yet and should not fail just because no capture result is produced at start. This revision removes that global start wait and only fences the exposure-bias path that the logs identified.

If the camera is open but no capture result arrives before applying exposure bias, the controller now fails after 5s with a specific native error instead of letting the Harness file-level RPC timeout burn roughly 120s. Invalid or no-op exposure-bias calls skip the readiness wait and still go through CameraX directly.

## Verification

- `bun run lint-kotlin -- packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraSession.kt`
- `cd apps/simple-camera/android && JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew :react-native-vision-camera:compileDebugKotlin --no-daemon --console=plain`

Device Farm is running again on `34b52f0c` to verify that the Android controller suite still runs and the multi-output regression from the global start wait is gone.