### PR TITLE
chore: diagnose iOS Harness open handles

### DIFF
--- a/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
+++ b/apps/simple-camera/device-farm-tests/AwsTestSpecIOS.yml
@@ -75,6 +75,7 @@ phases:
             --harnessRunner ios \
             --reporters=default \
             --reporters=jest-junit \
+            --detectOpenHandles \
             --verbose 2>&1 | tee "$HARNESS_LOG"
 
 artifacts:


### PR DESCRIPTION
Adds Jest's official --detectOpenHandles flag to the iOS Device Farm Harness command only.\n\nThis is a diagnostic PR on top of #3999 to identify the handle that keeps the iOS Harness process alive after all suites pass. It should not be merged as-is.