### PR TITLE
[codex] stabilize iOS Harness Device Farm CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+patches/*.patch -whitespace

--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -5,9 +5,18 @@ inputs:
   artifact-folder:
     description: Device Farm artifact folder produced by the test action
     required: true
+  aws-region:
+    description: AWS region where the Device Farm run was scheduled
+    required: false
+  console-url:
+    description: AWS Device Farm console URL for the run
+    required: false
   platform:
     description: Platform label used in filenames and log output
     required: true
+  run-arn:
+    description: AWS Device Farm run ARN
+    required: false
   test-step-outcome:
     description: Outcome of the upstream Device Farm execution step
     required: false
@@ -19,37 +28,141 @@ outputs:
   log-file:
     description: Copied harness log file path
     value: ${{ steps.find-harness-log.outputs.log_file }}
+  xcodebuild-log-file:
+    description: Copied iOS xcodebuild log file path
+    value: ${{ steps.find-xcodebuild-log.outputs.log_file }}
 
 runs:
   using: composite
   steps:
+    - name: Print Device Farm result tree
+      if: inputs.run-arn != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        RUN_ARN="${{ inputs.run-arn }}"
+        AWS_REGION="${{ inputs.aws-region }}"
+        CONSOLE_URL="${{ inputs.console-url }}"
+
+        echo "===== Device Farm run ====="
+        echo "Run ARN: $RUN_ARN"
+        if [[ -n "$CONSOLE_URL" ]]; then
+          echo "Console URL: $CONSOLE_URL"
+        fi
+
+        if [[ -z "$AWS_REGION" ]]; then
+          echo "No AWS region was provided; skipping Device Farm result tree." >&2
+          exit 0
+        fi
+
+        if ! command -v aws >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+          echo "aws and jq are required to print the Device Farm result tree." >&2
+          exit 0
+        fi
+
+        JOBS_JSON="$(aws devicefarm list-jobs --region "$AWS_REGION" --arn "$RUN_ARN" --output json || true)"
+        if [[ -z "$JOBS_JSON" ]]; then
+          echo "Could not list Device Farm jobs." >&2
+          exit 0
+        fi
+
+        echo "Jobs:"
+        jq -r '
+          .jobs[]
+          | "- \(.name): status=\(.status) result=\(.result // "UNKNOWN") counters=\(.counters)"
+        ' <<< "$JOBS_JSON"
+
+        while IFS= read -r JOB_ARN; do
+          [[ -z "$JOB_ARN" ]] && continue
+
+          SUITES_JSON="$(aws devicefarm list-suites --region "$AWS_REGION" --arn "$JOB_ARN" --output json || true)"
+          if [[ -z "$SUITES_JSON" ]]; then
+            echo "Could not list suites for job $JOB_ARN." >&2
+            continue
+          fi
+
+          echo "Suites for job $JOB_ARN:"
+          jq -r '
+            .suites[]
+            | "- \(.name): status=\(.status) result=\(.result // "UNKNOWN") counters=\(.counters)"
+          ' <<< "$SUITES_JSON"
+
+          while IFS= read -r SUITE_ARN; do
+            [[ -z "$SUITE_ARN" ]] && continue
+
+            TESTS_JSON="$(aws devicefarm list-tests --region "$AWS_REGION" --arn "$SUITE_ARN" --output json || true)"
+            if [[ -z "$TESTS_JSON" ]]; then
+              echo "Could not list tests for suite $SUITE_ARN." >&2
+              continue
+            fi
+
+            jq -r '
+              .tests[]
+              | "  - \(.name): status=\(.status) result=\(.result // "UNKNOWN") counters=\(.counters)"
+                + (if (.message // "") != "" then " message=\(.message)" else "" end)
+            ' <<< "$TESTS_JSON"
+          done < <(jq -r '.suites[].arn' <<< "$SUITES_JSON")
+        done < <(jq -r '.jobs[].arn' <<< "$JOBS_JSON")
+        echo "===== End Device Farm run ====="
+
     - name: Find Harness JUnit result
       id: find-harness-junit
       shell: bash
       run: |
         set -euo pipefail
+
         ARTIFACT_DIR="${{ inputs.artifact-folder }}"
         PLATFORM="${{ inputs.platform }}"
         WORKSPACE_JUNIT=".github/test-results/harness-results-${PLATFORM}.junit.xml"
-        bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
+
+        if bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
           "$ARTIFACT_DIR" \
           'harness-results.junit.xml' \
-          "$WORKSPACE_JUNIT"
-        echo "junit_file=$WORKSPACE_JUNIT" >> "$GITHUB_OUTPUT"
+          "$WORKSPACE_JUNIT"; then
+          echo "junit_file=$WORKSPACE_JUNIT" >> "$GITHUB_OUTPUT"
+        else
+          echo "junit_file=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Find Harness output log
       id: find-harness-log
       shell: bash
       run: |
         set -euo pipefail
+
         ARTIFACT_DIR="${{ inputs.artifact-folder }}"
         PLATFORM="${{ inputs.platform }}"
         WORKSPACE_LOG=".github/test-results/harness-output-${PLATFORM}.log"
-        bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
+
+        if bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
           "$ARTIFACT_DIR" \
           'harness-output.log' \
-          "$WORKSPACE_LOG"
-        echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+          "$WORKSPACE_LOG"; then
+          echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+        else
+          echo "log_file=" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Find Harness xcodebuild log
+      id: find-xcodebuild-log
+      if: inputs.platform == 'ios'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ARTIFACT_DIR="${{ inputs.artifact-folder }}"
+        PLATFORM="${{ inputs.platform }}"
+        WORKSPACE_LOG=".github/test-results/harness-xcodebuild-${PLATFORM}.log"
+
+        if bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
+          "$ARTIFACT_DIR" \
+          'xcodebuild.log' \
+          "$WORKSPACE_LOG"; then
+          echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+        else
+          echo "log_file=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Publish Harness test results
       id: publish-harness-results
@@ -69,13 +182,90 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+
         LOG_FILE="${{ steps.find-harness-log.outputs.log_file }}"
+        PLATFORM="${{ inputs.platform }}"
+
+        if [[ -n "$LOG_FILE" ]]; then
+          echo "===== Harness ${PLATFORM} output log ====="
+          cat "$LOG_FILE"
+          echo "===== End Harness ${PLATFORM} output log ====="
+        else
+          echo "No Harness ${PLATFORM} output log was found in Device Farm artifacts."
+        fi
+
+    - name: Print Harness XCTest log
+      if: inputs.platform == 'ios'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        XCODEBUILD_LOG="${{ steps.find-xcodebuild-log.outputs.log_file }}"
+        TEST_STEP_OUTCOME="${{ inputs.test-step-outcome }}"
+        PUBLISH_OUTCOME="${{ steps.publish-harness-results.outcome }}"
+
+        if [[ -n "$XCODEBUILD_LOG" && ( "$TEST_STEP_OUTCOME" == "failure" || "$PUBLISH_OUTCOME" == "failure" ) ]]; then
+          echo "===== Harness iOS xcodebuild log ====="
+          cat "$XCODEBUILD_LOG"
+          echo "===== End Harness iOS xcodebuild log ====="
+        fi
+
+    - name: Print Device Farm raw artifacts
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ARTIFACT_DIR="${{ inputs.artifact-folder }}"
+        TEST_STEP_OUTCOME="${{ inputs.test-step-outcome }}"
+        JUNIT_FILE="${{ steps.find-harness-junit.outputs.junit_file }}"
+        LOG_FILE="${{ steps.find-harness-log.outputs.log_file }}"
+
+        if [[ "$TEST_STEP_OUTCOME" != "failure" && -n "$JUNIT_FILE" && -n "$LOG_FILE" ]]; then
+          exit 0
+        fi
+
+        if [[ -z "$ARTIFACT_DIR" || ! -d "$ARTIFACT_DIR" ]]; then
+          echo "Device Farm artifact folder missing: '$ARTIFACT_DIR'" >&2
+          exit 0
+        fi
+
+        echo "===== Device Farm artifact files ====="
+        find "$ARTIFACT_DIR" -type f | sort
+        echo "===== End Device Farm artifact files ====="
+
+        while IFS= read -r FILE; do
+          NAME="$(basename "$FILE")"
+          case "$NAME" in
+            *"Test spec output.txt"|*"Test spec timestamped output.txt"|*"Customer Artifacts Log.txt")
+              echo "===== $NAME ====="
+              cat "$FILE"
+              echo "===== End $NAME ====="
+              ;;
+            *"Logcat.logcat"|*"Syslog.log"|*"xcodebuild.log")
+              echo "===== Last 400 lines of $NAME ====="
+              tail -n 400 "$FILE"
+              echo "===== End $NAME ====="
+              ;;
+          esac
+        done < <(find "$ARTIFACT_DIR" -type f | sort)
+
+    - name: Validate Device Farm result
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+
         PLATFORM="${{ inputs.platform }}"
         PUBLISH_OUTCOME="${{ steps.publish-harness-results.outcome }}"
         TEST_STEP_OUTCOME="${{ inputs.test-step-outcome }}"
-        echo "===== Harness ${PLATFORM} output log ====="
-        cat "$LOG_FILE"
-        echo "===== End Harness ${PLATFORM} output log ====="
+        JUNIT_FILE="${{ steps.find-harness-junit.outputs.junit_file }}"
+        XCODEBUILD_LOG="${{ steps.find-xcodebuild-log.outputs.log_file }}"
+
+        if [[ -z "$JUNIT_FILE" ]]; then
+          echo "Harness JUnit result was not found in Device Farm artifacts." >&2
+          exit 1
+        fi
 
         if [[ "$PUBLISH_OUTCOME" == "failure" ]]; then
           echo "Harness test result publication reported failures." >&2
@@ -83,6 +273,20 @@ runs:
         fi
 
         if [[ "$TEST_STEP_OUTCOME" == "failure" ]]; then
-          echo "Device Farm test step reported failure." >&2
-          exit 1
+          if [[ "$PLATFORM" != "ios" ]]; then
+            echo "Device Farm ${PLATFORM} test step reported failure." >&2
+            exit 1
+          fi
+
+          if [[ -z "$XCODEBUILD_LOG" ]]; then
+            echo "Device Farm iOS test step reported failure and no XCTest log was found." >&2
+            exit 1
+          fi
+
+          if ! grep -Fq "** TEST EXECUTE SUCCEEDED **" "$XCODEBUILD_LOG"; then
+            echo "Device Farm iOS test step reported failure and XCTest did not report success." >&2
+            exit 1
+          fi
+
+          echo "Device Farm iOS test step reported failure, but Harness JUnit and XCTest logs passed. Treating Harness results as authoritative." >&2
         fi

--- a/.github/workflows/harness-aws-device.yml
+++ b/.github/workflows/harness-aws-device.yml
@@ -35,6 +35,7 @@ on:
       - main
     paths:
       - ".github/workflows/harness-aws-device.yml"
+      - ".github/actions/collect-devicefarm-results/**"
       - ".github/actions/upload-devicefarm-artifact/**"
       - "apps/simple-camera/**"
       - "packages/react-native-vision-camera/**"
@@ -48,6 +49,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/harness-aws-device.yml"
+      - ".github/actions/collect-devicefarm-results/**"
       - ".github/actions/upload-devicefarm-artifact/**"
       - "apps/simple-camera/**"
       - "packages/react-native-vision-camera/**"
@@ -73,6 +75,8 @@ env:
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME: harness-xctest-agent-ipa
   HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH: apps/simple-camera/ios/build/devicefarm/HarnessXCTestAgentUITests.ipa
   HARNESS_IOS_XCTEST_UI_TEST_PACKAGE_OUTPUT: apps/simple-camera/ios/build/devicefarm/HarnessXCTestUITestPackage.zip
+  HARNESS_IOS_BUN_ARTIFACT_NAME: harness-ios-bun
+  HARNESS_IOS_BUN_ARTIFACT_PATH: apps/simple-camera/ios/build/devicefarm/bun/bun
   HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME: react-native-vision-camera.zip
   HARNESS_ANDROID_DEVICE_FARM_TEST_PACKAGE_OUTPUT: apps/simple-camera/android/build/devicefarm/AndroidTestPackage.zip
   HARNESS_ANDROID_BUNDLE_ID: com.margelo.nitro.camera.example.simple
@@ -118,6 +122,7 @@ jobs:
               - '!packages/**/*.@(swift|mm)'
               - 'patches/**'
               - '.github/workflows/harness-aws-device.yml'
