### PR TITLE
fix: finish iOS Harness XCTest runs cleanly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+patches/*.patch -whitespace

--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -19,6 +19,9 @@ outputs:
   log-file:
     description: Copied harness log file path
     value: ${{ steps.find-harness-log.outputs.log_file }}
+  xcodebuild-log-file:
+    description: Copied iOS XCTest xcodebuild log file path
+    value: ${{ steps.find-xcodebuild-log.outputs.log_file }}
 
 runs:
   using: composite
@@ -51,6 +54,23 @@ runs:
           "$WORKSPACE_LOG"
         echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
 
+    - name: Find Harness XCTest log
+      id: find-xcodebuild-log
+      if: inputs.platform == 'ios'
+      shell: bash
+      run: |
+        set -euo pipefail
+        ARTIFACT_DIR="${{ inputs.artifact-folder }}"
+        WORKSPACE_LOG=".github/test-results/harness-xcodebuild-ios.log"
+        if bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
+          "$ARTIFACT_DIR" \
+          'xcodebuild.log' \
+          "$WORKSPACE_LOG"; then
+          echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+        else
+          echo "log_file=" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Publish Harness test results
       id: publish-harness-results
       if: steps.find-harness-junit.outputs.junit_file != ''
@@ -76,6 +96,13 @@ runs:
         echo "===== Harness ${PLATFORM} output log ====="
         cat "$LOG_FILE"
         echo "===== End Harness ${PLATFORM} output log ====="
+
+        XCODEBUILD_LOG="${{ steps.find-xcodebuild-log.outputs.log_file }}"
+        if [[ -n "$XCODEBUILD_LOG" && ( "$TEST_STEP_OUTCOME" == "failure" || "$PUBLISH_OUTCOME" == "failure" ) ]]; then
+          echo "===== Harness ${PLATFORM} xcodebuild log ====="
+          cat "$XCODEBUILD_LOG"
+          echo "===== End Harness ${PLATFORM} xcodebuild log ====="
+        fi
 
         if [[ "$PUBLISH_OUTCOME" == "failure" ]]; then
           echo "Harness test result publication reported failures." >&2

--- a/.github/actions/collect-devicefarm-results/action.yml
+++ b/.github/actions/collect-devicefarm-results/action.yml
@@ -22,6 +22,9 @@ outputs:
   xcodebuild-log-file:
     description: Copied iOS XCTest xcodebuild log file path
     value: ${{ steps.find-xcodebuild-log.outputs.log_file }}
+  customer-artifacts-log-file:
+    description: Copied Device Farm customer artifacts log file path
+    value: ${{ steps.find-customer-artifacts-log.outputs.log_file }}
 
 runs:
   using: composite
@@ -71,6 +74,23 @@ runs:
           echo "log_file=" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Find Device Farm customer artifacts log
+      id: find-customer-artifacts-log
+      shell: bash
+      run: |
+        set -euo pipefail
+        ARTIFACT_DIR="${{ inputs.artifact-folder }}"
+        PLATFORM="${{ inputs.platform }}"
+        WORKSPACE_LOG=".github/test-results/devicefarm-customer-artifacts-${PLATFORM}.log"
+        if bash "$GITHUB_ACTION_PATH/../../scripts/find-devicefarm-artifact.sh" \
+          "$ARTIFACT_DIR" \
+          '*-Customer Artifacts Log.txt' \
+          "$WORKSPACE_LOG"; then
+          echo "log_file=$WORKSPACE_LOG" >> "$GITHUB_OUTPUT"
+        else
+          echo "log_file=" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Publish Harness test results
       id: publish-harness-results
       if: steps.find-harness-junit.outputs.junit_file != ''
@@ -102,6 +122,13 @@ runs:
           echo "===== Harness ${PLATFORM} xcodebuild log ====="
           cat "$XCODEBUILD_LOG"
           echo "===== End Harness ${PLATFORM} xcodebuild log ====="
+        fi
+
+        CUSTOMER_ARTIFACTS_LOG="${{ steps.find-customer-artifacts-log.outputs.log_file }}"
+        if [[ -n "$CUSTOMER_ARTIFACTS_LOG" && "$TEST_STEP_OUTCOME" == "failure" ]]; then
+          echo "===== Device Farm ${PLATFORM} customer artifacts log ====="
+          cat "$CUSTOMER_ARTIFACTS_LOG"
+          echo "===== End Device Farm ${PLATFORM} customer artifacts log ====="
         fi
 
         if [[ "$PUBLISH_OUTCOME" == "failure" ]]; then

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -79,7 +79,3 @@ phases:
 
 artifacts:
   - $WORKING_DIRECTORY/harness-artifacts
-  # Keep this at the Harness root. Device Farm treats an explicitly listed
-  # empty artifact directory as a failed test step, and crash-reports is empty
-  # on successful native runs.
-  - $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -79,4 +79,7 @@ phases:
 
 artifacts:
   - $WORKING_DIRECTORY/harness-artifacts
-  - $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness/crash-reports
+  # Keep this at the Harness root. Device Farm treats an explicitly listed
+  # empty artifact directory as a failed test step, and crash-reports is empty
+  # on successful native runs.
+  - $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness

--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -33,7 +33,7 @@ phases:
       - HARNESS_JUNIT="$HARNESS_ARTIFACTS/harness-results.junit.xml"
       - HARNESS_LOG="$HARNESS_ARTIFACTS/harness-output.log"
       - HARNESS_METRO_HOST_FILE="$HARNESS_ARTIFACTS/metro-host-ip.txt"
-      - mkdir -p "$HARNESS_ARTIFACTS" "$WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness/crash-reports"
+      - mkdir -p "$HARNESS_ARTIFACTS"
 
       # Resolve host IPv6 for Metro. On macOS runners IPv4 won't work, as
       # confirmed by AWS support. AWS recommends utun interfaces for this.

--- a/bun.lock
+++ b/bun.lock
@@ -230,7 +230,9 @@
   ],
   "patchedDependencies": {
     "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
+    "@react-native-harness/bridge@1.4.0-rc.1": "patches/@react-native-harness%2Fbridge@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch",
+    "@react-native-harness/cli@1.4.0-rc.1": "patches/@react-native-harness%2Fcli@1.4.0-rc.1.patch",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/bun.lock
+++ b/bun.lock
@@ -229,6 +229,7 @@
     "@shopify/react-native-skia",
   ],
   "patchedDependencies": {
+    "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     }
   },
   "patchedDependencies": {
+    "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch"
   },
   "version": "5.0.11"

--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     }
   },
   "patchedDependencies": {
+    "@react-native-harness/bridge@1.4.0-rc.1": "patches/@react-native-harness%2Fbridge@1.4.0-rc.1.patch",
+    "@react-native-harness/cli@1.4.0-rc.1": "patches/@react-native-harness%2Fcli@1.4.0-rc.1.patch",
     "@react-native-harness/platform-apple@1.4.0-rc.1": "patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch",
     "react-native@0.85.3": "patches/react-native@0.85.3.patch"
   },

--- a/patches/@react-native-harness%2Fbridge@1.4.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fbridge@1.4.0-rc.1.patch
@@ -1,0 +1,145 @@
+diff --git a/dist/server.d.ts b/dist/server.d.ts
+index be42f719cc837e28e3eeacb342ffab4b57ee5a81..5da6a6055183ef7d7bc532d0fa7fb6fc5e65d90b 100644
+--- a/dist/server.d.ts
++++ b/dist/server.d.ts
+@@ -31,7 +31,7 @@ export type HarnessBridge = {
+     nextConnection: (signal?: AbortSignal) => Promise<AppConnection>;
+     on: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => void;
+     off: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => void;
+-    dispose: () => void;
++    dispose: () => Promise<void>;
+ };
+ export declare const createHarnessBridge: (options: HarnessBridgeOptions) => Promise<HarnessBridge>;
+ //# sourceMappingURL=server.d.ts.map
+diff --git a/dist/server.js b/dist/server.js
+index 16ba50eaab5636872b26f5f85ec607f68ef7c08b..84bb166b6ae7c122934c2d1cebfe4b1ddd7aec50 100644
+--- a/dist/server.js
++++ b/dist/server.js
+@@ -43,7 +43,17 @@ export const createHarnessBridge = async (options) => {
+     const emitter = new EventEmitter();
+     let currentConnection = null;
+     let activeSession = null;
++    let disposePromise = null;
+     const connectionWaiters = [];
++    const closeServer = () => new Promise((resolve, reject) => {
++        wss.close((error) => {
++            if (error) {
++                reject(error);
++                return;
++            }
++            resolve();
++        });
++    });
+     wss.on('connection', (ws) => {
+         if (activeSession) {
+             bridgeLogger.info('replacing existing app connection with a newer client');
+@@ -202,16 +212,23 @@ export const createHarnessBridge = async (options) => {
+         on: (event, listener) => emitter.on(event, listener),
+         off: (event, listener) => emitter.off(event, listener),
+         dispose: () => {
+-            bridgeLogger.debug('disposing bridge');
+-            for (const { reject } of connectionWaiters.splice(0)) {
+-                reject(new AppBridgeDisconnectedError('bridge-disposed'));
+-            }
+-            activeSession?.disconnect(new AppBridgeDisconnectedError('bridge-disposed'));
+-            for (const client of wss.clients) {
+-                client.terminate();
+-            }
+-            wss.close();
+-            emitter.removeAllListeners();
++            disposePromise ??= (async () => {
++                bridgeLogger.debug('disposing bridge');
++                for (const { reject } of connectionWaiters.splice(0)) {
++                    reject(new AppBridgeDisconnectedError('bridge-disposed'));
++                }
++                activeSession?.disconnect(new AppBridgeDisconnectedError('bridge-disposed'));
++                for (const client of wss.clients) {
++                    client.terminate();
++                }
++                try {
++                    await closeServer();
++                }
++                finally {
++                    emitter.removeAllListeners();
++                }
++            })();
++            return disposePromise;
+         },
+     };
+ };
+diff --git a/src/server.ts b/src/server.ts
+index 3cded6184d33110309ae5cc76ddef868a83ce047..d44433181dbd7cc256875b5f31cab8b1179630ae 100644
+--- a/src/server.ts
++++ b/src/server.ts
+@@ -68,7 +68,7 @@ export type HarnessBridge = {
+   nextConnection: (signal?: AbortSignal) => Promise<AppConnection>;
+   on: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => void;
+   off: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => void;
+-  dispose: () => void;
++  dispose: () => Promise<void>;
+ };
+ 
+ const createWss = (transport: TransportOptions): Promise<WebSocketServer> => {
+@@ -118,11 +118,24 @@ export const createHarnessBridge = async (
+   let currentConnection: AppConnection | null = null;
+   let activeSession: { disconnect: (reason?: Error) => void; transport: BridgeTransport } | null =
+     null;
++  let disposePromise: Promise<void> | null = null;
+   const connectionWaiters: Array<{
+     resolve: (c: AppConnection) => void;
+     reject: (e: unknown) => void;
+   }> = [];
+ 
++  const closeServer = (): Promise<void> =>
++    new Promise((resolve, reject) => {
++      wss.close((error) => {
++        if (error) {
++          reject(error);
++          return;
++        }
++
++        resolve();
++      });
++    });
++
+   wss.on('connection', (ws: WebSocket) => {
+     if (activeSession) {
+       bridgeLogger.info('replacing existing app connection with a newer client');
+@@ -328,20 +341,27 @@ export const createHarnessBridge = async (
+     on: (event, listener) => emitter.on(event, listener),
+     off: (event, listener) => emitter.off(event, listener),
+     dispose: () => {
+-      bridgeLogger.debug('disposing bridge');
++      disposePromise ??= (async () => {
++        bridgeLogger.debug('disposing bridge');
+ 
+-      for (const { reject } of connectionWaiters.splice(0)) {
+-        reject(new AppBridgeDisconnectedError('bridge-disposed'));
+-      }
++        for (const { reject } of connectionWaiters.splice(0)) {
++          reject(new AppBridgeDisconnectedError('bridge-disposed'));
++        }
+ 
+-      activeSession?.disconnect(new AppBridgeDisconnectedError('bridge-disposed'));
++        activeSession?.disconnect(new AppBridgeDisconnectedError('bridge-disposed'));
+ 
+-      for (const client of wss.clients) {
+-        client.terminate();
+-      }
++        for (const client of wss.clients) {
++          client.terminate();
++        }
++
++        try {
++          await closeServer();
++        } finally {
++          emitter.removeAllListeners();
++        }
++      })();
+ 
+-      wss.close();
+-      emitter.removeAllListeners();
++      return disposePromise;
+     },
+   };
+ };

--- a/patches/@react-native-harness%2Fcli@1.4.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fcli@1.4.0-rc.1.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.js b/dist/index.js
+index b1054c2bd34b2383e95b18cec1fe23e602e2131f..b410f2163d2c25277ee0fc86faf8ef076a5cc398 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -182,7 +182,7 @@ const main = async () => {
+         cwd: process.cwd(),
+     });
+     await checkForOldConfig();
+-    run();
++    await run();
+ };
+ main().catch((error) => {
+     console.error(getErrorMessage(error));
+diff --git a/src/index.ts b/src/index.ts
+index af488bd42934870e44e0cd03300f26fe174646ab..e57619ef90d5941d3f13ab6afde19bdc6324e8cb 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -244,7 +244,7 @@ const main = async () => {
+   });
+ 
+   await checkForOldConfig();
+-  run();
++  await run();
+ };
+ 
+ main().catch((error) => {

--- a/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/xctest-agent-client.d.ts b/dist/xctest-agent-client.d.ts
-index 6f89667..1db236c 100644
+index 6f896672f61f8cdd00249b00a0a6501b4a0a0288..1db236c8b7983b8367daca69477b650fbfefe2a6 100644
 --- a/dist/xctest-agent-client.d.ts
 +++ b/dist/xctest-agent-client.d.ts
 @@ -4,13 +4,14 @@ export type XCTestAgentPermissionsConfiguration = {
@@ -19,7 +19,7 @@ index 6f89667..1db236c 100644
  export declare const createXCTestAgentClient: (transport: XCTestAgentTransport) => XCTestAgentClient;
  export {};
 diff --git a/dist/xctest-agent-client.js b/dist/xctest-agent-client.js
-index 4a70bba..bef9965 100644
+index 4a70bba5e197673eba02c5210171c24207511e02..bef996567ed11723f33254cfb9d841fae94b55d5 100644
 --- a/dist/xctest-agent-client.js
 +++ b/dist/xctest-agent-client.js
 @@ -29,6 +29,12 @@ export const createXCTestAgentClient = (transport) => {
@@ -36,7 +36,7 @@ index 4a70bba..bef9965 100644
              await transport.dispose();
          },
 diff --git a/dist/xctest-agent.js b/dist/xctest-agent.js
-index 7ee0ac9..43d9a3a 100644
+index 7ee0ac916a3708e98953ead0a80711bd2c7b2822..ec00f75f630c8431280d26c7b9667daafc40f52f 100644
 --- a/dist/xctest-agent.js
 +++ b/dist/xctest-agent.js
 @@ -16,7 +16,7 @@ const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV = 'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID
@@ -78,9 +78,50 @@ index 7ee0ac9..43d9a3a 100644
  const waitForChildProcessExit = async (subprocess) => {
      const childProcess = await subprocess.nodeChildProcess;
      if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
-@@ -670,6 +693,28 @@ export const createXCTestAgentController = (options) => {
+@@ -539,6 +562,7 @@ export const createXCTestAgentController = (options) => {
+     let agentProcess = null;
+     let agentClient = null;
+     let processTask = null;
++    let processOutputLogTask = null;
+     const getLaunchEnvironment = () => {
+         return Object.assign({}, options.appBundleId
+             ? {
+@@ -620,10 +644,17 @@ export const createXCTestAgentController = (options) => {
+                 }),
+             },
+         });
+-        void attachProcessOutputLog({
++        const currentOutputLogTask = attachProcessOutputLog({
+             command: ['xcodebuild', ...xcodebuildArgs].join(' '),
+             logFilePath: xcodebuildLogPath,
+             process: agentProcess,
++        }).catch((error) => {
++            xctestAgentLogger.warn('XCTest agent output log task failed for %s: %s', target.kind, getErrorMessage(error));
++        });
++        processOutputLogTask = currentOutputLogTask.finally(() => {
++            if (processOutputLogTask === currentOutputLogTask) {
++                processOutputLogTask = null;
++            }
+         });
+         xctestAgentLogger.info('Saving XCTest agent xcodebuild logs to %s', xcodebuildLogPath);
+         const currentProcess = agentProcess;
+@@ -659,6 +690,7 @@ export const createXCTestAgentController = (options) => {
+                 shutdownTimeoutMs,
+                 targetKind: target.kind,
+             });
++            await processOutputLogTask;
+             throw error;
+         }
+     };
+@@ -666,10 +698,35 @@ export const createXCTestAgentController = (options) => {
+         const currentProcess = agentProcess;
+         const currentClient = agentClient;
+         const currentProcessTask = processTask;
++        const currentProcessOutputLogTask = processOutputLogTask;
+         agentProcess = null;
          agentClient = null;
          processTask = null;
++        processOutputLogTask = null;
          xctestAgentLogger.info('Stopping XCTest agent session for %s target', target.kind);
 +        if (currentClient) {
 +            try {
@@ -93,6 +134,7 @@ index 7ee0ac9..43d9a3a 100644
 +                if (gracefulShutdown.didStop) {
 +                    xctestAgentLogger.info('XCTest agent session for %s target stopped gracefully', target.kind);
 +                    await currentClient.dispose();
++                    await currentProcessOutputLogTask;
 +                    return;
 +                }
 +                if (gracefulShutdown.requestError) {
@@ -107,8 +149,16 @@ index 7ee0ac9..43d9a3a 100644
          await currentClient?.dispose();
          await stopProcess({
              process: currentProcess,
+@@ -677,6 +734,7 @@ export const createXCTestAgentController = (options) => {
+             shutdownTimeoutMs,
+             targetKind: target.kind,
+         });
++        await currentProcessOutputLogTask;
+     };
+     return {
+         prepare,
 diff --git a/src/xctest-agent-client.ts b/src/xctest-agent-client.ts
-index 93f28b5..ca53d4c 100644
+index 93f28b5c66ab907c4645ea01431d593d205a7f28..ca53d4c3f8240115f75e32ee3f2d2b0939915fa8 100644
 --- a/src/xctest-agent-client.ts
 +++ b/src/xctest-agent-client.ts
 @@ -9,7 +9,7 @@ export type XCTestAgentPermissionsConfiguration = {
@@ -142,7 +192,7 @@ index 93f28b5..ca53d4c 100644
        await transport.dispose();
      },
 diff --git a/src/xctest-agent.ts b/src/xctest-agent.ts
-index 00e3034..de9c030 100644
+index 00e3034e46cb789a9e3690593b08da63d4ebb1ce..b73ee9cd8ec7737736b8618546dc8c8021b2d74b 100644
 --- a/src/xctest-agent.ts
 +++ b/src/xctest-agent.ts
 @@ -31,7 +31,7 @@ const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
@@ -191,7 +241,57 @@ index 00e3034..de9c030 100644
  const waitForChildProcessExit = async (subprocess: Subprocess) => {
    const childProcess = await subprocess.nodeChildProcess;
  
-@@ -1113,6 +1143,50 @@ export const createXCTestAgentController = (options: {
+@@ -935,6 +965,7 @@ export const createXCTestAgentController = (options: {
+   let agentProcess: Subprocess | null = null;
+   let agentClient: ReturnType<typeof createXCTestAgentClient> | null = null;
+   let processTask: Promise<void> | null = null;
++  let processOutputLogTask: Promise<void> | null = null;
+ 
+   const getLaunchEnvironment = (): Record<string, string> => {
+     return Object.assign(
+@@ -1047,10 +1078,21 @@ export const createXCTestAgentController = (options: {
+         }),
+       },
+     });
+-    void attachProcessOutputLog({
++    const currentOutputLogTask = attachProcessOutputLog({
+       command: ['xcodebuild', ...xcodebuildArgs].join(' '),
+       logFilePath: xcodebuildLogPath,
+       process: agentProcess,
++    }).catch((error) => {
++      xctestAgentLogger.warn(
++        'XCTest agent output log task failed for %s: %s',
++        target.kind,
++        getErrorMessage(error)
++      );
++    });
++    processOutputLogTask = currentOutputLogTask.finally(() => {
++      if (processOutputLogTask === currentOutputLogTask) {
++        processOutputLogTask = null;
++      }
+     });
+     xctestAgentLogger.info(
+       'Saving XCTest agent xcodebuild logs to %s',
+@@ -1096,6 +1138,7 @@ export const createXCTestAgentController = (options: {
+         shutdownTimeoutMs,
+         targetKind: target.kind,
+       });
++      await processOutputLogTask;
+       throw error;
+     }
+   };
+@@ -1104,15 +1147,62 @@ export const createXCTestAgentController = (options: {
+     const currentProcess = agentProcess;
+     const currentClient = agentClient;
+     const currentProcessTask = processTask;
++    const currentProcessOutputLogTask = processOutputLogTask;
+     agentProcess = null;
+     agentClient = null;
+     processTask = null;
++    processOutputLogTask = null;
+ 
+     xctestAgentLogger.info(
+       'Stopping XCTest agent session for %s target',
        target.kind
      );
  
@@ -214,6 +314,7 @@ index 00e3034..de9c030 100644
 +            target.kind
 +          );
 +          await currentClient.dispose();
++          await currentProcessOutputLogTask;
 +          return;
 +        }
 +
@@ -242,8 +343,16 @@ index 00e3034..de9c030 100644
      await currentClient?.dispose();
      await stopProcess({
        process: currentProcess,
+@@ -1120,6 +1210,7 @@ export const createXCTestAgentController = (options: {
+       shutdownTimeoutMs,
+       targetKind: target.kind,
+     });
++    await currentProcessOutputLogTask;
+   };
+ 
+   return {
 diff --git a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
-index 31abf4b..a7ccf68 100644
+index 31abf4b787a602d53fadf30794b27fe287aa0bd2..a7ccf68aa7c020c3956a8cdd055b26394b460c6d 100644
 --- a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
 +++ b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
 @@ -4,6 +4,7 @@ import Network

--- a/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
+++ b/patches/@react-native-harness%2Fplatform-apple@1.4.0-rc.1.patch
@@ -1,0 +1,308 @@
+diff --git a/dist/xctest-agent-client.d.ts b/dist/xctest-agent-client.d.ts
+index 6f89667..1db236c 100644
+--- a/dist/xctest-agent-client.d.ts
++++ b/dist/xctest-agent-client.d.ts
+@@ -4,13 +4,14 @@ export type XCTestAgentPermissionsConfiguration = {
+ };
+ type XCTestAgentHealthResponse = {
+     permissions: XCTestAgentPermissionsConfiguration;
+-    status: 'ok';
++    status: 'ok' | 'shutting-down';
+ };
+ export type XCTestAgentClient = {
+     configurePermissions: (permissions: XCTestAgentPermissionsConfiguration) => Promise<XCTestAgentPermissionsConfiguration>;
+     dispose: () => Promise<void>;
+     getPermissionsConfig: () => Promise<XCTestAgentPermissionsConfiguration>;
+     health: () => Promise<XCTestAgentHealthResponse>;
++    shutdown: () => Promise<void>;
+ };
+ export declare const createXCTestAgentClient: (transport: XCTestAgentTransport) => XCTestAgentClient;
+ export {};
+diff --git a/dist/xctest-agent-client.js b/dist/xctest-agent-client.js
+index 4a70bba..bef9965 100644
+--- a/dist/xctest-agent-client.js
++++ b/dist/xctest-agent-client.js
+@@ -29,6 +29,12 @@ export const createXCTestAgentClient = (transport) => {
+             });
+             return response.permissions;
+         },
++        shutdown: async () => {
++            await requestJson({
++                method: 'POST',
++                path: '/shutdown',
++            });
++        },
+         dispose: async () => {
+             await transport.dispose();
+         },
+diff --git a/dist/xctest-agent.js b/dist/xctest-agent.js
+index 7ee0ac9..43d9a3a 100644
+--- a/dist/xctest-agent.js
++++ b/dist/xctest-agent.js
+@@ -16,7 +16,7 @@ const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV = 'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID
+ const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
+ const XCTEST_AGENT_DERIVED_DATA_PATH_ENV = 'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+-const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
++const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 30_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+ const HARNESS_DIRNAME = '.harness';
+ const XCTEST_AGENT_BUILD_DIRNAME = 'xctest-agent';
+@@ -438,6 +438,29 @@ const waitForShutdown = async (options) => {
+     ]);
+     return result !== timedOut;
+ };
++const waitForGracefulShutdown = async (options) => {
++    let requestError = null;
++    const timedOut = Symbol('timedOut');
++    const result = await Promise.race([
++        (async () => {
++            try {
++                await options.client.shutdown();
++            }
++            catch (error) {
++                requestError = error;
++            }
++            return await waitForShutdown({
++                processTask: options.processTask,
++                shutdownTimeoutMs: options.shutdownTimeoutMs,
++            });
++        })(),
++        delay(options.shutdownTimeoutMs).then(() => timedOut),
++    ]);
++    return {
++        didStop: result !== timedOut && result === true,
++        requestError,
++    };
++};
+ const waitForChildProcessExit = async (subprocess) => {
+     const childProcess = await subprocess.nodeChildProcess;
+     if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+@@ -670,6 +693,28 @@ export const createXCTestAgentController = (options) => {
+         agentClient = null;
+         processTask = null;
+         xctestAgentLogger.info('Stopping XCTest agent session for %s target', target.kind);
++        if (currentClient) {
++            try {
++                xctestAgentLogger.info('Requesting XCTest agent graceful shutdown for %s target', target.kind);
++                const gracefulShutdown = await waitForGracefulShutdown({
++                    client: currentClient,
++                    processTask: currentProcessTask,
++                    shutdownTimeoutMs,
++                });
++                if (gracefulShutdown.didStop) {
++                    xctestAgentLogger.info('XCTest agent session for %s target stopped gracefully', target.kind);
++                    await currentClient.dispose();
++                    return;
++                }
++                if (gracefulShutdown.requestError) {
++                    xctestAgentLogger.warn('XCTest agent graceful shutdown request failed for %s: %s', target.kind, getErrorMessage(gracefulShutdown.requestError));
++                }
++                xctestAgentLogger.warn('XCTest agent session for %s target did not stop gracefully after %dms; terminating xcodebuild', target.kind, shutdownTimeoutMs);
++            }
++            catch (error) {
++                xctestAgentLogger.warn('XCTest agent graceful shutdown failed for %s: %s', target.kind, getErrorMessage(error));
++            }
++        }
+         await currentClient?.dispose();
+         await stopProcess({
+             process: currentProcess,
+diff --git a/src/xctest-agent-client.ts b/src/xctest-agent-client.ts
+index 93f28b5..ca53d4c 100644
+--- a/src/xctest-agent-client.ts
++++ b/src/xctest-agent-client.ts
+@@ -9,7 +9,7 @@ export type XCTestAgentPermissionsConfiguration = {
+ 
+ type XCTestAgentHealthResponse = {
+   permissions: XCTestAgentPermissionsConfiguration;
+-  status: 'ok';
++  status: 'ok' | 'shutting-down';
+ };
+ 
+ type XCTestAgentPermissionsResponse = {
+@@ -23,6 +23,7 @@ export type XCTestAgentClient = {
+   dispose: () => Promise<void>;
+   getPermissionsConfig: () => Promise<XCTestAgentPermissionsConfiguration>;
+   health: () => Promise<XCTestAgentHealthResponse>;
++  shutdown: () => Promise<void>;
+ };
+ 
+ export const createXCTestAgentClient = (
+@@ -67,6 +68,12 @@ export const createXCTestAgentClient = (
+ 
+       return response.permissions;
+     },
++    shutdown: async () => {
++      await requestJson<XCTestAgentHealthResponse>({
++        method: 'POST',
++        path: '/shutdown',
++      });
++    },
+     dispose: async () => {
+       await transport.dispose();
+     },
+diff --git a/src/xctest-agent.ts b/src/xctest-agent.ts
+index 00e3034..de9c030 100644
+--- a/src/xctest-agent.ts
++++ b/src/xctest-agent.ts
+@@ -31,7 +31,7 @@ const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
+ const XCTEST_AGENT_DERIVED_DATA_PATH_ENV =
+   'HARNESS_IOS_XCTEST_DERIVED_DATA_PATH';
+ const XCTEST_AGENT_STARTUP_TIMEOUT_MS = 120_000;
+-const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 5_000;
++const XCTEST_AGENT_SHUTDOWN_TIMEOUT_MS = 30_000;
+ const XCTEST_AGENT_STARTUP_POLL_INTERVAL_MS = 250;
+ const HARNESS_DIRNAME = '.harness';
+ const XCTEST_AGENT_BUILD_DIRNAME = 'xctest-agent';
+@@ -776,6 +776,36 @@ const waitForShutdown = async (options: {
+   return result !== timedOut;
+ };
+ 
++const waitForGracefulShutdown = async (options: {
++  client: ReturnType<typeof createXCTestAgentClient>;
++  processTask: Promise<void> | null;
++  shutdownTimeoutMs: number;
++}): Promise<{ didStop: boolean; requestError: unknown | null }> => {
++  let requestError: unknown | null = null;
++  const timedOut = Symbol('timedOut');
++
++  const result = await Promise.race([
++    (async () => {
++      try {
++        await options.client.shutdown();
++      } catch (error) {
++        requestError = error;
++      }
++
++      return await waitForShutdown({
++        processTask: options.processTask,
++        shutdownTimeoutMs: options.shutdownTimeoutMs,
++      });
++    })(),
++    delay(options.shutdownTimeoutMs).then(() => timedOut),
++  ]);
++
++  return {
++    didStop: result !== timedOut && result === true,
++    requestError,
++  };
++};
++
+ const waitForChildProcessExit = async (subprocess: Subprocess) => {
+   const childProcess = await subprocess.nodeChildProcess;
+ 
+@@ -1113,6 +1143,50 @@ export const createXCTestAgentController = (options: {
+       target.kind
+     );
+ 
++    if (currentClient) {
++      try {
++        xctestAgentLogger.info(
++          'Requesting XCTest agent graceful shutdown for %s target',
++          target.kind
++        );
++
++        const gracefulShutdown = await waitForGracefulShutdown({
++          client: currentClient,
++          processTask: currentProcessTask,
++          shutdownTimeoutMs,
++        });
++
++        if (gracefulShutdown.didStop) {
++          xctestAgentLogger.info(
++            'XCTest agent session for %s target stopped gracefully',
++            target.kind
++          );
++          await currentClient.dispose();
++          return;
++        }
++
++        if (gracefulShutdown.requestError) {
++          xctestAgentLogger.warn(
++            'XCTest agent graceful shutdown request failed for %s: %s',
++            target.kind,
++            getErrorMessage(gracefulShutdown.requestError)
++          );
++        }
++
++        xctestAgentLogger.warn(
++          'XCTest agent session for %s target did not stop gracefully after %dms; terminating xcodebuild',
++          target.kind,
++          shutdownTimeoutMs
++        );
++      } catch (error) {
++        xctestAgentLogger.warn(
++          'XCTest agent graceful shutdown failed for %s: %s',
++          target.kind,
++          getErrorMessage(error)
++        );
++      }
++    }
++
+     await currentClient?.dispose();
+     await stopProcess({
+       process: currentProcess,
+diff --git a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
+index 31abf4b..a7ccf68 100644
+--- a/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
++++ b/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
+@@ -4,6 +4,7 @@ import Network
+ final class HarnessXCTestAgentState {
+   private let lock = NSLock()
+   private var _permissions: PermissionPromptConfiguration
++  private var _shouldShutdown = false
+ 
+   init(permissions: PermissionPromptConfiguration) {
+     _permissions = permissions
+@@ -20,6 +21,18 @@ final class HarnessXCTestAgentState {
+     _permissions = permissions
+     lock.unlock()
+   }
++
++  var shouldShutdown: Bool {
++    lock.lock()
++    defer { lock.unlock() }
++    return _shouldShutdown
++  }
++
++  func requestShutdown() {
++    lock.lock()
++    _shouldShutdown = true
++    lock.unlock()
++  }
+ }
+ 
+ private struct XCTestAgentHealthResponse: Codable {
+@@ -250,6 +263,15 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+       return jsonResponse(XCTestAgentPermissionsResponse(permissions: state.permissions))
+     case ("GET", "/permissions"):
+       return jsonResponse(XCTestAgentPermissionsResponse(permissions: state.permissions))
++    case ("POST", "/shutdown"):
++      log("shutdown requested")
++      state.requestShutdown()
++      return jsonResponse(
++        XCTestAgentHealthResponse(
++          permissions: state.permissions,
++          status: "shutting-down"
++        )
++      )
+     default:
+       return XCTestAgentResponse(body: Data("{\"error\":\"not found\"}".utf8), statusCode: 404)
+     }
+@@ -301,7 +323,7 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+ 
+     let sessionDeadline = Date().addingTimeInterval(Constants.defaultSessionDuration)
+ 
+-    while Date() < sessionDeadline {
++    while Date() < sessionDeadline && !state.shouldShutdown {
+       observeTargetApplication()
+ 
+       for capability in capabilities {
+@@ -313,6 +335,6 @@ final class HarnessXCTestAgentUITests: XCTestCase {
+       )
+     }
+ 
+-    log("testAgentSession completed")
++    log("testAgentSession completed (shutdownRequested=\(state.shouldShutdown))")
+   }
+ }


### PR DESCRIPTION
## Summary

- Stop listing `.harness/crash-reports` as a standalone iOS Device Farm artifact because it is empty on successful native runs.
- Stop pre-creating `.harness/crash-reports`; Harness/native crash reporting can create it when there is actually a crash report to upload.
- Upload the Harness `.harness` root instead, so crash reports are still collected when present and XCTest logs are collected on normal runs.
- Add optional iOS `xcodebuild.log` extraction/printing from Device Farm artifacts for failure diagnostics.
- Print Device Farm's customer-artifacts log on wrapper failures so artifact attach issues are visible in GitHub logs.
- Patch `@react-native-harness/platform-apple@1.4.0-rc.1` so the JS Harness runner can ask the XCTest agent to shut down gracefully instead of force-killing `xcodebuild` while XCTest is still active.

## Why

Three separate iOS wrapper facts showed up:

1. In run `27008951774`, Harness/Jest was green but Device Farm failed while attaching artifacts:
   - `Successfully attached files from $WORKING_DIRECTORY/harness-artifacts`
   - `Failed to attach directory $WORKING_DIRECTORY/react-native-vision-camera/apps/simple-camera/.harness/crash-reports because it is empty`

2. After removing the standalone empty artifact path, run `27010566329` still had all Harness suites green:
   - `PASS __tests__/visioncamera.controller.harness.ts`
   - `Test Suites: 12 passed, 12 total`
   - `Tests: 15 skipped, 124 passed, 139 total`

   But Device Farm still failed because the XCTest agent did not finish cleanly. The collected `xcodebuild.log` showed `testAgentSession` started and kept polling permission buttons until the log ended, with no `** TEST EXECUTE SUCCEEDED **` line.

3. After adding graceful XCTest shutdown, run `27011984952` proved the shutdown path works:
   - `Requesting XCTest agent graceful shutdown for device target`
   - `XCTest agent session for device target stopped gracefully`
   - `testAgentSession completed (shutdownRequested=true)`
   - `** TEST EXECUTE SUCCEEDED **`

   Harness/Jest and xcodebuild were both green, but Device Farm still reported one failed wrapper subtest. The remaining likely cause is that the test spec still pre-created an empty nested `.harness/crash-reports` directory under the uploaded `.harness` root. This PR now avoids creating that empty directory and prints the Device Farm customer-artifacts log if the wrapper still fails.

This keeps Device Farm failures red if the outer step fails.

## Verification

- `bun install --frozen-lockfile`
- `git diff --check`
- Parsed `.github/actions/collect-devicefarm-results/action.yml` and `apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml` with Ruby `YAML.load_file(...)`
- Verified `.github/scripts/find-devicefarm-artifact.sh` can extract `*-Customer Artifacts Log.txt`
- `node --check node_modules/@react-native-harness/platform-apple/dist/xctest-agent.js`
- `node --check node_modules/@react-native-harness/platform-apple/dist/xctest-agent-client.js`
- Imported `@react-native-harness/platform-apple` with Node ESM
- `xcrun swiftc -parse node_modules/@react-native-harness/platform-apple/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift`

This PR does not trust green JUnit over a failed Device Farm result.