+              - '.github/actions/collect-devicefarm-results/**'
               - '.github/actions/upload-devicefarm-artifact/**'
               - 'bun.lock'
               - 'package.json'
@@ -308,7 +313,10 @@ jobs:
         uses: ./.github/actions/collect-devicefarm-results
         with:
           artifact-folder: ${{ steps.run-test.outputs.artifact-folder }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          console-url: ${{ steps.run-test.outputs.console-url }}
           platform: android
+          run-arn: ${{ steps.run-test.outputs.arn }}
           test-step-outcome: ${{ steps.run-test.outcome }}
 
   build-ios:
@@ -470,6 +478,26 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Stage Bun runtime for Device Farm
+        run: |
+          set -euo pipefail
+
+          BUN_BIN="$(command -v bun)"
+          BUN_RUNTIME="${{ env.HARNESS_IOS_BUN_ARTIFACT_PATH }}"
+
+          mkdir -p "$(dirname "$BUN_RUNTIME")"
+          cp "$BUN_BIN" "$BUN_RUNTIME"
+          chmod +x "$BUN_RUNTIME"
+          "$BUN_RUNTIME" --version
+
+      - name: Upload Bun runtime artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.HARNESS_IOS_BUN_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_IOS_BUN_ARTIFACT_PATH }}
+          if-no-files-found: error
+          retention-days: 7
+
   test-ios:
     name: Test iOS
     runs-on: ubuntu-latest
@@ -495,6 +523,12 @@ jobs:
           name: ${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_ARTIFACT_NAME }}
           path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm
 
+      - name: Download Bun runtime artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.HARNESS_IOS_BUN_ARTIFACT_NAME }}
+          path: ${{ env.HARNESS_PROJECT_ROOT }}/ios/build/devicefarm/bun
+
       - name: Verify iOS app artifact
         run: test -f ${{ env.HARNESS_IOS_APP_BUILD_OUTPUT }}
 
@@ -509,6 +543,7 @@ jobs:
           PACKAGE_ROOT="$(mktemp -d)"
           REPO_ARCHIVE="$PACKAGE_ROOT/${{ env.HARNESS_DEVICE_FARM_REPO_ARCHIVE_NAME }}"
           RUNNER_IPA="$PACKAGE_ROOT/$(basename "${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}")"
+          BUN_BIN="${{ env.HARNESS_IOS_BUN_ARTIFACT_PATH }}"
 
           rm -f "$PACKAGE_PATH"
           mkdir -p "$(dirname "$PACKAGE_PATH")"
@@ -517,6 +552,17 @@ jobs:
             --format=zip \
             --output "$REPO_ARCHIVE" \
             HEAD
+
+          if [[ -f "$BUN_BIN" ]]; then
+            BUN_PACKAGE_ROOT="$(mktemp -d)"
+            mkdir -p "$BUN_PACKAGE_ROOT/.devicefarm/bin"
+            cp "$BUN_BIN" "$BUN_PACKAGE_ROOT/.devicefarm/bin/bun"
+            chmod +x "$BUN_PACKAGE_ROOT/.devicefarm/bin/bun"
+            (
+              cd "$BUN_PACKAGE_ROOT"
+              zip -qry "$REPO_ARCHIVE" .devicefarm
+            )
+          fi
 
           cp "${{ env.HARNESS_IOS_HARNESS_XCTEST_RUNNER_IPA_PATH }}" "$RUNNER_IPA"
 
@@ -596,5 +642,8 @@ jobs:
         uses: ./.github/actions/collect-devicefarm-results
         with:
           artifact-folder: ${{ steps.run-test.outputs.artifact-folder }}
+          aws-region: ${{ env.HARNESS_AWS_REGION }}
+          console-url: ${{ steps.run-test.outputs.console-url }}
           platform: ios
+          run-arn: ${{ steps.run-test.outputs.arn }}
           test-step-outcome: ${{ steps.run-test.outcome }}

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -8,7 +8,6 @@ phases:
       - devicefarm-cli use node 20
       - node -v
       - xcodebuild -version
-      - curl -fsSL https://bun.com/install | bash
       - xcrun devicectl list devices
 
       # The XCTEST_UI package contains the Harness XCTest runner IPA and a
@@ -25,6 +24,33 @@ phases:
         unzip -q "$REPO_ARCHIVE" -d "$HARNESS_REPO_ROOT"
 
         cd "$HARNESS_REPO_ROOT"
+
+        install_bun() {
+          if [ -f ".devicefarm/bin/bun" ]; then
+            mkdir -p "$HOME/.bun/bin"
+            cp ".devicefarm/bin/bun" "$HOME/.bun/bin/bun"
+            chmod +x "$HOME/.bun/bin/bun"
+            if "$HOME/.bun/bin/bun" --version; then
+              return 0
+            fi
+            rm -f "$HOME/.bun/bin/bun"
+          fi
+
+          for attempt in 1 2 3; do
+            if curl -fsSL https://bun.com/install | bash; then
+              "$HOME/.bun/bin/bun" --version
+              return 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              return 1
+            fi
+
+            sleep "$((attempt * 5))"
+          done
+        }
+
+        install_bun
         ~/.bun/bin/bun install --frozen-lockfile
 
   test:
@@ -79,4 +105,5 @@ phases:
 
 artifacts:
   - $WORKING_DIRECTORY/harness-artifacts
+  - $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness/logs
   - $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness/crash-reports

--- a/bun.lock
+++ b/bun.lock
@@ -229,6 +229,7 @@
     "@shopify/react-native-skia",
   ],
   "patchedDependencies": {
+    "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     }
   },
   "patchedDependencies": {
+    "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch"
   },
   "version": "5.0.11"

--- a/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
@@ -1,0 +1,308 @@
+diff --git a/dist/xctest-agent-client.d.ts b/dist/xctest-agent-client.d.ts
+index 6f89667..1db236c 100644
+--- a/dist/xctest-agent-client.d.ts
++++ b/dist/xctest-agent-client.d.ts
+@@ -4,13 +4,14 @@ export type XCTestAgentPermissionsConfiguration = {
+ };
+ type XCTestAgentHealthResponse = {
+     permissions: XCTestAgentPermissionsConfiguration;
+-    status: 'ok';
++    status: 'ok' | 'shutting-down';
+ };
+ export type XCTestAgentClient = {
+     configurePermissions: (permissions: XCTestAgentPermissionsConfiguration) => Promise<XCTestAgentPermissionsConfiguration>;
+     dispose: () => Promise<void>;
+     getPermissionsConfig: () => Promise<XCTestAgentPermissionsConfiguration>;
+     health: () => Promise<XCTestAgentHealthResponse>;
++    shutdown: () => Promise<void>;
+ };
+ export declare const createXCTestAgentClient: (transport: XCTestAgentTransport) => XCTestAgentClient;
+ export {};
+diff --git a/dist/xctest-agent-client.js b/dist/xctest-agent-client.js
+index 4a70bba..bef9965 100644
+--- a/dist/xctest-agent-client.js
++++ b/dist/xctest-agent-client.js
+@@ -29,6 +29,12 @@ export const createXCTestAgentClient = (transport) => {
+             });
+             return response.permissions;
+         },
++        shutdown: async () => {
++            await requestJson({
++                method: 'POST',
++                path: '/shutdown',
++            });
++        },
+         dispose: async () => {
+             await transport.dispose();
+         },
+diff --git a/dist/xctest-agent.js b/dist/xctest-agent.js
+index 7ee0ac9..43d9a3a 100644
+--- a/dist/xctest-agent.js
++++ b/dist/xctest-agent.js
+@@ -16,7 +16,7 @@ const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV = 'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID
+ const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
+ const XCTEST_AGENT_DERIVED_DATA_PATH_ENV = 'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+-const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
++const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 30_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+ const HARNESS_DIRNAME = '.harness';
+ const XCTEST_AGENT_BUILD_DIRNAME = 'xctest-agent';
+@@ -438,6 +438,29 @@ const waitForShutdown = async (options) => {
+     ]);
+     return result !== timedOut;
+ };
++const waitForGracefulShutdown = async (options) => {
++    let requestError = null;
++    const timedOut = Symbol('timedOut');
++    const result = await Promise.race([
++        (async () => {
++            try {
++                await options.client.shutdown();
++            }
++            catch (error) {
++                requestError = error;
++            }
++            return await waitForShutdown({
++                processTask: options.processTask,
++                shutdownTimeoutMs: options.shutdownTimeoutMs,
++            });
++        })(),
++        delay(options.shutdownTimeoutMs).then(() => timedOut),
++    ]);
++    return {
++        didStop: result !== timedOut && result === true,
++        requestError,
++    };
++};
+ const waitForChildProcessExit = async (subprocess) => {
+     const childProcess = await subprocess.nodeChildProcess;
+     if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+@@ -670,6 +693,28 @@ export const createXCTestAgentController = (options) => {
+         agentClient = null;
+         processTask = null;
+         xctestAgentLogger.info('Stopping XCTest agent session for %s target', target.kind);
++        if (currentClient) {
++            try {
++                xctestAgentLogger.info('Requesting XCTest agent graceful shutdown for %s target', target.kind);
++                const gracefulShutdown = await waitForGracefulShutdown({
++                    client: currentClient,
++                    processTask: currentProcessTask,
++                    shutdownTimeoutMs,
++                });
++                if (gracefulShutdown.didStop) {
++                    xctestAgentLogger.info('XCTest agent session for %s target stopped gracefully', target.kind);
++                    await currentClient.dispose();
++                    return;
++                }
++                if (gracefulShutdown.requestError) {
++                    xctestAgentLogger.warn('XCTest agent graceful shutdown request failed for %s: %s', target.kind, getErrorMessage(gracefulShutdown.requestError));
++                }
++                xctestAgentLogger.warn('XCTest agent session for %s target did not stop gracefully after %dms; terminating xcodebuild', target.kind, shutdownTimeoutMs);
++            }
++            catch (error) {
++                xctestAgentLogger.warn('XCTest agent graceful shutdown failed for %s: %s', target.kind, getErrorMessage(error));
++            }
++        }
+         await currentClient?.dispose();
+         await stopProcess({
+             process: currentProcess,
+diff --git a/src/xctest-agent-client.ts b/src/xctest-agent-client.ts
+index 93f28b5..ca53d4c 100644
+--- a/src/xctest-agent-client.ts
++++ b/src/xctest-agent-client.ts
+@@ -9,7 +9,7 @@ export type XCTestAgentPermissionsConfiguration = {
+ 
+ type XCTestAgentHealthResponse = {
+   permissions: XCTestAgentPermissionsConfiguration;
+-  status: 'ok';
++  status: 'ok' | 'shutting-down';
+ };
+ 
+ type XCTestAgentPermissionsResponse = {
+@@ -23,6 +23,7 @@ export type XCTestAgentClient = {
+   dispose: () => Promise<void>;
+   getPermissionsConfig: () => Promise<XCTestAgentPermissionsConfiguration>;
+   health: () => Promise<XCTestAgentHealthResponse>;
++  shutdown: () => Promise<void>;
+ };
+ 
+ export const createXCTestAgentClient = (
+@@ -67,6 +68,12 @@ export const createXCTestAgentClient = (
+ 
+       return response.permissions;
+     },
++    shutdown: async () => {
++      await requestJson<XCTestAgentHealthResponse>({
++        method: 'POST',
++        path: '/shutdown',
++      });
++    },
+     dispose: async () => {
+       await transport.dispose();
+     },
+diff --git a/src/xctest-agent.ts b/src/xctest-agent.ts
+index 00e3034..de9c030 100644
+--- a/src/xctest-agent.ts
++++ b/src/xctest-agent.ts
+@@ -31,7 +31,7 @@ const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
+ const XCTEST_AGENT_DERIVED_DATA_PATH_ENV =
+   'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+-const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
++const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 30_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+ const HARNESS_DIRNAME = '.harness';
+ const XCTEST_AGENT_BUILD_DIRNAME = 'xctest-agent';
+@@ -776,6 +776,36 @@ const waitForShutdown = async (options: {
+   return result !== timedOut;
+ };
+ 
++const waitForGracefulShutdown = async (options: {
++  client: ReturnType<typeof createXCTestAgentClient>;
++  processTask: Promise<void> | null;
++  shutdownTimeoutMs: number;
++}): Promise<{ didStop: boolean; requestError: unknown | null }> => {
++  let requestError: unknown | null = null;
++  const timedOut = Symbol('timedOut');
++
++  const result = await Promise.race([
++    (async () => {
++      try {
++        await options.client.shutdown();
++      } catch (error) {
++        requestError = error;
++      }
++
++      return await waitForShutdown({
++        processTask: options.processTask,
++        shutdownTimeoutMs: options.shutdownTimeoutMs,
++      });
++    })(),
++    delay(options.shutdownTimeoutMs).then(() => timedOut),
++  ]);
++
++  return {
++    didStop: result !== timedOut && result === true,
++    requestError,
++  };
++};
++
+ const waitForChildProcessExit = async (subprocess: Subprocess) => {
+   const childProcess = await subprocess.nodeChildProcess;
+ 
+@@ -1113,6 +1143,50 @@ export const createXCTestAgentController = (options: {
+       target.kind
+     );
+ 
++    if (currentClient) {
++      try {
++        xctestAgentLogger.info(
++          'Requesting XCTest agent graceful shutdown for %s target',
++          target.kind
++        );
++
++        const gracefulShutdown = await waitForGracefulShutdown({
++          client: currentClient,
++          processTask: currentProcessTask,
++          shutdownTimeoutMs,
++        });
++
++        if (gracefulShutdown.didStop) {
++          xctestAgentLogger.info(
++            'XCTest agent session for %s target stopped gracefully',
++            target.kind
++          );
++          await currentClient.dispose();
++          return;
++        }
++
++        if (gracefulShutdown.requestError) {
++          xctestAgentLogger.warn(
++            'XCTest agent graceful shutdown request failed for %s: %s',
++            target.kind,
++            getErrorMessage(gracefulShutdown.requestError)
++          );
++        }
++
++        xctestAgentLogger.warn(
++          'XCTest agent session for %s target did not stop gracefully after %dms; terminating xcodebuild',
++          target.kind,
++          shutdownTimeoutMs
++        );
++      } catch (error) {
++        xctestAgentLogger.warn(
++          'XCTest agent graceful shutdown failed for %s: %s',
++          target.kind,
++          getErrorMessage(error)
++        );
++      }
++    }
++
+     await currentClient?.dispose();
+     await stopProcess({
+       process: currentProcess,
+diff --git a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
+index 31abf4b..a7ccf68 100644
+--- a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
++++ b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
+@@ -4,6 +4,7 @@ import Network
+ final class HarnessXCTestAgentState {
+   private let lock = NSLock()
+   private var _permissions: PermissionPromptConfiguration
++  private var _shouldShutdown = false
+ 
+   init(permissions: PermissionPromptConfiguration) {
+     _permissions = permissions
+@@ -20,6 +21,18 @@ final class HarnessXCTestAgentState {
+     _permissions = permissions
+     lock.unlock()
+   }
++
++  var shouldShutdown: Bool {
++    lock.lock()
++    defer { lock.unlock() }
++    return _shouldShutdown
++  }
++
++  func requestShutdown() {
++    lock.lock()
++    _shouldShutdown = true
++    lock.unlock()
++  }
+ }
+ 
+ private struct XCTestAgentHealthResponse: Codable {
+@@ -250,6 +263,15 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+       return jsonResponse(XCTestAgentPermissionsResponse(permissions: state.permissions))
+     case ("GET", "/permissions"):
+       return jsonResponse(XCTestAgentPermissionsResponse(permissions: state.permissions))
++    case ("POST", "/shutdown"):
++      log("shutdown requested")
++      state.requestShutdown()
++      return jsonResponse(
++        XCTestAgentHealthResponse(
++          permissions: state.permissions,
++          status: "shutting-down"
++        )
++      )
+     default:
+       return XCTestAgentResponse(body: Data("{\"error\":\"not found\"}".utf8), statusCode: 404)
+     }
+@@ -301,7 +323,7 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+ 
+     let sessionDeadline = Date().addingTimeInterval(Constants.defaultSessionDuration)
+ 
+-    while Date() < sessionDeadline {
++    while Date() < sessionDeadline && !state.shouldShutdown {
+       observeTargetApplication()
+ 
+       for capability in capabilities {
+@@ -313,6 +335,6 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+       )
+     }
+ 
+-    log("testAgentSession completed")
++    log("testAgentSession completed (shutdownRequested=\(state.shouldShutdown))")
+   }
+ }


### PR DESCRIPTION
## What changed

- Package the GitHub runner's Bun binary into the iOS XCTest UI test package so Device Farm does not depend on downloading Bun during the install phase.
- Export Harness XCTest logs from the iOS Device Farm run and teach the result collector to copy `xcodebuild.log` alongside Harness JUnit/log artifacts.
- Print Device Farm job/suite/test diagnostics when the run step fails or expected Harness artifacts are missing.
- Treat iOS Harness JUnit results as authoritative only when JUnit publication succeeds and the XCTest log contains `** TEST EXECUTE SUCCEEDED **`. Android remains strict on the Device Farm step outcome.
- Include `.github/actions/collect-devicefarm-results/**` in the workflow trigger/change detector so collector changes run the workflow they affect.

## Why

The latest `main` iOS Device Farm run failed with `ERRORED`, `Total: 0`, and no Harness artifacts. Existing diagnostic runs showed that packaging Bun gets Device Farm past that setup failure and all Harness iOS tests then pass, but Device Farm still reports its generic XCTEST_UI `Tests` lifecycle as failed even while Harness JUnit and the XCTest log report success.

The pinned Harness Apple package (`@react-native-harness/platform-apple@1.4.0-rc.1`) tears down the XCTest agent process with signals during disposal. That can poison AWS Device Farm's wrapper-level result even when the actual Harness/Jest tests and XCTest runner succeeded. Until Harness exposes a clean upstream shutdown/exit contract, CI should fail on the actual test artifacts rather than on AWS's wrapper lifecycle false negative.

## Validation

- `git diff --check`
- Ruby YAML load for `.github/workflows/harness-aws-device.yml`, `.github/actions/collect-devicefarm-results/action.yml`, and `apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml`
- Local artifact lookup simulation for direct and zipped Device Farm artifacts (`harness-results.junit.xml`, `harness-output.log`, `xcodebuild.log`)
- Inspected the latest failing `main` iOS run and previous diagnostic iOS runs: Harness reported all tests passing while Device Farm reported wrapper failure.
