### PR TITLE
Add start crash reproducer for #3773

### DIFF
--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -6,9 +6,9 @@ Branch: `codex/start-crash-3773`
 
 ## Current status
 
-This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked and SpringBoard denied further launches, while the available iPhone SE 3rd gen ran the repro loop without crashing. The first CI iOS Harness run also ran the new 120-cycle repro on a multi-camera iOS Device Farm device without crashing.
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked and SpringBoard denied further launches, while the available iPhone SE 3rd gen ran the earlier repro loop without crashing. The first CI iOS Harness run also ran the earlier 120-cycle repro on a multi-camera iOS Device Farm device without crashing.
 
-The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. The exact assertion condition inside `-[AVCaptureOutput attachToFigCaptureSession:]` is private Apple code, so the remaining internal invariant is inferred from the stack, not decompiled source.
+The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The original stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. A separate client report mentions the sibling private assertion `AVCaptureOutput detachFromFigCaptureSession` during rapid `photo -> video -> photo` changes, especially with a filter-preview path involved. That client report is not a stack trace, but it is directionally important because it points at the same output lifetime boundary from the detach side rather than the attach side. The exact assertion conditions inside `-[AVCaptureOutput attachToFigCaptureSession:]` and `detachFromFigCaptureSession` are private Apple code, so the remaining internal invariant is inferred from stacks/logs, not decompiled source.
 
 ## What the crash stack proves
 
@@ -28,6 +28,8 @@ Because VisionCamera serializes `configure()` and `start()` on `HybridCameraSess
 5. VisionCamera's next queued `start()` runs and calls `session.startRunning()`.
 6. AVFoundation is still attaching outputs from the committed configuration on `FigCaptureSessionNotificationQueue`.
 7. AVFoundation hits its private assertion in `attachToFigCaptureSession`.
+
+The newer client report describes `detachFromFigCaptureSession`, which is the same class of invariant violation during output teardown instead of output attachment. Taken together, the evidence points at AVFoundation output attachment/detachment lifetime crossing a session start or a subsequent output topology change. It does not point at JavaScript timing alone, and it does not prove that a single specific output type is always responsible.
 
 ## VisionCamera code path responsible
 
@@ -61,30 +63,31 @@ That is a valid VisionCamera queue order, but it is the exact dangerous order if
 The example app starts the camera automatically, then loops from native callbacks:
 
 1. `onStarted` sets `isActive=false`.
-2. `onStopped` swaps video output settings and optional HDR constraints.
+2. `onStopped` alternates the active output topology between photo-only and video-only.
 3. `onStopped` immediately sets `isActive=true`.
 4. The next React commit reconfigures outputs/constraints and restarts without sleeps.
 
-The loop attaches both photo and video outputs, alternates `HD_16_9`/`FHD_16_9` video output settings, requests 60 FPS when supported, requests cinematic-extended stabilization when supported, and toggles `photoHDR` when supported.
+The current loop uses `<SkiaCamera>` so the preview path is a frame output rendered through Skia rather than a native preview output. It alternates `photo -> video -> photo`, alternates `HD_16_9`/`FHD_16_9` video output settings, requests 60 FPS when supported, requests cinematic-extended stabilization during video cycles when supported, and toggles `photoHDR` during photo cycles when supported.
 
 This is intentionally event-driven. It does not use artificial sleeps or timeouts to create the race window.
 
 ## Harness reproducer added
 
-`apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx` now contains:
+`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains two iOS-only stress tests:
 
 ```text
-reconfigures outputs and immediately restarts from Camera lifecycle callbacks
+cycles photo -> video -> photo outputs through native preview start/stop
+cycles photo -> video -> photo outputs with Skia frame-preview attached
 ```
 
-It renders a high-level `<Camera>` and runs 120 cycles of:
+They render high-level camera components and run 60 cycles of:
 
 ```text
 onStarted -> inactive
-onStopped -> replace video output + toggle constraints + active
+onStopped -> switch photo-only/video-only output topology + toggle constraints + active
 ```
 
-This is the closest Harness shape to the reported crash because it exercises the React hook lifecycle that can enqueue `configure()` followed by `start()` in the same commit. A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
+The first stress test uses the normal `<Camera>` native preview path. The second uses `<SkiaCamera>`, which always adds a frame output for preview rendering and therefore exercises the filter-preview shape mentioned in the newer client report. A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
 
 ## Device observations
 
@@ -100,16 +103,18 @@ Observed locally:
 - Subsequent iPhone 15 Pro launches were denied because the device was locked: `Unable to launch com.margelo.nitro.camera.example.simple because the device was not, or could not be, unlocked`.
 - The attached Teams video shows an app crash alert after an active video recording session, but it does not expose a native stack. It supports the general "active camera plus output/session state changes" trigger shape, not the internal AVFoundation diagnosis by itself.
 
-CI observations from PR #4001 / Harness AWS Device run `27018903509`:
+CI observations from PR #4001 / Harness AWS Device run `27018903509` for the earlier, now-replaced Harness repro:
 
 - Build iOS passed.
 - Test iOS executed on a multi-camera iOS device exposing wide, ultra-wide, telephoto, dual, dual-wide, triple, lidar-depth, and true-depth devices.
 - The new Harness test completed 120 cycles on `Back Camera` in 25.766s: `reconfigures outputs and immediately restarts from Camera lifecycle callbacks`.
 - iOS Harness summary was green: 12 test suites passed, 125 tests passed, 15 skipped, 0 failed.
 - The GitHub `Test iOS` job still reported failure because the Device Farm step itself returned failed, but the Harness output did not contain an AVFoundation crash, app crash, failed test, or assertion.
-- Android also ran the new test and completed 120 cycles in 27.414s. Android failed in unrelated existing suites (`photo`, `coordinates`, `controller`, `video`), not in the new Camera-view repro.
+- Android also ran the earlier test and completed 120 cycles in 27.414s. Android failed in unrelated existing suites (`photo`, `coordinates`, `controller`, `video`), not in the Camera-view repro.
 
-Negative evidence: the iPhone SE result and the first iOS Device Farm result suggest the current loop is not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, recording state, recorder preparation, lens switching, mount/unmount timing, or a narrower output transition likely matters.
+Why CI passed: that earlier Harness test was not equivalent to either report. It kept photo and video outputs attached together, then mostly recreated the video output and restarted. It did not remove the photo output before adding video, did not remove video before re-adding photo, did not use the Skia/filter-preview path, did not record video, and did not run on the original iPhone 11 / iOS 18.7.7 matrix. Its green result only proves that "replace video while photo remains attached, then restart" did not hit the assertion on that AWS device in 120 cycles.
+
+Negative evidence: the iPhone SE result and the first iOS Device Farm result suggest the earlier loop was not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, recording state, recorder preparation, lens switching, mount/unmount timing, or the narrower photo-only/video-only output transition likely matters.
 
 ## Verification done
 
@@ -122,7 +127,7 @@ git diff --check
 bun --cwd apps/simple-camera react-native bundle --platform ios --dev true --entry-file index.js --bundle-output /tmp/simple-camera-start-crash.bundle --assets-dest /tmp/simple-camera-start-crash-assets --reset-cache
 ```
 
-`bunx biome check apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx apps/simple-camera/src/screens/CameraScreen.tsx` reported only pre-existing unused-variable warnings in `CameraScreen.tsx`. The new Harness file had no Biome diagnostics.
+`bunx biome check apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx apps/simple-camera/src/screens/CameraScreen.tsx START_CRASH_FINDINGS.md apps/simple-camera/__tests__/README.md` reported only pre-existing unused-variable warnings in `CameraScreen.tsx`. The new stress Harness file had no Biome diagnostics.
 
 Local `react-native-harness --harnessRunner ios` tried to boot an iOS simulator, so I stopped it. The simulator is not useful for this camera pipeline race; the PR CI iOS Harness run on real hardware is the relevant signal.
 
@@ -130,7 +135,7 @@ Local `react-native-harness --harnessRunner ios` tried to boot an iOS simulator,
 
 The best current issue description is:
 
-> VisionCamera can enqueue `AVCaptureSession.startRunning()` immediately after a configuration commit that replaces outputs or changes output-affecting constraints. VisionCamera's own serial queue ensures `startRunning()` happens after `commitConfiguration()` returns, but AVFoundation/CoreMedia may still be processing the committed configuration asynchronously on `FigCaptureSessionNotificationQueue`. On affected hardware/OS combinations, `startRunning()` can overlap that private output-attachment work and trip AVFoundation's internal assertion in `-[AVCaptureOutput attachToFigCaptureSession:]`.
+> VisionCamera can enqueue `AVCaptureSession.startRunning()` immediately after a configuration commit that replaces outputs or changes output-affecting constraints. VisionCamera's own serial queue ensures `startRunning()` happens after `commitConfiguration()` returns, but AVFoundation/CoreMedia may still be processing the committed configuration asynchronously on `FigCaptureSessionNotificationQueue`. On affected hardware/OS combinations, `startRunning()` or a subsequent topology change can overlap that private output attachment/detachment work and trip AVFoundation's internal assertions in `-[AVCaptureOutput attachToFigCaptureSession:]` or `detachFromFigCaptureSession`.
 
 This is proven at the call-order/concurrency level by the crash stack and VisionCamera source. It is not yet proven at the "Apple internal field X had value Y" level because AVFoundation source is private and the exact assertion condition is not visible.
 

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -6,7 +6,7 @@ Branch: `codex/start-crash-3773`
 
 ## Current status
 
-This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run both the earlier broad 120-cycle repro and the corrected `photo -> video -> photo` native/Skia topology repro on real iOS Device Farm hardware without crashing.
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run the earlier broad 120-cycle repro, the corrected `photo -> video -> photo` native/Skia topology repro, and the active photo/video capture topology repro on real iOS Device Farm hardware without crashing.
 
 The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The original stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. A separate client report mentions the sibling private assertion `AVCaptureOutput detachFromFigCaptureSession` during rapid `photo -> video -> photo` changes, especially with a filter-preview path involved. That client report is not a stack trace, but it is directionally important because it points at the same output lifetime boundary from the detach side rather than the attach side. The exact assertion conditions inside `-[AVCaptureOutput attachToFigCaptureSession:]` and `detachFromFigCaptureSession` are private Apple code, so the remaining internal invariant is inferred from stacks/logs, not decompiled source.
 
@@ -76,12 +76,13 @@ This is intentionally event-driven. It does not use artificial sleeps or timeout
 
 ## Harness reproducer added
 
-`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains three iOS-only stress tests:
+`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains four iOS-only stress tests:
 
 ```text
 cycles photo -> video -> photo outputs through native preview start/stop
 cycles photo -> video -> photo outputs with Skia frame-preview attached
 captures photo -> records video -> captures photo with Skia frame-preview attached
+restarts with stable photo/video outputs while toggling audio, HDR, and zoom
 ```
 
 The first two tests render high-level camera components and run 60 cycles of:
@@ -100,6 +101,8 @@ photo mode -> capturePhoto -> inactive
 video mode -> create recorder -> startRecording -> stopRecording -> inactive
 onStopped -> switch photo-only/video-only output topology + active
 ```
+
+The fourth test is closer to the production code in #3773. It keeps both photo and video outputs attached as `[photoOutput, videoOutput]`, recreates the video output by toggling `enableAudio`, toggles `photoHDR` plus HDR video dynamic range when supported, applies zoom targets across the virtual-device zoom range from `onStarted`, and immediately restarts from `onStopped`.
 
 A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
 
@@ -137,7 +140,16 @@ CI observations from PR #4001 / Harness AWS Device run `27022466051` on commit `
 - iOS Harness summary was green: 13 test suites passed, 126 tests passed, 15 skipped, 0 failed.
 - The GitHub `Test iOS` job still reported failure because AWS Device Farm reported one failed item outside the Harness summary: `Total: 3, passed: 2, failed: 1`. The printed Harness output did not contain an AVFoundation crash, app crash, failed test, `attachToFigCaptureSession`, or `detachFromFigCaptureSession`.
 
-Negative evidence: the iPhone SE result and the first two iOS Device Farm results suggest output topology changes alone are not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, active recording/capture state, recorder preparation, lens switching, mount/unmount timing, or the original iPhone 11 / iOS 18.7.7 matrix likely matters.
+CI observations from PR #4001 / Harness AWS Device run `27023974149` on commit `eab8faca6403e5d91ef84c98c627f97fef90ee75`:
+
+- Build iOS passed.
+- Test iOS executed on Apple iPhone 16 Pro.
+- The active capture stress test passed: 18 Skia cycles completed in 7.838s.
+- iOS Harness summary was green: 13 test suites passed, 127 tests passed, 15 skipped, 0 failed.
+- The GitHub `Test iOS` job still reported failure because AWS Device Farm reported one failed item outside the Harness summary: `Total: 3, passed: 2, failed: 1`.
+- The printed Harness output did not contain an AVFoundation crash, app crash, failed test, `attachToFigCaptureSession`, or `detachFromFigCaptureSession`.
+
+Negative evidence: the iPhone SE result and the first three iOS Device Farm results suggest simple output topology changes and immediate active capture/recording cycles are not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, recording while mutating the same output, recorder preparation lifetime, lens switching, mount/unmount timing, stable photo+video outputs with output recreation, or the original iPhone 11 / iOS 18.7.7 matrix likely matters.
 
 ## Verification done
 
@@ -164,7 +176,7 @@ This is proven at the call-order/concurrency level by the crash stack and Vision
 
 ## Next repro iteration
 
-The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The most likely next conditions to test are:
+The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The current next Harness iteration tests the production shape where photo and video outputs stay attached together while `enableAudio`, HDR constraints, and zoom change across immediate restart cycles. If that also passes, the most likely remaining conditions to test are:
 
 - actively recording while replacing or recreating the video output,
 - preparing a new recorder while the session is being stopped/reconfigured,

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -6,7 +6,7 @@ Branch: `codex/start-crash-3773`
 
 ## Current status
 
-This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run the earlier broad 120-cycle repro, the corrected `photo -> video -> photo` native/Skia topology repro, the active photo/video capture topology repro, and a production-shape photo+video output restart repro on real iOS Device Farm hardware without crashing.
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run the earlier broad 120-cycle repro, the corrected `photo -> video -> photo` native/Skia topology repro, the active photo/video capture topology repro, and a production-shape photo+video output restart repro on real iOS Device Farm hardware without crashing. A newer active-recorder mutation repro does fail deterministically on CI, but with `AVFoundationErrorDomain Code=-11818 "Recording Stopped"` rather than the private attach/detach assertion.
 
 The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The original stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. A separate client report mentions the sibling private assertion `AVCaptureOutput detachFromFigCaptureSession` during rapid `photo -> video -> photo` changes, especially with a filter-preview path involved. That client report is not a stack trace, but it is directionally important because it points at the same output lifetime boundary from the detach side rather than the attach side. The exact assertion conditions inside `-[AVCaptureOutput attachToFigCaptureSession:]` and `detachFromFigCaptureSession` are private Apple code, so the remaining internal invariant is inferred from stacks/logs, not decompiled source.
 
@@ -40,6 +40,12 @@ Native serialization is in `packages/react-native-vision-camera/ios/Hybrid Objec
 - `stop()` uses the same `Self.queue`, then calls `session.stopRunning()`.
 
 The queue guarantees call order only for VisionCamera's own work. It does not guarantee AVFoundation's private CoreMedia notification queue has finished processing the effects of `commitConfiguration()`.
+
+The active recording path involved in the latest repro is in:
+
+- `HybridCameraVideoOutput` creates a non-persistent `AVCaptureMovieFileOutput`.
+- `HybridVideoRecorder.startRecording(...)` calls `AVCaptureMovieFileOutput.startRecording(...)`.
+- `VideoDelegate.fileOutput(... didFinishRecordingTo: ... error:)` treats only max-duration and max-file-size errors as successful finishes. The latest repro receives AVFoundation's `AVErrorRecordingSuccessfullyFinishedKey=true` with `AVFoundationErrorDomain Code=-11818 "Recording Stopped"` and underlying `NSOSStatusErrorDomain Code=-16414`, which VisionCamera surfaces through `onRecordingError`.
 
 The high-level React hook path can enqueue `configure()` and `start()` back-to-back during one React update:
 
@@ -105,7 +111,7 @@ onStopped -> switch photo-only/video-only output topology + active
 
 The fourth test is closer to the production code in #3773. It keeps both photo and video outputs attached as `[photoOutput, videoOutput]`, recreates the video output by toggling `enableAudio`, toggles `photoHDR` plus HDR video dynamic range when supported, applies zoom targets across the virtual-device zoom range from `onStarted`, and immediately restarts from `onStopped`.
 
-The fifth test targets the active recording teardown boundary more directly. It keeps the Skia/filter-preview path attached, starts a real recorder, recreates the video output by toggling `enableAudio` while that recorder is still active, waits for `onSessionConfigSelected` from the reconfiguration, then stops the old recorder and restarts the camera from `onStopped`.
+The fifth test targets the active recording teardown boundary more directly. It keeps the Skia/filter-preview path attached, starts a real recorder, recreates the video output by toggling `enableAudio` while that recorder is still active, waits for `onSessionConfigSelected` from the reconfiguration, then stops the old recorder and restarts the camera from `onStopped`. After CI proved AVFoundation forcibly stops the active recording with `AVFoundationErrorDomain Code=-11818`, the current version treats that specific forced stop as an observed event and continues cycling.
 
 A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
 
@@ -167,7 +173,29 @@ CI observations from PR #4001 / Harness AWS Device run `27025713494` on commit `
 - The GitHub `Test iOS` job still reported failure because AWS Device Farm reported one failed item outside the Harness summary: `Total: 3, passed: 2, failed: 1`.
 - The printed Harness output did not contain an AVFoundation crash, app crash, failed test, `AVCaptureOutput`, `attachToFigCaptureSession`, or `detachFromFigCaptureSession`.
 
-Negative evidence: the iPhone SE result and the first four iOS Device Farm results suggest simple output topology changes, immediate active capture/recording cycles, and production-shape photo+video output recreation across restarts are not sufficient to deterministically reproduce the crash on the tested hardware/OS. Hardware/OS version, camera topology, recording while mutating the same output, recorder preparation/finalization lifetime, actual photo HDR enablement, lens switching during recording/capture, mount/unmount timing, or the original iPhone 11 / iOS 18.7.7 matrix likely matters.
+CI observations from PR #4001 / Harness AWS Device run `27027231154` on commit `62f9c32a855afa3b431454e518ceeed28f933c0d`:
+
+- Build iOS passed.
+- Test iOS executed on Apple iPhone 16 Pro.
+- The first four start-crash stress tests still passed:
+  - 60 native preview topology cycles completed in 13.509s.
+  - 60 Skia topology cycles completed in 13.392s.
+  - 18 active capture/record cycles completed in 7.877s.
+  - 80 production-shape restart cycles completed in 19.825s.
+- The new active-recorder mutation test failed in 627ms:
+  - `recreates video output while recording with Skia frame-preview attached`.
+  - Error: `AVFoundationErrorDomain Code=-11818 "Recording Stopped"`.
+  - User info includes `AVErrorRecordingSuccessfullyFinishedKey=true`.
+  - Recovery suggestion: `Stop any other actions using the recording device and try again.`
+  - Underlying error: `NSOSStatusErrorDomain Code=-16414`.
+- iOS Harness summary was red: 1 failed suite, 1 failed test, 128 passed, 15 skipped, 144 total.
+- The printed Harness output did not contain an app crash, `AVCaptureOutput`, `attachToFigCaptureSession`, or `detachFromFigCaptureSession`.
+
+Positive evidence: mutating/recreating the non-persistent video output while an `AVCaptureMovieFileOutput` recording is active is invalid on AVFoundation. AVFoundation forcibly stops that recording immediately. This is a concrete, deterministic reproduction of the dangerous output-lifetime boundary, but it is not yet the original private attach/detach assertion.
+
+The first implementation of this test intentionally failed on that forced stop. The current branch version now treats only this specific `Code=-11818` + `AVErrorRecordingSuccessfullyFinishedKey=true` result as an expected forced-stop event, then continues the stress loop to test the restart/finalization window that follows the forced stop.
+
+Negative evidence: the iPhone SE result and the first four iOS Device Farm results suggest simple output topology changes, immediate active capture/recording cycles, and production-shape photo+video output recreation across restarts are not sufficient to deterministically reproduce the crash on the tested hardware/OS. The active-recorder mutation result suggests the remaining crash window is probably after AVFoundation forcibly stops or finalizes an interrupted recording, not merely at the moment the output prop changes. Hardware/OS version, camera topology, actual photo HDR enablement, lens switching during recording/capture, mount/unmount timing, or the original iPhone 11 / iOS 18.7.7 matrix likely still matters.
 
 ## Verification done
 
@@ -190,13 +218,17 @@ The best current issue description is:
 
 > VisionCamera can enqueue `AVCaptureSession.startRunning()` immediately after a configuration commit that replaces outputs or changes output-affecting constraints. VisionCamera's own serial queue ensures `startRunning()` happens after `commitConfiguration()` returns, but AVFoundation/CoreMedia may still be processing the committed configuration asynchronously on `FigCaptureSessionNotificationQueue`. On affected hardware/OS combinations, `startRunning()` or a subsequent topology change can overlap that private output attachment/detachment work and trip AVFoundation's internal assertions in `-[AVCaptureOutput attachToFigCaptureSession:]` or `detachFromFigCaptureSession`.
 
-This is proven at the call-order/concurrency level by the crash stack and VisionCamera source. It is not yet proven at the "Apple internal field X had value Y" level because AVFoundation source is private and the exact assertion condition is not visible.
+The active-recorder mutation result adds one concrete sub-cause:
+
+> If JS recreates the video output, for example by toggling `enableAudio`, while a non-persistent `AVCaptureMovieFileOutput` recorder is active, AVFoundation forcibly stops the recording with `AVFoundationErrorDomain Code=-11818 "Recording Stopped"` and underlying `NSOSStatusErrorDomain Code=-16414`. That proves the output replacement crosses an AVFoundation recording lifetime boundary even before the private attach/detach assertion is hit.
+
+This is proven at the call-order/concurrency level by the crash stack and VisionCamera source, and at the active-recording lifetime level by the failing Harness run. It is not yet proven at the "Apple internal field X had value Y" level because AVFoundation source is private and the exact assertion condition is not visible.
 
 ## Next repro iteration
 
-The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The production-shape Harness iteration also passed on CI. The current next Harness iteration mutates/recreates the video output while a recorder is active and the Skia/frame-preview path is attached. If that also passes, the most likely remaining conditions to test are:
+The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, and the active-recorder mutation test now proves the non-persistent video output cannot be replaced during an active `AVCaptureMovieFileOutput` recording without AVFoundation forcibly stopping the recording. The current next Harness iteration continues after that forced stop. If that also does not crash, the most likely remaining conditions to test are:
 
-- preparing/finalizing a recorder while the session is being stopped/reconfigured,
+- immediately changing device or zoom after AVFoundation forcibly stops the interrupted recording,
 - changing zoom across a virtual-device lens switch during active capture or recording,
 - actual photo HDR enablement on a device where `supportsPhotoHDR` is true,
 - switching between virtual multi-camera device IDs instead of only using the default back camera,

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -1,0 +1,136 @@
+# Issue #3773 start crash findings
+
+Issue: https://github.com/mrousavy/react-native-vision-camera/issues/3773
+
+Branch: `codex/start-crash-3773`
+
+## Current status
+
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally yet. The local multi-physical-camera iPhone 15 Pro became locked and SpringBoard denied further launches, while the available iPhone SE 3rd gen ran the repro loop without crashing.
+
+The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. The exact assertion condition inside `-[AVCaptureOutput attachToFigCaptureSession:]` is private Apple code, so the remaining internal invariant is inferred from the stack, not decompiled source.
+
+## What the crash stack proves
+
+The crash stack in #3773 has two important concurrent paths:
+
+- One thread is inside `HybridCameraSession.start()` -> `AVCaptureSession.startRunning()` -> AVFoundation graph build.
+- Another thread is on `FigCaptureSessionNotificationQueue` inside AVFoundation's configuration-commit notification path, including `_handleConfigurationCommittedNotificationWithPayload`, `_makeConfigurationLive:`, and `-[AVCaptureOutput attachToFigCaptureSession:]`.
+
+That proves VisionCamera had already called `startRunning()` while AVFoundation/CoreMedia was still making a recently committed configuration live on its private notification queue.
+
+Because VisionCamera serializes `configure()` and `start()` on `HybridCameraSession.queue`, this overlap cannot be explained by two VisionCamera calls running at the same time on our queue. The only sequence consistent with the stack is:
+
+1. VisionCamera enters `session.beginConfiguration()`.
+2. VisionCamera mutates inputs, outputs, connections, formats, FPS, and stabilization.
+3. VisionCamera calls `session.commitConfiguration()`.
+4. `commitConfiguration()` returns to VisionCamera before AVFoundation's private "configuration committed" work has fully drained.
+5. VisionCamera's next queued `start()` runs and calls `session.startRunning()`.
+6. AVFoundation is still attaching outputs from the committed configuration on `FigCaptureSessionNotificationQueue`.
+7. AVFoundation hits its private assertion in `attachToFigCaptureSession`.
+
+## VisionCamera code path responsible
+
+Native serialization is in `packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift`:
+
+- `configure(...)` uses `Promise.parallel(Self.queue)`, then calls `beginConfiguration()` and `commitConfiguration()`.
+- `start()` uses the same `Self.queue`, then calls `session.startRunning()`.
+- `stop()` uses the same `Self.queue`, then calls `session.stopRunning()`.
+
+The queue guarantees call order only for VisionCamera's own work. It does not guarantee AVFoundation's private CoreMedia notification queue has finished processing the effects of `commitConfiguration()`.
+
+The high-level React hook path can enqueue `configure()` and `start()` back-to-back during one React update:
+
+- `useCameraController(...)` starts an async `session.configure(...)` effect when outputs or constraints change.
+- `useCamera()` then computes `hasController = controller != null`.
+- `useCameraSessionIsRunning(session, isActive && hasController)` starts an async `session.start()` effect.
+
+On a reconfiguration update, the previous controller can still be non-null until the new `configure()` resolves. If `isActive` is true in that same commit, React schedules both effects. Since `useCameraController(...)` is called before `useCameraSessionIsRunning(...)`, the native queue receives:
+
+```text
+session.configure(new outputs / constraints)
+session.start()
+```
+
+That is a valid VisionCamera queue order, but it is the exact dangerous order if AVFoundation's `commitConfiguration()` is not a full barrier for its private "make configuration live" work.
+
+## Local reproducer added
+
+`apps/simple-camera/src/screens/CameraScreen.tsx` now has `START_CRASH_REPRO = true`.
+
+The example app starts the camera automatically, then loops from native callbacks:
+
+1. `onStarted` sets `isActive=false`.
+2. `onStopped` swaps video output settings and optional HDR constraints.
+3. `onStopped` immediately sets `isActive=true`.
+4. The next React commit reconfigures outputs/constraints and restarts without sleeps.
+
+The loop attaches both photo and video outputs, alternates `HD_16_9`/`FHD_16_9` video output settings, requests 60 FPS when supported, requests cinematic-extended stabilization when supported, and toggles `photoHDR` when supported.
+
+This is intentionally event-driven. It does not use artificial sleeps or timeouts to create the race window.
+
+## Harness reproducer added
+
+`apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx` now contains:
+
+```text
+reconfigures outputs and immediately restarts from Camera lifecycle callbacks
+```
+
+It renders a high-level `<Camera>` and runs 120 cycles of:
+
+```text
+onStarted -> inactive
+onStopped -> replace video output + toggle constraints + active
+```
+
+This is the closest Harness shape to the reported crash because it exercises the React hook lifecycle that can enqueue `configure()` followed by `start()` in the same commit. A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
+
+## Device observations
+
+Local devices seen by `xcrun devicectl list devices`:
+
+- iPhone SE 3rd gen, iOS 26.5, single back wide camera.
+- iPhone 15 Pro, iOS 26.5, multi-physical back camera.
+
+Observed locally:
+
+- iPhone SE 3rd gen completed roughly 480 event-driven repro cycles without the AVFoundation assertion.
+- iPhone 15 Pro reached roughly 140 cycles in an earlier mixed-log run without the assertion, then the app process ended with exit code 0. I did not find a local crash report for `SimpleCamera`.
+- Subsequent iPhone 15 Pro launches were denied because the device was locked: `Unable to launch com.margelo.nitro.camera.example.simple because the device was not, or could not be, unlocked`.
+- The attached Teams video shows an app crash alert after an active video recording session, but it does not expose a native stack. It supports the general "active camera plus output/session state changes" trigger shape, not the internal AVFoundation diagnosis by itself.
+
+Negative evidence: the iPhone SE result suggests the crash is not a simple deterministic JavaScript loop bug on all hardware/OS combinations. Hardware, OS version, camera topology, or a narrower recording/output transition likely matters.
+
+## Verification done
+
+Commands that passed:
+
+```sh
+bun run build
+bunx tsc --noEmit --project apps/simple-camera/tsconfig.json
+git diff --check
+bun --cwd apps/simple-camera react-native bundle --platform ios --dev true --entry-file index.js --bundle-output /tmp/simple-camera-start-crash.bundle --assets-dest /tmp/simple-camera-start-crash-assets --reset-cache
+```
+
+`bunx biome check apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx apps/simple-camera/src/screens/CameraScreen.tsx` reported only pre-existing unused-variable warnings in `CameraScreen.tsx`. The new Harness file had no Biome diagnostics.
+
+Local `react-native-harness --harnessRunner ios` tried to boot an iOS simulator, so I stopped it. The simulator is not useful for this camera pipeline race; the PR CI iOS Harness run on real hardware is the relevant signal.
+
+## Current root-cause statement
+
+The best current issue description is:
+
+> VisionCamera can enqueue `AVCaptureSession.startRunning()` immediately after a configuration commit that replaces outputs or changes output-affecting constraints. VisionCamera's own serial queue ensures `startRunning()` happens after `commitConfiguration()` returns, but AVFoundation/CoreMedia may still be processing the committed configuration asynchronously on `FigCaptureSessionNotificationQueue`. On affected hardware/OS combinations, `startRunning()` can overlap that private output-attachment work and trip AVFoundation's internal assertion in `-[AVCaptureOutput attachToFigCaptureSession:]`.
+
+This is proven at the call-order/concurrency level by the crash stack and VisionCamera source. It is not yet proven at the "Apple internal field X had value Y" level because AVFoundation source is private and the exact assertion condition is not visible.
+
+## What would count as proof of a fix
+
+A proper fix needs to change the ordering contract, then re-run the same repro loop and Harness test:
+
+- prevent `startRunning()` from being enqueued while a reconfiguration is still becoming live, or
+- make the high-level hook clear/withhold the previous controller during reconfiguration so a prop update cannot schedule `configure()` and `start()` in the same React commit, or
+- add a native barrier based on a real AVFoundation lifecycle signal if one exists.
+
+Artificial sleeps are not proof. They would only lower the race probability.

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -6,7 +6,7 @@ Branch: `codex/start-crash-3773`
 
 ## Current status
 
-This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally yet. The local multi-physical-camera iPhone 15 Pro became locked and SpringBoard denied further launches, while the available iPhone SE 3rd gen ran the repro loop without crashing.
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked and SpringBoard denied further launches, while the available iPhone SE 3rd gen ran the repro loop without crashing. The first CI iOS Harness run also ran the new 120-cycle repro on a multi-camera iOS Device Farm device without crashing.
 
 The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. The exact assertion condition inside `-[AVCaptureOutput attachToFigCaptureSession:]` is private Apple code, so the remaining internal invariant is inferred from the stack, not decompiled source.
 
@@ -100,7 +100,16 @@ Observed locally:
 - Subsequent iPhone 15 Pro launches were denied because the device was locked: `Unable to launch com.margelo.nitro.camera.example.simple because the device was not, or could not be, unlocked`.
 - The attached Teams video shows an app crash alert after an active video recording session, but it does not expose a native stack. It supports the general "active camera plus output/session state changes" trigger shape, not the internal AVFoundation diagnosis by itself.
 
-Negative evidence: the iPhone SE result suggests the crash is not a simple deterministic JavaScript loop bug on all hardware/OS combinations. Hardware, OS version, camera topology, or a narrower recording/output transition likely matters.
+CI observations from PR #4001 / Harness AWS Device run `27018903509`:
+
+- Build iOS passed.
+- Test iOS executed on a multi-camera iOS device exposing wide, ultra-wide, telephoto, dual, dual-wide, triple, lidar-depth, and true-depth devices.
+- The new Harness test completed 120 cycles on `Back Camera` in 25.766s: `reconfigures outputs and immediately restarts from Camera lifecycle callbacks`.
+- iOS Harness summary was green: 12 test suites passed, 125 tests passed, 15 skipped, 0 failed.
+- The GitHub `Test iOS` job still reported failure because the Device Farm step itself returned failed, but the Harness output did not contain an AVFoundation crash, app crash, failed test, or assertion.
+- Android also ran the new test and completed 120 cycles in 27.414s. Android failed in unrelated existing suites (`photo`, `coordinates`, `controller`, `video`), not in the new Camera-view repro.
+
+Negative evidence: the iPhone SE result and the first iOS Device Farm result suggest the current loop is not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, recording state, recorder preparation, lens switching, mount/unmount timing, or a narrower output transition likely matters.
 
 ## Verification done
 
@@ -124,6 +133,17 @@ The best current issue description is:
 > VisionCamera can enqueue `AVCaptureSession.startRunning()` immediately after a configuration commit that replaces outputs or changes output-affecting constraints. VisionCamera's own serial queue ensures `startRunning()` happens after `commitConfiguration()` returns, but AVFoundation/CoreMedia may still be processing the committed configuration asynchronously on `FigCaptureSessionNotificationQueue`. On affected hardware/OS combinations, `startRunning()` can overlap that private output-attachment work and trip AVFoundation's internal assertion in `-[AVCaptureOutput attachToFigCaptureSession:]`.
 
 This is proven at the call-order/concurrency level by the crash stack and VisionCamera source. It is not yet proven at the "Apple internal field X had value Y" level because AVFoundation source is private and the exact assertion condition is not visible.
+
+## Next repro iteration
+
+The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The most likely next conditions to test are:
+
+- actively recording while replacing or recreating the video output,
+- preparing a new recorder while the session is being stopped/reconfigured,
+- changing zoom across a virtual-device lens switch before the stop/restart cycle,
+- switching between virtual multi-camera device IDs instead of only using the default back camera,
+- unmounting/remounting `<Camera>` instead of only toggling `isActive`,
+- testing on the original crash matrix, especially iPhone 11 on iOS 18.7.7.
 
 ## What would count as proof of a fix
 

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -76,13 +76,14 @@ This is intentionally event-driven. It does not use artificial sleeps or timeout
 
 ## Harness reproducer added
 
-`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains four iOS-only stress tests:
+`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains five iOS-only stress tests:
 
 ```text
 cycles photo -> video -> photo outputs through native preview start/stop
 cycles photo -> video -> photo outputs with Skia frame-preview attached
 captures photo -> records video -> captures photo with Skia frame-preview attached
 restarts with stable photo/video outputs while toggling audio, HDR, and zoom
+recreates video output while recording with Skia frame-preview attached
 ```
 
 The first two tests render high-level camera components and run 60 cycles of:
@@ -103,6 +104,8 @@ onStopped -> switch photo-only/video-only output topology + active
 ```
 
 The fourth test is closer to the production code in #3773. It keeps both photo and video outputs attached as `[photoOutput, videoOutput]`, recreates the video output by toggling `enableAudio`, toggles `photoHDR` plus HDR video dynamic range when supported, applies zoom targets across the virtual-device zoom range from `onStarted`, and immediately restarts from `onStopped`.
+
+The fifth test targets the active recording teardown boundary more directly. It keeps the Skia/filter-preview path attached, starts a real recorder, recreates the video output by toggling `enableAudio` while that recorder is still active, waits for `onSessionConfigSelected` from the reconfiguration, then stops the old recorder and restarts the camera from `onStopped`.
 
 A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
 
@@ -191,9 +194,8 @@ This is proven at the call-order/concurrency level by the crash stack and Vision
 
 ## Next repro iteration
 
-The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The production-shape Harness iteration also passed on CI. The most likely remaining conditions to test are:
+The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The production-shape Harness iteration also passed on CI. The current next Harness iteration mutates/recreates the video output while a recorder is active and the Skia/frame-preview path is attached. If that also passes, the most likely remaining conditions to test are:
 
-- actively recording while replacing or recreating the video output,
 - preparing/finalizing a recorder while the session is being stopped/reconfigured,
 - changing zoom across a virtual-device lens switch during active capture or recording,
 - actual photo HDR enablement on a device where `supportsPhotoHDR` is true,

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -6,7 +6,7 @@ Branch: `codex/start-crash-3773`
 
 ## Current status
 
-This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked and SpringBoard denied further launches, while the available iPhone SE 3rd gen ran the earlier repro loop without crashing. The first CI iOS Harness run also ran the earlier 120-cycle repro on a multi-camera iOS Device Farm device without crashing.
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run both the earlier broad 120-cycle repro and the corrected `photo -> video -> photo` native/Skia topology repro on real iOS Device Farm hardware without crashing.
 
 The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The original stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. A separate client report mentions the sibling private assertion `AVCaptureOutput detachFromFigCaptureSession` during rapid `photo -> video -> photo` changes, especially with a filter-preview path involved. That client report is not a stack trace, but it is directionally important because it points at the same output lifetime boundary from the detach side rather than the attach side. The exact assertion conditions inside `-[AVCaptureOutput attachToFigCaptureSession:]` and `detachFromFigCaptureSession` are private Apple code, so the remaining internal invariant is inferred from stacks/logs, not decompiled source.
 
@@ -62,10 +62,13 @@ That is a valid VisionCamera queue order, but it is the exact dangerous order if
 
 The example app starts the camera automatically, then loops from native callbacks:
 
-1. `onStarted` sets `isActive=false`.
-2. `onStopped` alternates the active output topology between photo-only and video-only.
-3. `onStopped` immediately sets `isActive=true`.
-4. The next React commit reconfigures outputs/constraints and restarts without sleeps.
+1. `onStarted` runs actual capture work for the current mode.
+2. Photo cycles call `capturePhoto(...)` and dispose the returned `Photo`.
+3. Video cycles create a recorder, start recording, and stop recording immediately after `startRecording(...)` resolves.
+4. The capture cycle then sets `isActive=false`.
+5. `onStopped` alternates the active output topology between photo-only and video-only.
+6. `onStopped` immediately sets `isActive=true`.
+7. The next React commit reconfigures outputs/constraints and restarts without sleeps.
 
 The current loop uses `<SkiaCamera>` so the preview path is a frame output rendered through Skia rather than a native preview output. It alternates `photo -> video -> photo`, alternates `HD_16_9`/`FHD_16_9` video output settings, requests 60 FPS when supported, requests cinematic-extended stabilization during video cycles when supported, and toggles `photoHDR` during photo cycles when supported.
 
@@ -73,21 +76,32 @@ This is intentionally event-driven. It does not use artificial sleeps or timeout
 
 ## Harness reproducer added
 
-`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains two iOS-only stress tests:
+`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains three iOS-only stress tests:
 
 ```text
 cycles photo -> video -> photo outputs through native preview start/stop
 cycles photo -> video -> photo outputs with Skia frame-preview attached
+captures photo -> records video -> captures photo with Skia frame-preview attached
 ```
 
-They render high-level camera components and run 60 cycles of:
+The first two tests render high-level camera components and run 60 cycles of:
 
 ```text
 onStarted -> inactive
 onStopped -> switch photo-only/video-only output topology + toggle constraints + active
 ```
 
-The first stress test uses the normal `<Camera>` native preview path. The second uses `<SkiaCamera>`, which always adds a frame output for preview rendering and therefore exercises the filter-preview shape mentioned in the newer client report. A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
+The first stress test uses the normal `<Camera>` native preview path. The second uses `<SkiaCamera>`, which always adds a frame output for preview rendering and therefore exercises the filter-preview shape mentioned in the newer client report.
+
+The third test keeps the Skia preview path and runs 18 cycles of real capture activity:
+
+```text
+photo mode -> capturePhoto -> inactive
+video mode -> create recorder -> startRecording -> stopRecording -> inactive
+onStopped -> switch photo-only/video-only output topology + active
+```
+
+A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
 
 ## Device observations
 
@@ -101,6 +115,7 @@ Observed locally:
 - iPhone SE 3rd gen completed roughly 480 event-driven repro cycles without the AVFoundation assertion.
 - iPhone 15 Pro reached roughly 140 cycles in an earlier mixed-log run without the assertion, then the app process ended with exit code 0. I did not find a local crash report for `SimpleCamera`.
 - Subsequent iPhone 15 Pro launches were denied because the device was locked: `Unable to launch com.margelo.nitro.camera.example.simple because the device was not, or could not be, unlocked`.
+- A later iPhone 15 Pro launch attempt on the same branch failed before app launch with `xcodebuild` exit code 65 and a final linker failure. That local run did not exercise the camera repro.
 - The attached Teams video shows an app crash alert after an active video recording session, but it does not expose a native stack. It supports the general "active camera plus output/session state changes" trigger shape, not the internal AVFoundation diagnosis by itself.
 
 CI observations from PR #4001 / Harness AWS Device run `27018903509` for the earlier, now-replaced Harness repro:
@@ -114,7 +129,15 @@ CI observations from PR #4001 / Harness AWS Device run `27018903509` for the ear
 
 Why CI passed: that earlier Harness test was not equivalent to either report. It kept photo and video outputs attached together, then mostly recreated the video output and restarted. It did not remove the photo output before adding video, did not remove video before re-adding photo, did not use the Skia/filter-preview path, did not record video, and did not run on the original iPhone 11 / iOS 18.7.7 matrix. Its green result only proves that "replace video while photo remains attached, then restart" did not hit the assertion on that AWS device in 120 cycles.
 
-Negative evidence: the iPhone SE result and the first iOS Device Farm result suggest the earlier loop was not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, recording state, recorder preparation, lens switching, mount/unmount timing, or the narrower photo-only/video-only output transition likely matters.
+CI observations from PR #4001 / Harness AWS Device run `27022466051` on commit `aa4456ce71f6a81a9dab7c89de1c7c69604c15ff`:
+
+- Build iOS passed.
+- Test iOS executed on Apple iPhone 16 Pro.
+- The corrected start-crash stress file passed: 60 native preview topology cycles completed in 13.257s and 60 Skia topology cycles completed in 13.668s.
+- iOS Harness summary was green: 13 test suites passed, 126 tests passed, 15 skipped, 0 failed.
+- The GitHub `Test iOS` job still reported failure because AWS Device Farm reported one failed item outside the Harness summary: `Total: 3, passed: 2, failed: 1`. The printed Harness output did not contain an AVFoundation crash, app crash, failed test, `attachToFigCaptureSession`, or `detachFromFigCaptureSession`.
+
+Negative evidence: the iPhone SE result and the first two iOS Device Farm results suggest output topology changes alone are not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, active recording/capture state, recorder preparation, lens switching, mount/unmount timing, or the original iPhone 11 / iOS 18.7.7 matrix likely matters.
 
 ## Verification done
 

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -6,7 +6,7 @@ Branch: `codex/start-crash-3773`
 
 ## Current status
 
-This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run the earlier broad 120-cycle repro, the corrected `photo -> video -> photo` native/Skia topology repro, and the active photo/video capture topology repro on real iOS Device Farm hardware without crashing.
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run the earlier broad 120-cycle repro, the corrected `photo -> video -> photo` native/Skia topology repro, the active photo/video capture topology repro, and a production-shape photo+video output restart repro on real iOS Device Farm hardware without crashing.
 
 The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The original stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. A separate client report mentions the sibling private assertion `AVCaptureOutput detachFromFigCaptureSession` during rapid `photo -> video -> photo` changes, especially with a filter-preview path involved. That client report is not a stack trace, but it is directionally important because it points at the same output lifetime boundary from the detach side rather than the attach side. The exact assertion conditions inside `-[AVCaptureOutput attachToFigCaptureSession:]` and `detachFromFigCaptureSession` are private Apple code, so the remaining internal invariant is inferred from stacks/logs, not decompiled source.
 
@@ -149,7 +149,22 @@ CI observations from PR #4001 / Harness AWS Device run `27023974149` on commit `
 - The GitHub `Test iOS` job still reported failure because AWS Device Farm reported one failed item outside the Harness summary: `Total: 3, passed: 2, failed: 1`.
 - The printed Harness output did not contain an AVFoundation crash, app crash, failed test, `attachToFigCaptureSession`, or `detachFromFigCaptureSession`.
 
-Negative evidence: the iPhone SE result and the first three iOS Device Farm results suggest simple output topology changes and immediate active capture/recording cycles are not sufficient to deterministically reproduce the crash. Hardware/OS version, camera topology, recording while mutating the same output, recorder preparation lifetime, lens switching, mount/unmount timing, stable photo+video outputs with output recreation, or the original iPhone 11 / iOS 18.7.7 matrix likely matters.
+CI observations from PR #4001 / Harness AWS Device run `27025713494` on commit `41d3378c3b4ca3684cdd80b889b2974a9148d5c8`:
+
+- Build iOS passed.
+- Test iOS executed on Apple iPhone 16 Pro.
+- The complete start-crash stress file passed:
+  - 60 native preview topology cycles completed in 13.139s.
+  - 60 Skia topology cycles completed in 13.519s.
+  - 18 active capture/record cycles completed in 7.734s.
+  - 80 production-shape restart cycles completed in 20.028s.
+- The production-shape test kept `[photoOutput, videoOutput]` attached, toggled `enableAudio`, toggled HDR video dynamic range when supported, applied zoom from `onStarted`, and immediately restarted from `onStopped`.
+- The iPhone 16 Pro back devices in this run reported `supportsPhotoHDR: false` and `hdrRanges: 6`, so this run exercised video HDR dynamic range toggling but not actual photo HDR enablement.
+- iOS Harness summary was green: 13 test suites passed, 128 tests passed, 15 skipped, 0 failed.
+- The GitHub `Test iOS` job still reported failure because AWS Device Farm reported one failed item outside the Harness summary: `Total: 3, passed: 2, failed: 1`.
+- The printed Harness output did not contain an AVFoundation crash, app crash, failed test, `AVCaptureOutput`, `attachToFigCaptureSession`, or `detachFromFigCaptureSession`.
+
+Negative evidence: the iPhone SE result and the first four iOS Device Farm results suggest simple output topology changes, immediate active capture/recording cycles, and production-shape photo+video output recreation across restarts are not sufficient to deterministically reproduce the crash on the tested hardware/OS. Hardware/OS version, camera topology, recording while mutating the same output, recorder preparation/finalization lifetime, actual photo HDR enablement, lens switching during recording/capture, mount/unmount timing, or the original iPhone 11 / iOS 18.7.7 matrix likely matters.
 
 ## Verification done
 
@@ -176,11 +191,12 @@ This is proven at the call-order/concurrency level by the crash stack and Vision
 
 ## Next repro iteration
 
-The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The current next Harness iteration tests the production shape where photo and video outputs stay attached together while `enableAudio`, HDR constraints, and zoom change across immediate restart cycles. If that also passes, the most likely remaining conditions to test are:
+The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, but the negative CI result means the original issue likely needs an additional condition. The production-shape Harness iteration also passed on CI. The most likely remaining conditions to test are:
 
 - actively recording while replacing or recreating the video output,
-- preparing a new recorder while the session is being stopped/reconfigured,
-- changing zoom across a virtual-device lens switch before the stop/restart cycle,
+- preparing/finalizing a recorder while the session is being stopped/reconfigured,
+- changing zoom across a virtual-device lens switch during active capture or recording,
+- actual photo HDR enablement on a device where `supportsPhotoHDR` is true,
 - switching between virtual multi-camera device IDs instead of only using the default back camera,
 - unmounting/remounting `<Camera>` instead of only toggling `isActive`,
 - testing on the original crash matrix, especially iPhone 11 on iOS 18.7.7.

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -41,7 +41,14 @@ _outputInternal->figCaptureSession == NULL
 figCaptureSession == _outputInternal->figCaptureSession
 ```
 
-This is not source-level decompilation, and it is not the exact iPhone 11 / iOS 18.7.7 binary from the issue. It is still stronger than a guess: the assertion predicates are embedded in nearby iOS 18.7.x AVFCapture binaries and match the stack functions in #3773.
+Local disassembly of the iOS 18.7.1 `AVFCapture` binary confirms those strings are the actual branch predicates:
+
+- `-[AVCaptureOutput attachToFigCaptureSession:]` builds a dispatch barrier block on the output's internal queue. The block reads the output internal pointer at offset `0x10`, branches to `___45-[AVCaptureOutput attachToFigCaptureSession:]_block_invoke.cold.1` if it is non-null, otherwise stores the incoming FigCaptureSession pointer there and then calls `attachSafelyToFigCaptureSession:`.
+- `-[AVCaptureOutput detachFromFigCaptureSession:]` uses the same dispatch barrier shape. The block compares the incoming FigCaptureSession pointer to the output internal pointer at offset `0x10`, branches to `___47-[AVCaptureOutput detachFromFigCaptureSession:]_block_invoke.cold.1` if they differ, otherwise clears that internal pointer to null and then calls `detachSafelyFromFigCaptureSession:`.
+- `_makeConfigurationLive:` first computes unique inputs/outputs/preview layers from the old and new `AVCaptureSessionConfiguration`s, calls `detachFromFigCaptureSession:` for old preview layers, then calls `attachToFigCaptureSession:` for new preview layers. Around the unique input/output sets it also calls `makeObjectsPerformSelector:withObject:` with the same old/new FigCaptureSession pointer. This matches the reporter stack: `_handleConfigurationCommittedNotificationWithPayload:` calls `_makeConfigurationLive:`, which makes the output attachment live on `FigCaptureSessionNotificationQueue`.
+- The same symbol table exposes separate `AVCaptureSessionInternal` fields for `committedAVCaptureSessionConfigurations`, `liveAVCaptureSessionConfiguration`, and `waitingForFigCaptureSessionConfigurationToBecomeLive`. That makes the important lifecycle split explicit: a configuration can be committed before it is live.
+
+This is not source-level decompilation, and it is not the exact iPhone 11 / iOS 18.7.7 binary from the issue. It is still stronger than a guess: the assertion predicates and attachment order are visible in nearby iOS 18.7.x AVFCapture binaries and match the stack functions in #3773.
 
 ## VisionCamera code path responsible
 
@@ -245,7 +252,23 @@ CI observations from PR #4001 / Harness AWS Device run `27029008264` on commit `
 - The GitHub `Test iOS` job still reported failure because AWS Device Farm reported `FAILED` outside the Harness summary and the wrapper exited with code 1.
 - The printed Harness output did not contain an app crash, `AVCaptureOutput`, `attachToFigCaptureSession`, `detachFromFigCaptureSession`, `SIGABRT`, or `EXC_`.
 
-Negative evidence: the iPhone SE result and the first five iOS Device Farm results suggest simple output topology changes, immediate active capture/recording cycles, production-shape photo+video output recreation across restarts, active-recorder output mutation, and continuing after AVFoundation forced recording stops are not sufficient to deterministically reproduce the crash on the tested hardware/OS. Hardware/OS version, camera topology, actual photo HDR enablement, lens switching during recording/capture, mount/unmount timing, reporter-style active control mutation, or the original iPhone 11 / iOS 18.7.7 matrix likely still matters.
+CI observations from PR #4001 / Harness AWS Device run `27030309527` on commit `695e1fe3cc4ab510a67072279b97eae500e348bd`:
+
+- Build iOS passed.
+- Test iOS executed on Apple iPhone 16 Pro.
+- The six pushed start-crash stress tests all passed:
+  - 60 native preview topology cycles completed in 13.720s.
+  - 60 Skia topology cycles completed in 12.624s.
+  - 18 active capture/record cycles completed in 7.512s.
+  - 80 production-shape restart cycles completed in 19.208s.
+  - 12 active-recorder mutation cycles completed in 10.414s, with 12 forced recording stops.
+  - 80 reporter-style active interaction cycles completed in 15.163s.
+- iOS Harness summary was green: 13 passed suites, 130 passed tests, 15 skipped, 145 total, time 326.018s.
+- The GitHub `Test iOS` job still reported failure because AWS Device Farm reported `FAILED` outside the Harness summary and the wrapper exited with code 1.
+- The active-interaction test produced expected/tolerated focus metering cancellation/timeouts and torch rejections on a no-torch device. These were control API failures, not session errors.
+- The printed Harness output did not contain an app crash, `AVCaptureOutput`, `attachToFigCaptureSession`, `detachFromFigCaptureSession`, `AVFoundationErrorDomain`, `SIGABRT`, or `EXC_`.
+
+Negative evidence: the iPhone SE result and the first six iOS Device Farm results suggest simple output topology changes, immediate active capture/recording cycles, production-shape photo+video output recreation across restarts, active-recorder output mutation, continuing after AVFoundation forced recording stops, and reporter-style active control mutation are not sufficient to deterministically reproduce the crash on the tested hardware/OS. Hardware/OS version, camera topology, actual photo HDR enablement, lens switching during recording/capture, mount/unmount timing, TestFlight/release timing, or the original iPhone 11 / iOS 18.7.7 matrix likely still matters.
 
 ## Verification done
 
@@ -257,8 +280,12 @@ bunx tsc --noEmit --project apps/simple-camera/tsconfig.json
 git diff --check
 bun --cwd apps/simple-camera react-native bundle --platform ios --dev true --entry-file index.js --bundle-output /tmp/simple-camera-start-crash.bundle --assets-dest /tmp/simple-camera-start-crash-assets --reset-cache
 xcrun nm -m "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" | rg "attachToFigCaptureSession|detachFromFigCaptureSession|_makeConfigurationLive|_handleConfigurationCommittedNotification"
+xcrun nm -m "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" | rg "AVCaptureSessionInternal"
 strings -a "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" | rg "attachToFigCaptureSession|detachFromFigCaptureSession|figCaptureSession|AVCaptureOutput\\.m"
 strings -a "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7 (22H20)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" | rg "AVCaptureOutput\\.m|_outputInternal->figCaptureSession == NULL|figCaptureSession == _outputInternal->figCaptureSession|attachToFigCaptureSession|detachFromFigCaptureSession"
+xcrun llvm-objdump --arch-name=arm64 --start-address=0x1a1d0fd6c --stop-address=0x1a1d0fe20 -d "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture"
+xcrun llvm-objdump --arch-name=arm64 --start-address=0x1a1d527f8 --stop-address=0x1a1d528c0 -d "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture"
+xcrun llvm-objdump --arch-name=arm64 --start-address=0x1a1d27c30 --stop-address=0x1a1d28080 -d "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" > /tmp/avfcapture_make_live_disasm.txt
 ```
 
 `bunx biome check apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx apps/simple-camera/src/screens/CameraScreen.tsx START_CRASH_FINDINGS.md apps/simple-camera/__tests__/README.md` reported only pre-existing unused-variable warnings in `CameraScreen.tsx`. The new stress Harness file had no Biome diagnostics.

--- a/START_CRASH_FINDINGS.md
+++ b/START_CRASH_FINDINGS.md
@@ -6,9 +6,9 @@ Branch: `codex/start-crash-3773`
 
 ## Current status
 
-This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and a later local `run-ios` attempt failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run the earlier broad 120-cycle repro, the corrected `photo -> video -> photo` native/Skia topology repro, the active photo/video capture topology repro, and a production-shape photo+video output restart repro on real iOS Device Farm hardware without crashing. A newer active-recorder mutation repro does fail deterministically on CI, but with `AVFoundationErrorDomain Code=-11818 "Recording Stopped"` rather than the private attach/detach assertion.
+This branch contains an event-driven reproducer in the simple-camera app and an iOS Harness stress test. I have not produced the exact AVFoundation assertion locally or in CI yet. The local multi-physical-camera iPhone 15 Pro became locked during the first attempt and later local `run-ios` attempts failed in Xcode before launching the app. The available iPhone SE 3rd gen ran the earlier repro loop without crashing. CI has now run the earlier broad 120-cycle repro, the corrected `photo -> video -> photo` native/Skia topology repro, the active photo/video capture topology repro, and a production-shape photo+video output restart repro on real iOS Device Farm hardware without crashing. A newer active-recorder mutation repro does fail deterministically on CI, but with `AVFoundationErrorDomain Code=-11818 "Recording Stopped"` rather than the private attach/detach assertion.
 
-The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The original stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. A separate client report mentions the sibling private assertion `AVCaptureOutput detachFromFigCaptureSession` during rapid `photo -> video -> photo` changes, especially with a filter-preview path involved. That client report is not a stack trace, but it is directionally important because it points at the same output lifetime boundary from the detach side rather than the attach side. The exact assertion conditions inside `-[AVCaptureOutput attachToFigCaptureSession:]` and `detachFromFigCaptureSession` are private Apple code, so the remaining internal invariant is inferred from stacks/logs, not decompiled source.
+The strongest confirmed root-cause evidence is therefore the original issue stack plus the VisionCamera call ordering below. The original stack proves `AVCaptureSession.startRunning()` overlapped with AVFoundation's private configuration-commit notification path. A symbol/string pass over local iOS 18.7 and 18.7.1 `AVFCapture` DeviceSupport binaries confirms the private assertion strings for this exact output lifetime boundary: `-[AVCaptureOutput attachToFigCaptureSession:]_block_invoke` asserts `_outputInternal->figCaptureSession == NULL`, while `-[AVCaptureOutput detachFromFigCaptureSession:]_block_invoke` asserts `figCaptureSession == _outputInternal->figCaptureSession`. The reporter's attach-side crash means AVFoundation tried to attach an output object whose internal `figCaptureSession` pointer was already non-null. A separate client report mentions the sibling private assertion `AVCaptureOutput detachFromFigCaptureSession` during rapid `photo -> video -> photo` changes, especially with a filter-preview path involved. That client report is not a stack trace, but it is directionally important because it points at the same output lifetime boundary from the detach side rather than the attach side.
 
 ## What the crash stack proves
 
@@ -30,6 +30,18 @@ Because VisionCamera serializes `configure()` and `start()` on `HybridCameraSess
 7. AVFoundation hits its private assertion in `attachToFigCaptureSession`.
 
 The newer client report describes `detachFromFigCaptureSession`, which is the same class of invariant violation during output teardown instead of output attachment. Taken together, the evidence points at AVFoundation output attachment/detachment lifetime crossing a session start or a subsequent output topology change. It does not point at JavaScript timing alone, and it does not prove that a single specific output type is always responsible.
+
+Local private-symbol evidence from `/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7 (22H20)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture` and the matching 18.7.1 DeviceSupport binary:
+
+```text
+-[AVCaptureOutput attachToFigCaptureSession:]_block_invoke
+AVCaptureOutput.m
+_outputInternal->figCaptureSession == NULL
+-[AVCaptureOutput detachFromFigCaptureSession:]_block_invoke
+figCaptureSession == _outputInternal->figCaptureSession
+```
+
+This is not source-level decompilation, and it is not the exact iPhone 11 / iOS 18.7.7 binary from the issue. It is still stronger than a guess: the assertion predicates are embedded in nearby iOS 18.7.x AVFCapture binaries and match the stack functions in #3773.
 
 ## VisionCamera code path responsible
 
@@ -53,7 +65,7 @@ The high-level React hook path can enqueue `configure()` and `start()` back-to-b
 - `useCamera()` then computes `hasController = controller != null`.
 - `useCameraSessionIsRunning(session, isActive && hasController)` starts an async `session.start()` effect.
 
-On a reconfiguration update, the previous controller can still be non-null until the new `configure()` resolves. If `isActive` is true in that same commit, React schedules both effects. Since `useCameraController(...)` is called before `useCameraSessionIsRunning(...)`, the native queue receives:
+On a reconfiguration update, `useCameraController(...)` does not clear the previous controller before starting the new async `session.configure(...)`. The previous controller can therefore remain non-null until the new `configure()` resolves. If `isActive` is true in that same commit, React schedules both effects. Since `useCameraController(...)` is called before `useCameraSessionIsRunning(...)`, the native queue receives:
 
 ```text
 session.configure(new outputs / constraints)
@@ -61,6 +73,27 @@ session.start()
 ```
 
 That is a valid VisionCamera queue order, but it is the exact dangerous order if AVFoundation's `commitConfiguration()` is not a full barrier for its private "make configuration live" work.
+
+The imperative controller path from the reporter repro is less suspicious than the output/session path. `HybridCameraController` is initialized with `HybridCameraSession.Self.queue`; `setZoom`, `focusTo`, `setExposureBias`, `setTorchMode`, and the controller `configure(...)` all lock the `AVCaptureDevice` on that same queue. Those calls are therefore serialized with VisionCamera's own `configure/start/stop` work. They may still cause AVFoundation/CoreMedia to do additional private work after the lock is released, but they are not concurrent VisionCamera queue mutations.
+
+## Reporter repro repo comparison
+
+The #3773 reporter provided `https://github.com/qutrek/vision-camera-v5-attach-race-repro`. I cloned it to `/tmp/vision-camera-v5-attach-race-repro` and inspected `src/camera/CameraModal.tsx`.
+
+Important production-shape details from that repro:
+
+- Only one `<Camera>` is mounted.
+- There are no frame processors in the reporter repro.
+- `photoOutput` and `videoOutput` stay attached together as `[photoOutput, videoOutput]`.
+- Toggling mute recreates `videoOutput` because `enableAudio: !isMuted` changes.
+- Toggling HDR changes the constraints array with 60 FPS, cinematic-extended stabilization, optional `photoHDR`, and optional HDR video dynamic range.
+- Video capture creates a fresh single-use recorder, calls `startRecording(...)`, then later `stopRecording()` or `cancelRecording()`.
+- Video review uses `pendingMedia`, which drives `isActive=false`; retake sets `pendingMedia=null`, so the same mounted `<Camera>` restarts.
+- Multi-photo capture keeps the camera active and appends to `pendingPhotos`.
+- `onCameraStarted` reapplies torch, exposure, and zoom imperatively.
+- Zoom preset changes can cross virtual-device lens-switch factors while the session is active.
+
+Current Harness coverage matches the stable `[photoOutput, videoOutput]`, mute-output recreation, HDR-video dynamic range, zoom-on-start, video recording, video-retake active restart, and reporter-style active-session control mutation pieces. It still does not cover exact iPhone 11 / iOS 18.7.7 hardware/OS behavior.
 
 ## Local reproducer added
 
@@ -82,7 +115,7 @@ This is intentionally event-driven. It does not use artificial sleeps or timeout
 
 ## Harness reproducer added
 
-`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains five iOS-only stress tests:
+`apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx` now contains six iOS-only stress tests:
 
 ```text
 cycles photo -> video -> photo outputs through native preview start/stop
@@ -90,6 +123,7 @@ cycles photo -> video -> photo outputs with Skia frame-preview attached
 captures photo -> records video -> captures photo with Skia frame-preview attached
 restarts with stable photo/video outputs while toggling audio, HDR, and zoom
 recreates video output while recording with Skia frame-preview attached
+mutates reporter-style active controls while reconfiguring outputs
 ```
 
 The first two tests render high-level camera components and run 60 cycles of:
@@ -113,6 +147,8 @@ The fourth test is closer to the production code in #3773. It keeps both photo a
 
 The fifth test targets the active recording teardown boundary more directly. It keeps the Skia/filter-preview path attached, starts a real recorder, recreates the video output by toggling `enableAudio` while that recorder is still active, waits for `onSessionConfigSelected` from the reconfiguration, then stops the old recorder and restarts the camera from `onStopped`. After CI proved AVFoundation forcibly stops the active recording with `AVFoundationErrorDomain Code=-11818`, the current version treats that specific forced stop as an observed event and continues cycling.
 
+The sixth test targets the reporter repro's active-session interaction pattern. It keeps the native preview `<Camera>` active, keeps `[photoOutput, videoOutput]` attached, fires zoom/focus/exposure/torch updates through public Camera APIs, then toggles `enableAudio`, HDR constraints, and occasionally front/back device selection. It advances from `onStarted` and `onConfigured`, not from sleeps.
+
 A crash on CI should appear as an iOS Harness process failure rather than a normal assertion failure.
 
 ## Device observations
@@ -127,7 +163,7 @@ Observed locally:
 - iPhone SE 3rd gen completed roughly 480 event-driven repro cycles without the AVFoundation assertion.
 - iPhone 15 Pro reached roughly 140 cycles in an earlier mixed-log run without the assertion, then the app process ended with exit code 0. I did not find a local crash report for `SimpleCamera`.
 - Subsequent iPhone 15 Pro launches were denied because the device was locked: `Unable to launch com.margelo.nitro.camera.example.simple because the device was not, or could not be, unlocked`.
-- A later iPhone 15 Pro launch attempt on the same branch failed before app launch with `xcodebuild` exit code 65 and a final linker failure. That local run did not exercise the camera repro.
+- Later iPhone 15 Pro launch attempts on the same branch failed before app launch with `xcodebuild` exit code 65 and a final linker failure. The latest run also showed unavailable C++ `std::error_code` / `std::error_condition` imports while compiling Pods. Those local runs did not exercise the camera repro.
 - The attached Teams video shows an app crash alert after an active video recording session, but it does not expose a native stack. It supports the general "active camera plus output/session state changes" trigger shape, not the internal AVFoundation diagnosis by itself.
 
 CI observations from PR #4001 / Harness AWS Device run `27018903509` for the earlier, now-replaced Harness repro:
@@ -195,7 +231,21 @@ Positive evidence: mutating/recreating the non-persistent video output while an 
 
 The first implementation of this test intentionally failed on that forced stop. The current branch version now treats only this specific `Code=-11818` + `AVErrorRecordingSuccessfullyFinishedKey=true` result as an expected forced-stop event, then continues the stress loop to test the restart/finalization window that follows the forced stop.
 
-Negative evidence: the iPhone SE result and the first four iOS Device Farm results suggest simple output topology changes, immediate active capture/recording cycles, and production-shape photo+video output recreation across restarts are not sufficient to deterministically reproduce the crash on the tested hardware/OS. The active-recorder mutation result suggests the remaining crash window is probably after AVFoundation forcibly stops or finalizes an interrupted recording, not merely at the moment the output prop changes. Hardware/OS version, camera topology, actual photo HDR enablement, lens switching during recording/capture, mount/unmount timing, or the original iPhone 11 / iOS 18.7.7 matrix likely still matters.
+CI observations from PR #4001 / Harness AWS Device run `27029008264` on commit `2f9ac85da8845983d57c349c7879ae641a522e0f`:
+
+- Build iOS passed.
+- Test iOS executed on Apple iPhone 16 Pro.
+- The five pushed start-crash stress tests all passed:
+  - 60 native preview topology cycles completed in 13.153s.
+  - 60 Skia topology cycles completed in 13.330s.
+  - 18 active capture/record cycles completed in 7.843s.
+  - 80 production-shape restart cycles completed in 19.748s.
+  - 12 active-recorder mutation cycles completed in 10.864s, with 12 forced recording stops.
+- iOS Harness summary was green: 13 test suites passed, 129 tests passed, 15 skipped, 144 total.
+- The GitHub `Test iOS` job still reported failure because AWS Device Farm reported `FAILED` outside the Harness summary and the wrapper exited with code 1.
+- The printed Harness output did not contain an app crash, `AVCaptureOutput`, `attachToFigCaptureSession`, `detachFromFigCaptureSession`, `SIGABRT`, or `EXC_`.
+
+Negative evidence: the iPhone SE result and the first five iOS Device Farm results suggest simple output topology changes, immediate active capture/recording cycles, production-shape photo+video output recreation across restarts, active-recorder output mutation, and continuing after AVFoundation forced recording stops are not sufficient to deterministically reproduce the crash on the tested hardware/OS. Hardware/OS version, camera topology, actual photo HDR enablement, lens switching during recording/capture, mount/unmount timing, reporter-style active control mutation, or the original iPhone 11 / iOS 18.7.7 matrix likely still matters.
 
 ## Verification done
 
@@ -206,6 +256,9 @@ bun run build
 bunx tsc --noEmit --project apps/simple-camera/tsconfig.json
 git diff --check
 bun --cwd apps/simple-camera react-native bundle --platform ios --dev true --entry-file index.js --bundle-output /tmp/simple-camera-start-crash.bundle --assets-dest /tmp/simple-camera-start-crash-assets --reset-cache
+xcrun nm -m "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" | rg "attachToFigCaptureSession|detachFromFigCaptureSession|_makeConfigurationLive|_handleConfigurationCommittedNotification"
+strings -a "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7.1 (22H31)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" | rg "attachToFigCaptureSession|detachFromFigCaptureSession|figCaptureSession|AVCaptureOutput\\.m"
+strings -a "/Users/mrousavy/Library/Developer/Xcode/iOS DeviceSupport/iPhone16,1 18.7 (22H20)/Symbols/System/Library/PrivateFrameworks/AVFCapture.framework/AVFCapture" | rg "AVCaptureOutput\\.m|_outputInternal->figCaptureSession == NULL|figCaptureSession == _outputInternal->figCaptureSession|attachToFigCaptureSession|detachFromFigCaptureSession"
 ```
 
 `bunx biome check apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx apps/simple-camera/src/screens/CameraScreen.tsx START_CRASH_FINDINGS.md apps/simple-camera/__tests__/README.md` reported only pre-existing unused-variable warnings in `CameraScreen.tsx`. The new stress Harness file had no Biome diagnostics.
@@ -216,20 +269,19 @@ Local `react-native-harness --harnessRunner ios` tried to boot an iOS simulator,
 
 The best current issue description is:
 
-> VisionCamera can enqueue `AVCaptureSession.startRunning()` immediately after a configuration commit that replaces outputs or changes output-affecting constraints. VisionCamera's own serial queue ensures `startRunning()` happens after `commitConfiguration()` returns, but AVFoundation/CoreMedia may still be processing the committed configuration asynchronously on `FigCaptureSessionNotificationQueue`. On affected hardware/OS combinations, `startRunning()` or a subsequent topology change can overlap that private output attachment/detachment work and trip AVFoundation's internal assertions in `-[AVCaptureOutput attachToFigCaptureSession:]` or `detachFromFigCaptureSession`.
+> VisionCamera can enqueue `AVCaptureSession.startRunning()` immediately after a configuration commit that replaces outputs or changes output-affecting constraints. VisionCamera's own serial queue ensures `startRunning()` happens after `commitConfiguration()` returns, but AVFoundation/CoreMedia may still be processing the committed configuration asynchronously on `FigCaptureSessionNotificationQueue`. On affected hardware/OS combinations, `startRunning()` or a subsequent topology change can overlap that private output attachment/detachment work. The attach-side assertion is `_outputInternal->figCaptureSession == NULL`, so the #3773 crash means AVFoundation tried to attach an output object whose internal Fig session pointer was already set. The detach-side sibling asserts that the Fig session being detached must equal the output's currently attached Fig session.
 
 The active-recorder mutation result adds one concrete sub-cause:
 
 > If JS recreates the video output, for example by toggling `enableAudio`, while a non-persistent `AVCaptureMovieFileOutput` recorder is active, AVFoundation forcibly stops the recording with `AVFoundationErrorDomain Code=-11818 "Recording Stopped"` and underlying `NSOSStatusErrorDomain Code=-16414`. That proves the output replacement crosses an AVFoundation recording lifetime boundary even before the private attach/detach assertion is hit.
 
-This is proven at the call-order/concurrency level by the crash stack and VisionCamera source, and at the active-recording lifetime level by the failing Harness run. It is not yet proven at the "Apple internal field X had value Y" level because AVFoundation source is private and the exact assertion condition is not visible.
+This is proven at the call-order/concurrency level by the crash stack and VisionCamera source, at the private-invariant level by the local AVFCapture assertion strings, and at the active-recording lifetime level by the failing Harness run. The exact Apple control-flow path that leaves the output pointer non-null is still not proven because AVFoundation source is private and the exact issue device binary is not available.
 
 ## Next repro iteration
 
-The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, and the active-recorder mutation test now proves the non-persistent video output cannot be replaced during an active `AVCaptureMovieFileOutput` recording without AVFoundation forcibly stopping the recording. The current next Harness iteration continues after that forced stop. If that also does not crash, the most likely remaining conditions to test are:
+The current repro proves the high-level hook can drive the suspected `configure() -> start()` ordering, and the active-recorder mutation test now proves the non-persistent video output cannot be replaced during an active `AVCaptureMovieFileOutput` recording without AVFoundation forcibly stopping the recording. The current Harness iterations continue after that forced stop and also cover reporter-style active-session interaction. If those still do not crash, the most likely remaining conditions to test are:
 
 - immediately changing device or zoom after AVFoundation forcibly stops the interrupted recording,
-- changing zoom across a virtual-device lens switch during active capture or recording,
 - actual photo HDR enablement on a device where `supportsPhotoHDR` is true,
 - switching between virtual multi-camera device IDs instead of only using the default back camera,
 - unmounting/remounting `<Camera>` instead of only toggling `isActive`,

--- a/apps/simple-camera/__tests__/README.md
+++ b/apps/simple-camera/__tests__/README.md
@@ -30,6 +30,7 @@ Tests are split by domain. Each file tests one slice of the imperative `VisionCa
 | [visioncamera.coordinates.harness.ts](visioncamera.coordinates.harness.ts) | `Frame.convertFramePointToCameraPoint` / `convertCameraPointToFramePoint`, `PreviewView.convertViewPointToCameraPoint` / `convertCameraPointToViewPoint`, `PreviewView.createMeteringPoint`, `convertScannedObjectCoordinatesToViewCoordinates`, end-to-end Frame → Camera → View round-trip |
 | [visioncamera.nativepreviewview.harness.tsx](visioncamera.nativepreviewview.harness.tsx) | Bare `NativePreviewView` lifecycle, layout-sensitive preview regression coverage, `resizeMode`, Android `implementationMode`, gesture controllers, multi-preview mounting, `PreviewView` ref methods, Android `takeSnapshot()` dimensions |
 | [visioncamera.camera-view.harness.tsx](visioncamera.camera-view.harness.tsx) | High-level `<Camera>` preview lifecycle, photo output integration, controller props, native gestures, `CameraRef` methods, `isActive`, mount / unmount / replacement behavior |
+| [visioncamera.start-crash.harness.tsx](visioncamera.start-crash.harness.tsx) | iOS AVFoundation output attach/detach stress repro for issue #3773, including photo -> video -> photo output topology and the Skia frame-preview path |
 
 Pick the file that best matches what you're testing. If you're reproducing a bug that spans multiple outputs, put it in the file most central to the failure. If nothing fits, open a new `visioncamera.<domain>.harness.ts` — Jest picks up anything matching `__tests__/**/*.harness.{ts,tsx}`.
 

--- a/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
@@ -1,4 +1,4 @@
-import { createRef, useCallback, useMemo, useState } from 'react'
+import { createRef } from 'react'
 import { type LayoutChangeEvent, StyleSheet } from 'react-native'
 import {
   afterEach,
@@ -9,12 +9,7 @@ import {
   it,
   render,
 } from 'react-native-harness'
-import type {
-  CameraDevice,
-  CameraRef,
-  Constraint,
-  Point,
-} from 'react-native-vision-camera'
+import type { CameraDevice, CameraRef, Point } from 'react-native-vision-camera'
 import {
   Camera,
   CommonResolutions,
@@ -431,104 +426,6 @@ describe('VisionCamera - Camera View', () => {
     const secondCamera = secondRef.current
     if (secondCamera == null) throw new Error('no second Camera ref')
     expectPreviewGeometry(secondCamera, secondCameraLayout)
-  })
-
-  it('reconfigures outputs and immediately restarts from Camera lifecycle callbacks', async () => {
-    const maxCycles = 120
-    const finished = deferred<number>()
-    let sessionError: Error | undefined
-
-    function RestartingCamera() {
-      const [isActive, setIsActive] = useState(true)
-      const [cycle, setCycle] = useState(0)
-      const [variant, setVariant] = useState(0)
-      const [enablePhotoHDR, setEnablePhotoHDR] = useState(false)
-
-      const photoOutput = useMemo(
-        () =>
-          VisionCamera.createPhotoOutput({
-            targetResolution: CommonResolutions.HD_4_3,
-            containerFormat: 'jpeg',
-            quality: 0.8,
-            qualityPrioritization: 'balanced',
-          }),
-        [],
-      )
-      const videoOutput = useMemo(
-        () =>
-          VisionCamera.createVideoOutput({
-            targetResolution:
-              variant % 2 === 0
-                ? CommonResolutions.FHD_16_9
-                : CommonResolutions.HD_16_9,
-            targetBitRate: variant % 2 === 0 ? 20_000_000 : 12_000_000,
-            enableAudio: false,
-          }),
-        [variant],
-      )
-      const outputs = useMemo(
-        () => [photoOutput, videoOutput],
-        [photoOutput, videoOutput],
-      )
-      const constraints = useMemo<Constraint[]>(() => {
-        const nextConstraints: Constraint[] = []
-        if (backDevice.supportsFPS(60)) {
-          nextConstraints.push({ fps: 60 })
-        }
-        if (backDevice.supportsVideoStabilizationMode('cinematic-extended')) {
-          nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
-        }
-        if (enablePhotoHDR && backDevice.supportsPhotoHDR) {
-          nextConstraints.unshift({ photoHDR: true })
-        }
-        return nextConstraints
-      }, [enablePhotoHDR])
-      const onStarted = useCallback(() => {
-        setIsActive(false)
-      }, [])
-      const onStopped = useCallback(() => {
-        const nextCycle = cycle + 1
-        if (nextCycle >= maxCycles) {
-          console.log(
-            `start crash repro harness completed ${nextCycle} cycles on ${backDevice.localizedName}`,
-          )
-          finished.resolve(nextCycle)
-          return
-        }
-
-        setCycle(nextCycle)
-        setVariant((current) => current + 1)
-        setEnablePhotoHDR((current) => !current)
-        setIsActive(true)
-      }, [cycle])
-      const onError = useCallback((error: Error) => {
-        sessionError = error
-        finished.reject(error)
-      }, [])
-
-      return (
-        <Camera
-          device={backDevice}
-          isActive={isActive}
-          outputs={outputs}
-          constraints={constraints}
-          style={StyleSheet.absoluteFill}
-          onStarted={onStarted}
-          onStopped={onStopped}
-          onError={onError}
-        />
-      )
-    }
-
-    await render(<RestartingCamera />)
-    const cycles = await withTimeout(
-      finished.promise,
-      120_000,
-      'Camera output reconfigure/restart cycles',
-    )
-
-    expect(cycles).toBe(maxCycles)
-    expect(sessionError).toBe(undefined)
   })
 
   it('fires stop callbacks when isActive is rerendered from true to false', async () => {

--- a/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
@@ -1,4 +1,4 @@
-import { createRef } from 'react'
+import { createRef, useCallback, useMemo, useState } from 'react'
 import { type LayoutChangeEvent, StyleSheet } from 'react-native'
 import {
   afterEach,
@@ -9,7 +9,12 @@ import {
   it,
   render,
 } from 'react-native-harness'
-import type { CameraDevice, CameraRef, Point } from 'react-native-vision-camera'
+import type {
+  CameraDevice,
+  CameraRef,
+  Constraint,
+  Point,
+} from 'react-native-vision-camera'
 import {
   Camera,
   CommonResolutions,
@@ -426,6 +431,104 @@ describe('VisionCamera - Camera View', () => {
     const secondCamera = secondRef.current
     if (secondCamera == null) throw new Error('no second Camera ref')
     expectPreviewGeometry(secondCamera, secondCameraLayout)
+  })
+
+  it('reconfigures outputs and immediately restarts from Camera lifecycle callbacks', async () => {
+    const maxCycles = 120
+    const finished = deferred<number>()
+    let sessionError: Error | undefined
+
+    function RestartingCamera() {
+      const [isActive, setIsActive] = useState(true)
+      const [cycle, setCycle] = useState(0)
+      const [variant, setVariant] = useState(0)
+      const [enablePhotoHDR, setEnablePhotoHDR] = useState(false)
+
+      const photoOutput = useMemo(
+        () =>
+          VisionCamera.createPhotoOutput({
+            targetResolution: CommonResolutions.HD_4_3,
+            containerFormat: 'jpeg',
+            quality: 0.8,
+            qualityPrioritization: 'balanced',
+          }),
+        [],
+      )
+      const videoOutput = useMemo(
+        () =>
+          VisionCamera.createVideoOutput({
+            targetResolution:
+              variant % 2 === 0
+                ? CommonResolutions.FHD_16_9
+                : CommonResolutions.HD_16_9,
+            targetBitRate: variant % 2 === 0 ? 20_000_000 : 12_000_000,
+            enableAudio: false,
+          }),
+        [variant],
+      )
+      const outputs = useMemo(
+        () => [photoOutput, videoOutput],
+        [photoOutput, videoOutput],
+      )
+      const constraints = useMemo<Constraint[]>(() => {
+        const nextConstraints: Constraint[] = []
+        if (backDevice.supportsFPS(60)) {
+          nextConstraints.push({ fps: 60 })
+        }
+        if (backDevice.supportsVideoStabilizationMode('cinematic-extended')) {
+          nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
+        }
+        if (enablePhotoHDR && backDevice.supportsPhotoHDR) {
+          nextConstraints.unshift({ photoHDR: true })
+        }
+        return nextConstraints
+      }, [enablePhotoHDR])
+      const onStarted = useCallback(() => {
+        setIsActive(false)
+      }, [])
+      const onStopped = useCallback(() => {
+        const nextCycle = cycle + 1
+        if (nextCycle >= maxCycles) {
+          console.log(
+            `start crash repro harness completed ${nextCycle} cycles on ${backDevice.localizedName}`,
+          )
+          finished.resolve(nextCycle)
+          return
+        }
+
+        setCycle(nextCycle)
+        setVariant((current) => current + 1)
+        setEnablePhotoHDR((current) => !current)
+        setIsActive(true)
+      }, [cycle])
+      const onError = useCallback((error: Error) => {
+        sessionError = error
+        finished.reject(error)
+      }, [])
+
+      return (
+        <Camera
+          device={backDevice}
+          isActive={isActive}
+          outputs={outputs}
+          constraints={constraints}
+          style={StyleSheet.absoluteFill}
+          onStarted={onStarted}
+          onStopped={onStopped}
+          onError={onError}
+        />
+      )
+    }
+
+    await render(<RestartingCamera />)
+    const cycles = await withTimeout(
+      finished.promise,
+      120_000,
+      'Camera output reconfigure/restart cycles',
+    )
+
+    expect(cycles).toBe(maxCycles)
+    expect(sessionError).toBe(undefined)
   })
 
   it('fires stop callbacks when isActive is rerendered from true to false', async () => {

--- a/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
@@ -9,9 +9,14 @@ import {
   it,
   render,
 } from 'react-native-harness'
-import type { CameraDevice, Constraint } from 'react-native-vision-camera'
+import type {
+  CameraDevice,
+  CameraRef,
+  Constraint,
+} from 'react-native-vision-camera'
 import {
   Camera,
+  CommonDynamicRanges,
   CommonResolutions,
   VisionCamera,
 } from 'react-native-vision-camera'
@@ -29,7 +34,9 @@ describe('VisionCamera - Start Crash Stress', () => {
 
   beforeAll(async () => {
     await VisionCamera.requestCameraPermission()
+    await VisionCamera.requestMicrophonePermission()
     expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
+    expect(VisionCamera.microphonePermissionStatus).toBe('authorized')
     const factory = await VisionCamera.createDeviceFactory()
     const back = factory.getDefaultCamera('back')
     expect(back).toBeDefined()
@@ -304,6 +311,139 @@ describe('VisionCamera - Start Crash Stress', () => {
     expect(sessionError).toBe(undefined)
   }
 
+  async function runProductionShapeRestartStress(maxCycles: number) {
+    const finished = deferred<number>()
+    let sessionError: Error | undefined
+
+    function ProductionShapeCamera() {
+      const cameraRef = useRef<CameraRef>(null)
+      const [isActive, setIsActive] = useState(true)
+      const [cycle, setCycle] = useState(0)
+      const [isMuted, setIsMuted] = useState(false)
+      const [enablePhotoHDR, setEnablePhotoHDR] = useState(false)
+
+      const photoOutput = useMemo(
+        () =>
+          VisionCamera.createPhotoOutput({
+            targetResolution: CommonResolutions.HD_4_3,
+            containerFormat: 'jpeg',
+            quality: 0.8,
+            qualityPrioritization: 'balanced',
+          }),
+        [],
+      )
+      const videoOutput = useMemo(
+        () =>
+          VisionCamera.createVideoOutput({
+            targetResolution: CommonResolutions.FHD_16_9,
+            targetBitRate: 20_000_000,
+            enableAudio: !isMuted,
+          }),
+        [isMuted],
+      )
+      const outputs = useMemo(
+        () => [photoOutput, videoOutput],
+        [photoOutput, videoOutput],
+      )
+      const constraints = useMemo<Constraint[]>(() => {
+        const nextConstraints: Constraint[] = []
+        if (enablePhotoHDR && backDevice.supportsPhotoHDR) {
+          nextConstraints.push({ photoHDR: true })
+        }
+        if (backDevice.supportsFPS(60)) {
+          nextConstraints.push({ fps: 60 })
+        }
+        if (backDevice.supportsVideoStabilizationMode('cinematic-extended')) {
+          nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
+        }
+        if (
+          enablePhotoHDR &&
+          backDevice.supportedVideoDynamicRanges.some(
+            (dynamicRange) => dynamicRange.bitDepth === 'hdr-10-bit',
+          )
+        ) {
+          nextConstraints.push({
+            videoDynamicRange: CommonDynamicRanges.ANY_HDR,
+          })
+        }
+        return nextConstraints
+      }, [enablePhotoHDR])
+      const zoomTargets = useMemo(() => {
+        const neutralZoom =
+          backDevice.zoomLensSwitchFactors[0] ?? Math.max(backDevice.minZoom, 1)
+        const candidates = [
+          backDevice.minZoom,
+          neutralZoom,
+          neutralZoom * 2,
+          neutralZoom * 3,
+        ]
+        return candidates.filter(
+          (zoom, index) =>
+            zoom >= backDevice.minZoom &&
+            zoom <= backDevice.maxZoom &&
+            candidates.indexOf(zoom) === index,
+        )
+      }, [])
+      const onStarted = useCallback(() => {
+        const applyZoomAndStop = async () => {
+          try {
+            const targetZoom = zoomTargets[cycle % zoomTargets.length] ?? 1
+            await cameraRef.current?.controller?.setZoom(targetZoom)
+          } catch (error) {
+            console.log(`start crash stress zoom update failed: ${error}`)
+          } finally {
+            setIsActive(false)
+          }
+        }
+
+        void applyZoomAndStop()
+      }, [cycle, zoomTargets])
+      const onStopped = useCallback(() => {
+        const nextCycle = cycle + 1
+        if (nextCycle >= maxCycles) {
+          console.log(
+            `start crash production-shape stress completed ${nextCycle} Camera cycles on ${backDevice.localizedName}`,
+          )
+          finished.resolve(nextCycle)
+          return
+        }
+
+        setCycle(nextCycle)
+        setIsMuted((current) => !current)
+        setEnablePhotoHDR((current) => !current)
+        setIsActive(true)
+      }, [cycle])
+      const onError = useCallback((error: Error) => {
+        sessionError = error
+        finished.reject(error)
+      }, [])
+
+      return (
+        <Camera
+          ref={cameraRef}
+          device={backDevice}
+          isActive={isActive}
+          outputs={outputs}
+          constraints={constraints}
+          style={StyleSheet.absoluteFill}
+          onStarted={onStarted}
+          onStopped={onStopped}
+          onError={onError}
+        />
+      )
+    }
+
+    await render(<ProductionShapeCamera />)
+    const cycles = await withTimeout(
+      finished.promise,
+      90_000,
+      'Camera production-shape restart stress',
+    )
+
+    expect(cycles).toBe(maxCycles)
+    expect(sessionError).toBe(undefined)
+  }
+
   it('cycles photo -> video -> photo outputs through native preview start/stop', async (context) => {
     if (Platform.OS !== 'ios') {
       return context.skip(
@@ -332,5 +472,15 @@ describe('VisionCamera - Start Crash Stress', () => {
     }
 
     await runActiveCaptureTopologyStress(18)
+  })
+
+  it('restarts with stable photo/video outputs while toggling audio, HDR, and zoom', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip(
+        'AVFoundation attach/detach assertion stress: iOS only',
+      )
+    }
+
+    await runProductionShapeRestartStress(80)
   })
 })

--- a/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
@@ -30,6 +30,14 @@ function getStartCrashStressMode(cycle: number): StartCrashStressMode {
   return cycle % 2 === 1 ? 'video' : 'photo'
 }
 
+function isExpectedForcedRecordingStop(error: Error): boolean {
+  const message = `${String(error)} ${error.message}`
+  return (
+    message.includes('AVFoundationErrorDomain Code=-11818') &&
+    message.includes('AVErrorRecordingSuccessfullyFinishedKey=true')
+  )
+}
+
 describe('VisionCamera - Start Crash Stress', () => {
   let backDevice: CameraDevice
 
@@ -446,7 +454,10 @@ describe('VisionCamera - Start Crash Stress', () => {
   }
 
   async function runRecordingOutputMutationStress(maxCycles: number) {
-    const finished = deferred<number>()
+    const finished = deferred<{
+      cycles: number
+      forcedRecordingStops: number
+    }>()
     let sessionError: Error | undefined
 
     function RecordingMutationCamera() {
@@ -457,6 +468,7 @@ describe('VisionCamera - Start Crash Stress', () => {
       const recorderRef = useRef<Recorder | null>(null)
       const recordingInFlight = useRef(false)
       const shouldStopAfterReconfigure = useRef(false)
+      const forcedRecordingStops = useRef(0)
 
       const photoOutput = useMemo(
         () =>
@@ -505,6 +517,21 @@ describe('VisionCamera - Start Crash Stress', () => {
         sessionError = error
         finished.reject(error)
       }, [])
+      const handleRecordingError = useCallback(
+        (error: Error) => {
+          if (!isExpectedForcedRecordingStop(error)) {
+            rejectWithError(error)
+            return
+          }
+
+          forcedRecordingStops.current += 1
+          recorderRef.current = null
+          recordingInFlight.current = false
+          shouldStopAfterReconfigure.current = false
+          setIsActive(false)
+        },
+        [rejectWithError],
+      )
       const stopRecorderAndDeactivate = useCallback(async () => {
         const recorder = recorderRef.current
         if (recorder == null) return
@@ -512,14 +539,14 @@ describe('VisionCamera - Start Crash Stress', () => {
         try {
           await recorder.stopRecording()
         } catch (error) {
-          rejectWithError(error as Error)
+          handleRecordingError(error as Error)
         } finally {
           recorderRef.current = null
           recordingInFlight.current = false
           shouldStopAfterReconfigure.current = false
           setIsActive(false)
         }
-      }, [rejectWithError])
+      }, [handleRecordingError])
       const onSessionConfigSelected = useCallback(() => {
         if (!shouldStopAfterReconfigure.current) return
 
@@ -537,7 +564,7 @@ describe('VisionCamera - Start Crash Stress', () => {
             await recorder.startRecording(
               () => {},
               (error) => {
-                rejectWithError(error)
+                handleRecordingError(error)
               },
             )
             shouldStopAfterReconfigure.current = true
@@ -550,14 +577,17 @@ describe('VisionCamera - Start Crash Stress', () => {
         }
 
         void mutateOutputWhileRecording()
-      }, [rejectWithError, videoOutput])
+      }, [handleRecordingError, rejectWithError, videoOutput])
       const onStopped = useCallback(() => {
         const nextCycle = cycle + 1
         if (nextCycle >= maxCycles) {
           console.log(
-            `start crash recording mutation stress completed ${nextCycle} Skia cycles on ${backDevice.localizedName}`,
+            `start crash recording mutation stress completed ${nextCycle} Skia cycles on ${backDevice.localizedName} with ${forcedRecordingStops.current} forced stops`,
           )
-          finished.resolve(nextCycle)
+          finished.resolve({
+            cycles: nextCycle,
+            forcedRecordingStops: forcedRecordingStops.current,
+          })
           return
         }
 
@@ -589,13 +619,14 @@ describe('VisionCamera - Start Crash Stress', () => {
     }
 
     await render(<RecordingMutationCamera />)
-    const cycles = await withTimeout(
+    const result = await withTimeout(
       finished.promise,
       90_000,
       'Skia recording output mutation stress',
     )
 
-    expect(cycles).toBe(maxCycles)
+    expect(result.cycles).toBe(maxCycles)
+    expect(result.forcedRecordingStops).toBeGreaterThan(0)
     expect(sessionError).toBe(undefined)
   }
 

--- a/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Platform, StyleSheet } from 'react-native'
 import {
   afterEach,
@@ -40,6 +40,7 @@ function isExpectedForcedRecordingStop(error: Error): boolean {
 
 describe('VisionCamera - Start Crash Stress', () => {
   let backDevice: CameraDevice
+  let frontDevice: CameraDevice | undefined
 
   beforeAll(async () => {
     await VisionCamera.requestCameraPermission()
@@ -51,6 +52,7 @@ describe('VisionCamera - Start Crash Stress', () => {
     expect(back).toBeDefined()
     if (back == null) throw new Error('no back camera')
     backDevice = back
+    frontDevice = factory.getDefaultCamera('front')
   })
 
   afterEach(() => {
@@ -453,6 +455,228 @@ describe('VisionCamera - Start Crash Stress', () => {
     expect(sessionError).toBe(undefined)
   }
 
+  async function runReporterStyleActiveInteractionStress(maxCycles: number) {
+    const finished = deferred<number>()
+    let sessionError: Error | undefined
+
+    function ActiveInteractionCamera() {
+      const cameraRef = useRef<CameraRef>(null)
+      const [, setCycle] = useState(0)
+      const [configuredTick, setConfiguredTick] = useState(0)
+      const [isMuted, setIsMuted] = useState(false)
+      const [enablePhotoHDR, setEnablePhotoHDR] = useState(false)
+      const [useFrontDevice, setUseFrontDevice] = useState(false)
+      const hasStarted = useRef(false)
+      const isRunningCycle = useRef(false)
+      const continueAfterConfigured = useRef(false)
+      const cycleRef = useRef(0)
+      const currentDevice =
+        useFrontDevice && frontDevice != null ? frontDevice : backDevice
+
+      const photoOutput = useMemo(
+        () =>
+          VisionCamera.createPhotoOutput({
+            targetResolution: CommonResolutions.HD_4_3,
+            containerFormat: 'jpeg',
+            quality: 0.8,
+            qualityPrioritization: 'balanced',
+          }),
+        [],
+      )
+      const videoOutput = useMemo(
+        () =>
+          VisionCamera.createVideoOutput({
+            targetResolution: CommonResolutions.FHD_16_9,
+            targetBitRate: 20_000_000,
+            enableAudio: !isMuted,
+          }),
+        [isMuted],
+      )
+      const outputs = useMemo(
+        () => [photoOutput, videoOutput],
+        [photoOutput, videoOutput],
+      )
+      const constraints = useMemo<Constraint[]>(() => {
+        const nextConstraints: Constraint[] = []
+        if (enablePhotoHDR && currentDevice.supportsPhotoHDR) {
+          nextConstraints.push({ photoHDR: true })
+        }
+        if (currentDevice.supportsFPS(60)) {
+          nextConstraints.push({ fps: 60 })
+        }
+        if (
+          currentDevice.supportsVideoStabilizationMode('cinematic-extended')
+        ) {
+          nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
+        }
+        if (
+          enablePhotoHDR &&
+          currentDevice.supportedVideoDynamicRanges.some(
+            (dynamicRange) => dynamicRange.bitDepth === 'hdr-10-bit',
+          )
+        ) {
+          nextConstraints.push({
+            videoDynamicRange: CommonDynamicRanges.ANY_HDR,
+          })
+        }
+        return nextConstraints
+      }, [currentDevice, enablePhotoHDR])
+      const zoomTargets = useMemo(() => {
+        const neutralZoom =
+          currentDevice.zoomLensSwitchFactors[0] ??
+          Math.max(currentDevice.minZoom, 1)
+        const candidates = [
+          currentDevice.minZoom,
+          neutralZoom,
+          neutralZoom * 2,
+          neutralZoom * 3,
+        ]
+        return candidates.filter(
+          (zoom, index) =>
+            zoom >= currentDevice.minZoom &&
+            zoom <= currentDevice.maxZoom &&
+            candidates.indexOf(zoom) === index,
+        )
+      }, [currentDevice])
+      const rejectWithError = useCallback((error: Error) => {
+        sessionError = error
+        finished.reject(error)
+      }, [])
+      const logExpectedControlError = useCallback(
+        (label: string, error: Error) => {
+          console.log(
+            `start crash active interaction ${label} failed: ${error}`,
+          )
+        },
+        [],
+      )
+      const runNextCycle = useCallback(() => {
+        if (isRunningCycle.current) return
+        isRunningCycle.current = true
+
+        try {
+          const nextCycle = cycleRef.current
+          if (nextCycle >= maxCycles) {
+            void cameraRef.current?.controller
+              ?.setTorchMode('off')
+              .catch(() => {})
+            console.log(
+              `start crash active interaction stress completed ${nextCycle} Camera cycles on ${backDevice.localizedName}`,
+            )
+            finished.resolve(nextCycle)
+            return
+          }
+
+          const controller = cameraRef.current?.controller
+          if (controller != null) {
+            const targetZoom = zoomTargets[nextCycle % zoomTargets.length] ?? 1
+            void controller
+              .setZoom(targetZoom)
+              .catch((error) => logExpectedControlError('zoom update', error))
+
+            if (currentDevice.supportsExposureBias) {
+              const exposureTargets = [
+                currentDevice.minExposureBias,
+                currentDevice.maxExposureBias,
+                0,
+              ]
+              const targetExposure =
+                exposureTargets[nextCycle % exposureTargets.length] ?? 0
+              void controller
+                .setExposureBias(targetExposure)
+                .catch((error) =>
+                  logExpectedControlError('exposure update', error),
+                )
+            }
+
+            if (currentDevice.hasTorch) {
+              void controller
+                .setTorchMode(nextCycle % 2 === 0 ? 'on' : 'off')
+                .catch((error) =>
+                  logExpectedControlError('torch update', error),
+                )
+            }
+
+            if (currentDevice.supportsFocusMetering) {
+              const focusPoints = [
+                { x: 120, y: 160 },
+                { x: 240, y: 240 },
+                { x: 160, y: 360 },
+              ]
+              const focusPoint =
+                focusPoints[nextCycle % focusPoints.length] ?? focusPoints[0]
+              if (focusPoint != null) {
+                void cameraRef.current
+                  ?.focusTo(focusPoint, {
+                    adaptiveness: 'continuous',
+                    autoResetAfter: null,
+                    responsiveness: 'snappy',
+                  })
+                  .catch((error) =>
+                    logExpectedControlError('focus update', error),
+                  )
+              }
+            }
+          }
+
+          cycleRef.current = nextCycle + 1
+          continueAfterConfigured.current = true
+          setCycle(cycleRef.current)
+          setIsMuted((current) => !current)
+          setEnablePhotoHDR((current) => !current)
+          if (frontDevice != null && nextCycle % 8 === 7) {
+            setUseFrontDevice((current) => !current)
+          }
+        } catch (error) {
+          rejectWithError(error as Error)
+        } finally {
+          isRunningCycle.current = false
+        }
+      }, [currentDevice, logExpectedControlError, rejectWithError, zoomTargets])
+      const onStarted = useCallback(() => {
+        if (hasStarted.current) return
+        hasStarted.current = true
+        runNextCycle()
+      }, [runNextCycle])
+      const onConfigured = useCallback(() => {
+        if (!hasStarted.current || !continueAfterConfigured.current) return
+
+        continueAfterConfigured.current = false
+        setConfiguredTick((current) => current + 1)
+      }, [])
+
+      useEffect(() => {
+        if (configuredTick === 0) return
+        runNextCycle()
+      }, [configuredTick, runNextCycle])
+
+      return (
+        <Camera
+          ref={cameraRef}
+          device={currentDevice}
+          isActive={true}
+          outputs={outputs}
+          constraints={constraints}
+          style={StyleSheet.absoluteFill}
+          mirrorMode={useFrontDevice ? 'on' : 'off'}
+          onStarted={onStarted}
+          onConfigured={onConfigured}
+          onError={rejectWithError}
+        />
+      )
+    }
+
+    await render(<ActiveInteractionCamera />)
+    const cycles = await withTimeout(
+      finished.promise,
+      90_000,
+      'Camera reporter-style active interaction stress',
+    )
+
+    expect(cycles).toBe(maxCycles)
+    expect(sessionError).toBe(undefined)
+  }
+
   async function runRecordingOutputMutationStress(maxCycles: number) {
     const finished = deferred<{
       cycles: number
@@ -678,5 +902,15 @@ describe('VisionCamera - Start Crash Stress', () => {
     }
 
     await runRecordingOutputMutationStress(12)
+  })
+
+  it('mutates reporter-style active controls while reconfiguring outputs', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip(
+        'AVFoundation attach/detach assertion stress: iOS only',
+      )
+    }
+
+    await runReporterStyleActiveInteractionStress(80)
   })
 })

--- a/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { Platform, StyleSheet } from 'react-native'
 import {
   afterEach,
@@ -168,6 +168,142 @@ describe('VisionCamera - Start Crash Stress', () => {
     expect(sessionError).toBe(undefined)
   }
 
+  async function runActiveCaptureTopologyStress(maxCycles: number) {
+    const finished = deferred<number>()
+    let sessionError: Error | undefined
+
+    function CapturingCamera() {
+      const [isActive, setIsActive] = useState(true)
+      const [cycle, setCycle] = useState(0)
+      const [variant, setVariant] = useState(0)
+      const captureInFlight = useRef(false)
+      const mode = getStartCrashStressMode(cycle)
+
+      const photoOutput = useMemo(
+        () =>
+          VisionCamera.createPhotoOutput({
+            targetResolution: CommonResolutions.HD_4_3,
+            containerFormat: 'jpeg',
+            quality: 0.8,
+            qualityPrioritization: 'balanced',
+          }),
+        [],
+      )
+      const videoOutput = useMemo(
+        () =>
+          VisionCamera.createVideoOutput({
+            targetResolution:
+              variant % 2 === 0
+                ? CommonResolutions.FHD_16_9
+                : CommonResolutions.HD_16_9,
+            targetBitRate: variant % 2 === 0 ? 20_000_000 : 12_000_000,
+            enableAudio: false,
+          }),
+        [variant],
+      )
+      const outputs = useMemo(
+        () => (mode === 'video' ? [videoOutput] : [photoOutput]),
+        [mode, photoOutput, videoOutput],
+      )
+      const constraints = useMemo<Constraint[]>(() => {
+        const nextConstraints: Constraint[] = []
+        if (backDevice.supportsFPS(60)) {
+          nextConstraints.push({ fps: 60 })
+        }
+        if (
+          mode === 'video' &&
+          backDevice.supportsVideoStabilizationMode('cinematic-extended')
+        ) {
+          nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
+        }
+        return nextConstraints
+      }, [mode])
+      const onStarted = useCallback(() => {
+        if (captureInFlight.current) return
+        captureInFlight.current = true
+
+        const runCapture = async () => {
+          try {
+            if (mode === 'photo') {
+              const photo = await photoOutput.capturePhoto(
+                { flashMode: 'off', enableShutterSound: false },
+                {},
+              )
+              photo.dispose()
+            } else {
+              const recorder = await videoOutput.createRecorder({})
+              await recorder.startRecording(
+                () => {},
+                (error) => {
+                  sessionError = error
+                  finished.reject(error)
+                },
+              )
+              await recorder.stopRecording()
+            }
+          } catch (error) {
+            sessionError = error as Error
+            finished.reject(sessionError)
+          } finally {
+            captureInFlight.current = false
+            setIsActive(false)
+          }
+        }
+
+        void runCapture()
+      }, [mode, photoOutput, videoOutput])
+      const onStopped = useCallback(() => {
+        const nextCycle = cycle + 1
+        if (nextCycle >= maxCycles) {
+          console.log(
+            `start crash active capture stress completed ${nextCycle} Skia cycles on ${backDevice.localizedName}`,
+          )
+          finished.resolve(nextCycle)
+          return
+        }
+
+        setCycle(nextCycle)
+        setVariant((current) => current + 1)
+        setIsActive(true)
+      }, [cycle])
+      const onError = useCallback((error: Error) => {
+        sessionError = error
+        finished.reject(error)
+      }, [])
+
+      return (
+        <SkiaCamera
+          device={backDevice}
+          isActive={isActive}
+          outputs={outputs}
+          constraints={constraints}
+          style={StyleSheet.absoluteFill}
+          enablePreviewSizedOutputBuffers={true}
+          onFrame={(frame, render) => {
+            'worklet'
+            render(({ canvas, frameTexture }) => {
+              canvas.drawImage(frameTexture, 0, 0)
+            })
+            frame.dispose()
+          }}
+          onStarted={onStarted}
+          onStopped={onStopped}
+          onError={onError}
+        />
+      )
+    }
+
+    await render(<CapturingCamera />)
+    const cycles = await withTimeout(
+      finished.promise,
+      90_000,
+      'Skia photo capture/video recording/photo capture topology stress',
+    )
+
+    expect(cycles).toBe(maxCycles)
+    expect(sessionError).toBe(undefined)
+  }
+
   it('cycles photo -> video -> photo outputs through native preview start/stop', async (context) => {
     if (Platform.OS !== 'ios') {
       return context.skip(
@@ -186,5 +322,15 @@ describe('VisionCamera - Start Crash Stress', () => {
     }
 
     await runOutputTopologyStress(true, 60)
+  })
+
+  it('captures photo -> records video -> captures photo with Skia frame-preview attached', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip(
+        'AVFoundation attach/detach assertion stress: iOS only',
+      )
+    }
+
+    await runActiveCaptureTopologyStress(18)
   })
 })

--- a/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
@@ -13,6 +13,7 @@ import type {
   CameraDevice,
   CameraRef,
   Constraint,
+  Recorder,
 } from 'react-native-vision-camera'
 import {
   Camera,
@@ -444,6 +445,160 @@ describe('VisionCamera - Start Crash Stress', () => {
     expect(sessionError).toBe(undefined)
   }
 
+  async function runRecordingOutputMutationStress(maxCycles: number) {
+    const finished = deferred<number>()
+    let sessionError: Error | undefined
+
+    function RecordingMutationCamera() {
+      const [isActive, setIsActive] = useState(true)
+      const [cycle, setCycle] = useState(0)
+      const [isMuted, setIsMuted] = useState(false)
+      const [enableVideoHDR, setEnableVideoHDR] = useState(false)
+      const recorderRef = useRef<Recorder | null>(null)
+      const recordingInFlight = useRef(false)
+      const shouldStopAfterReconfigure = useRef(false)
+
+      const photoOutput = useMemo(
+        () =>
+          VisionCamera.createPhotoOutput({
+            targetResolution: CommonResolutions.HD_4_3,
+            containerFormat: 'jpeg',
+            quality: 0.8,
+            qualityPrioritization: 'balanced',
+          }),
+        [],
+      )
+      const videoOutput = useMemo(
+        () =>
+          VisionCamera.createVideoOutput({
+            targetResolution: CommonResolutions.FHD_16_9,
+            targetBitRate: 20_000_000,
+            enableAudio: !isMuted,
+          }),
+        [isMuted],
+      )
+      const outputs = useMemo(
+        () => [photoOutput, videoOutput],
+        [photoOutput, videoOutput],
+      )
+      const constraints = useMemo<Constraint[]>(() => {
+        const nextConstraints: Constraint[] = []
+        if (backDevice.supportsFPS(60)) {
+          nextConstraints.push({ fps: 60 })
+        }
+        if (backDevice.supportsVideoStabilizationMode('cinematic-extended')) {
+          nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
+        }
+        if (
+          enableVideoHDR &&
+          backDevice.supportedVideoDynamicRanges.some(
+            (dynamicRange) => dynamicRange.bitDepth === 'hdr-10-bit',
+          )
+        ) {
+          nextConstraints.push({
+            videoDynamicRange: CommonDynamicRanges.ANY_HDR,
+          })
+        }
+        return nextConstraints
+      }, [enableVideoHDR])
+      const rejectWithError = useCallback((error: Error) => {
+        sessionError = error
+        finished.reject(error)
+      }, [])
+      const stopRecorderAndDeactivate = useCallback(async () => {
+        const recorder = recorderRef.current
+        if (recorder == null) return
+
+        try {
+          await recorder.stopRecording()
+        } catch (error) {
+          rejectWithError(error as Error)
+        } finally {
+          recorderRef.current = null
+          recordingInFlight.current = false
+          shouldStopAfterReconfigure.current = false
+          setIsActive(false)
+        }
+      }, [rejectWithError])
+      const onSessionConfigSelected = useCallback(() => {
+        if (!shouldStopAfterReconfigure.current) return
+
+        shouldStopAfterReconfigure.current = false
+        void stopRecorderAndDeactivate()
+      }, [stopRecorderAndDeactivate])
+      const onStarted = useCallback(() => {
+        if (recordingInFlight.current) return
+        recordingInFlight.current = true
+
+        const mutateOutputWhileRecording = async () => {
+          try {
+            const recorder = await videoOutput.createRecorder({})
+            recorderRef.current = recorder
+            await recorder.startRecording(
+              () => {},
+              (error) => {
+                rejectWithError(error)
+              },
+            )
+            shouldStopAfterReconfigure.current = true
+            setIsMuted((current) => !current)
+            setEnableVideoHDR((current) => !current)
+          } catch (error) {
+            recordingInFlight.current = false
+            rejectWithError(error as Error)
+          }
+        }
+
+        void mutateOutputWhileRecording()
+      }, [rejectWithError, videoOutput])
+      const onStopped = useCallback(() => {
+        const nextCycle = cycle + 1
+        if (nextCycle >= maxCycles) {
+          console.log(
+            `start crash recording mutation stress completed ${nextCycle} Skia cycles on ${backDevice.localizedName}`,
+          )
+          finished.resolve(nextCycle)
+          return
+        }
+
+        setCycle(nextCycle)
+        setIsActive(true)
+      }, [cycle])
+
+      return (
+        <SkiaCamera
+          device={backDevice}
+          isActive={isActive}
+          outputs={outputs}
+          constraints={constraints}
+          style={StyleSheet.absoluteFill}
+          enablePreviewSizedOutputBuffers={true}
+          onFrame={(frame, render) => {
+            'worklet'
+            render(({ canvas, frameTexture }) => {
+              canvas.drawImage(frameTexture, 0, 0)
+            })
+            frame.dispose()
+          }}
+          onStarted={onStarted}
+          onStopped={onStopped}
+          onSessionConfigSelected={onSessionConfigSelected}
+          onError={rejectWithError}
+        />
+      )
+    }
+
+    await render(<RecordingMutationCamera />)
+    const cycles = await withTimeout(
+      finished.promise,
+      90_000,
+      'Skia recording output mutation stress',
+    )
+
+    expect(cycles).toBe(maxCycles)
+    expect(sessionError).toBe(undefined)
+  }
+
   it('cycles photo -> video -> photo outputs through native preview start/stop', async (context) => {
     if (Platform.OS !== 'ios') {
       return context.skip(
@@ -482,5 +637,15 @@ describe('VisionCamera - Start Crash Stress', () => {
     }
 
     await runProductionShapeRestartStress(80)
+  })
+
+  it('recreates video output while recording with Skia frame-preview attached', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip(
+        'AVFoundation attach/detach assertion stress: iOS only',
+      )
+    }
+
+    await runRecordingOutputMutationStress(12)
   })
 })

--- a/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.start-crash.harness.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Platform, StyleSheet } from 'react-native'
+import {
+  afterEach,
+  beforeAll,
+  cleanup,
+  describe,
+  expect,
+  it,
+  render,
+} from 'react-native-harness'
+import type { CameraDevice, Constraint } from 'react-native-vision-camera'
+import {
+  Camera,
+  CommonResolutions,
+  VisionCamera,
+} from 'react-native-vision-camera'
+import { SkiaCamera } from 'react-native-vision-camera-skia'
+import { deferred, withTimeout } from './test-utils'
+
+type StartCrashStressMode = 'photo' | 'video'
+
+function getStartCrashStressMode(cycle: number): StartCrashStressMode {
+  return cycle % 2 === 1 ? 'video' : 'photo'
+}
+
+describe('VisionCamera - Start Crash Stress', () => {
+  let backDevice: CameraDevice
+
+  beforeAll(async () => {
+    await VisionCamera.requestCameraPermission()
+    expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
+    const factory = await VisionCamera.createDeviceFactory()
+    const back = factory.getDefaultCamera('back')
+    expect(back).toBeDefined()
+    if (back == null) throw new Error('no back camera')
+    backDevice = back
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  async function runOutputTopologyStress(
+    renderWithSkiaPreview: boolean,
+    maxCycles: number,
+  ) {
+    const finished = deferred<number>()
+    let sessionError: Error | undefined
+
+    function RestartingCamera() {
+      const [isActive, setIsActive] = useState(true)
+      const [cycle, setCycle] = useState(0)
+      const [variant, setVariant] = useState(0)
+      const [enablePhotoHDR, setEnablePhotoHDR] = useState(false)
+      const mode = getStartCrashStressMode(cycle)
+
+      const photoOutput = useMemo(
+        () =>
+          VisionCamera.createPhotoOutput({
+            targetResolution: CommonResolutions.HD_4_3,
+            containerFormat: 'jpeg',
+            quality: 0.8,
+            qualityPrioritization: 'balanced',
+          }),
+        [],
+      )
+      const videoOutput = useMemo(
+        () =>
+          VisionCamera.createVideoOutput({
+            targetResolution:
+              variant % 2 === 0
+                ? CommonResolutions.FHD_16_9
+                : CommonResolutions.HD_16_9,
+            targetBitRate: variant % 2 === 0 ? 20_000_000 : 12_000_000,
+            enableAudio: false,
+          }),
+        [variant],
+      )
+      const outputs = useMemo(
+        () => (mode === 'video' ? [videoOutput] : [photoOutput]),
+        [mode, photoOutput, videoOutput],
+      )
+      const constraints = useMemo<Constraint[]>(() => {
+        const nextConstraints: Constraint[] = []
+        if (backDevice.supportsFPS(60)) {
+          nextConstraints.push({ fps: 60 })
+        }
+        if (
+          mode === 'video' &&
+          backDevice.supportsVideoStabilizationMode('cinematic-extended')
+        ) {
+          nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
+        }
+        if (mode === 'photo' && enablePhotoHDR && backDevice.supportsPhotoHDR) {
+          nextConstraints.unshift({ photoHDR: true })
+        }
+        return nextConstraints
+      }, [enablePhotoHDR, mode])
+      const onStarted = useCallback(() => {
+        setIsActive(false)
+      }, [])
+      const onStopped = useCallback(() => {
+        const nextCycle = cycle + 1
+        if (nextCycle >= maxCycles) {
+          console.log(
+            `start crash stress completed ${nextCycle} ${renderWithSkiaPreview ? 'Skia' : 'Camera'} cycles on ${backDevice.localizedName}`,
+          )
+          finished.resolve(nextCycle)
+          return
+        }
+
+        setCycle(nextCycle)
+        setVariant((current) => current + 1)
+        setEnablePhotoHDR((current) => !current)
+        setIsActive(true)
+      }, [cycle])
+      const onError = useCallback((error: Error) => {
+        sessionError = error
+        finished.reject(error)
+      }, [])
+
+      if (renderWithSkiaPreview) {
+        return (
+          <SkiaCamera
+            device={backDevice}
+            isActive={isActive}
+            outputs={outputs}
+            constraints={constraints}
+            style={StyleSheet.absoluteFill}
+            enablePreviewSizedOutputBuffers={true}
+            onFrame={(frame, render) => {
+              'worklet'
+              render(({ canvas, frameTexture }) => {
+                canvas.drawImage(frameTexture, 0, 0)
+              })
+              frame.dispose()
+            }}
+            onStarted={onStarted}
+            onStopped={onStopped}
+            onError={onError}
+          />
+        )
+      }
+
+      return (
+        <Camera
+          device={backDevice}
+          isActive={isActive}
+          outputs={outputs}
+          constraints={constraints}
+          style={StyleSheet.absoluteFill}
+          onStarted={onStarted}
+          onStopped={onStopped}
+          onError={onError}
+        />
+      )
+    }
+
+    await render(<RestartingCamera />)
+    const cycles = await withTimeout(
+      finished.promise,
+      90_000,
+      `${renderWithSkiaPreview ? 'Skia' : 'Camera'} photo/video/photo output topology stress`,
+    )
+
+    expect(cycles).toBe(maxCycles)
+    expect(sessionError).toBe(undefined)
+  }
+
+  it('cycles photo -> video -> photo outputs through native preview start/stop', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip(
+        'AVFoundation attach/detach assertion stress: iOS only',
+      )
+    }
+
+    await runOutputTopologyStress(false, 60)
+  })
+
+  it('cycles photo -> video -> photo outputs with Skia frame-preview attached', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip(
+        'AVFoundation attach/detach assertion stress: iOS only',
+      )
+    }
+
+    await runOutputTopologyStress(true, 60)
+  })
+})

--- a/apps/simple-camera/src/screens/CameraScreen.tsx
+++ b/apps/simple-camera/src/screens/CameraScreen.tsx
@@ -1,7 +1,9 @@
 import { useIsFocused, useNavigation } from '@react-navigation/native'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { StatusBar, StyleSheet, Text, View } from 'react-native'
 import {
+  CommonResolutions,
+  type Constraint,
   type Recorder,
   useCameraDeviceExtensions,
   useCameraDevices,
@@ -21,6 +23,8 @@ import { useIsActive } from '../hooks/useIsActive'
 import { useSafeAreaPadding } from '../hooks/useSafeAreaPadding'
 import { logDevices } from '../logDevices'
 
+const START_CRASH_REPRO = true
+
 export function CameraScreen() {
   const navigation = useNavigation()
   const isAppActive = useIsActive()
@@ -32,8 +36,20 @@ export function CameraScreen() {
   const [enableDepthStream, setEnableDepthStream] = useState(false)
 
   const devices = useCameraDevices()
-  const defaultDevice = devices[0]
+  const defaultDevice = useMemo(
+    () =>
+      devices.find(
+        (d) => d.position === 'back' && d.physicalDevices.length > 1,
+      ) ??
+      devices.find((d) => d.position === 'back') ??
+      devices[0],
+    [devices],
+  )
   const [device, setDevice] = useState(defaultDevice)
+  const [startCrashReproActive, setStartCrashReproActive] = useState(true)
+  const [startCrashReproCycle, setStartCrashReproCycle] = useState(0)
+  const [startCrashReproVariant, setStartCrashReproVariant] = useState(0)
+  const [startCrashReproHDR, setStartCrashReproHDR] = useState(false)
 
   useEffect(() => {
     setDevice(defaultDevice)
@@ -62,8 +78,31 @@ export function CameraScreen() {
 
   const photoOutput = usePhotoOutput({})
   const videoOutput = useVideoOutput({
-    enableAudio: true,
+    targetResolution:
+      startCrashReproVariant % 2 === 0
+        ? CommonResolutions.FHD_16_9
+        : CommonResolutions.HD_16_9,
+    targetBitRate: startCrashReproVariant % 2 === 0 ? 20_000_000 : 12_000_000,
+    enableAudio: false,
   })
+  const cameraOutputs = useMemo(
+    () => (START_CRASH_REPRO ? [photoOutput, videoOutput] : [photoOutput]),
+    [photoOutput, videoOutput],
+  )
+  const cameraConstraints = useMemo<Constraint[]>(() => {
+    if (!START_CRASH_REPRO) return []
+    const nextConstraints: Constraint[] = []
+    if (device?.supportsFPS(60)) {
+      nextConstraints.push({ fps: 60 })
+    }
+    if (device?.supportsVideoStabilizationMode('cinematic-extended')) {
+      nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
+    }
+    if (startCrashReproHDR && device?.supportsPhotoHDR) {
+      nextConstraints.unshift({ photoHDR: true })
+    }
+    return nextConstraints
+  }, [device, startCrashReproHDR])
   const { resizer, error } = useResizer({
     width: 192,
     height: 192,
@@ -217,6 +256,26 @@ export function CameraScreen() {
     await recorder.stopRecording()
     console.log(`Recording stopped!`)
   }, [])
+  const onCameraStarted = useCallback(() => {
+    if (!START_CRASH_REPRO) return
+    console.log(
+      `[START_CRASH_REPRO] cycle ${startCrashReproCycle} started; stopping before next reconfigure/start`,
+    )
+    setStartCrashReproActive(false)
+  }, [startCrashReproCycle])
+  const onCameraStopped = useCallback(() => {
+    if (!START_CRASH_REPRO) return
+    setStartCrashReproCycle((cycle) => {
+      const nextCycle = cycle + 1
+      console.log(
+        `[START_CRASH_REPRO] cycle ${cycle} stopped; swapping output/constraints and immediately restarting cycle ${nextCycle}`,
+      )
+      return nextCycle
+    })
+    setStartCrashReproVariant((variant) => variant + 1)
+    setStartCrashReproHDR((hdr) => !hdr)
+    setStartCrashReproActive(true)
+  }, [])
 
   if (device == null) {
     return (
@@ -230,15 +289,17 @@ export function CameraScreen() {
       <StatusBar barStyle="light-content" />
 
       <CameraView
-        isActive={isAppActive && isScreenFocused}
-        device={device}
-        outputs={[photoOutput]}
-        mirrorMode={device.position === 'front' ? 'on' : 'off'}
-        constraints={
-          [
-            // Session Constraints
-          ]
+        isActive={
+          isAppActive &&
+          isScreenFocused &&
+          (!START_CRASH_REPRO || startCrashReproActive)
         }
+        device={device}
+        outputs={cameraOutputs}
+        mirrorMode={device.position === 'front' ? 'on' : 'off'}
+        constraints={cameraConstraints}
+        onStarted={onCameraStarted}
+        onStopped={onCameraStopped}
         onInterruptionStarted={(reason) =>
           console.log(`Camera interrupted! Reason: ${reason}`)
         }

--- a/apps/simple-camera/src/screens/CameraScreen.tsx
+++ b/apps/simple-camera/src/screens/CameraScreen.tsx
@@ -228,6 +228,7 @@ export function CameraScreen() {
 
   const preparedRecorder = useRef<Recorder>(undefined)
   const activeRecorder = useRef<Recorder>(undefined)
+  const startCrashReproCaptureInFlight = useRef(false)
   const startRecording = useCallback(async () => {
     console.log(`Starting Recording...`)
     // get previously prepared recorder (cached)
@@ -272,13 +273,56 @@ export function CameraScreen() {
     await recorder.stopRecording()
     console.log(`Recording stopped!`)
   }, [])
+  const runStartCrashReproCaptureCycle = useCallback(async () => {
+    if (startCrashReproCaptureInFlight.current) return
+    startCrashReproCaptureInFlight.current = true
+    try {
+      if (startCrashReproMode === 'photo') {
+        const photo = await photoOutput.capturePhoto(
+          { flashMode: 'off', enableShutterSound: false },
+          {},
+        )
+        console.log(
+          `[START_CRASH_REPRO] captured ${photo.width}x${photo.height} photo in cycle ${startCrashReproCycle}`,
+        )
+        photo.dispose()
+      } else {
+        const recorder = await videoOutput.createRecorder({})
+        await recorder.startRecording(
+          (path, reason) => {
+            console.log(
+              `[START_CRASH_REPRO] recording finished with ${reason}; path: ${path}`,
+            )
+          },
+          (error) =>
+            console.error(`[START_CRASH_REPRO] recording failed`, error),
+        )
+        await recorder.stopRecording()
+        console.log(
+          `[START_CRASH_REPRO] started and stopped video recording in cycle ${startCrashReproCycle}`,
+        )
+      }
+    } catch (error) {
+      console.error(
+        `[START_CRASH_REPRO] ${startCrashReproMode} capture cycle failed`,
+        error,
+      )
+    } finally {
+      startCrashReproCaptureInFlight.current = false
+      setStartCrashReproActive(false)
+    }
+  }, [photoOutput, startCrashReproCycle, startCrashReproMode, videoOutput])
   const onCameraStarted = useCallback(() => {
     if (!START_CRASH_REPRO) return
     console.log(
-      `[START_CRASH_REPRO] ${startCrashReproMode} cycle ${startCrashReproCycle} started; stopping before next reconfigure/start`,
+      `[START_CRASH_REPRO] ${startCrashReproMode} cycle ${startCrashReproCycle} started; running capture before next reconfigure/start`,
     )
-    setStartCrashReproActive(false)
-  }, [startCrashReproCycle, startCrashReproMode])
+    void runStartCrashReproCaptureCycle()
+  }, [
+    runStartCrashReproCaptureCycle,
+    startCrashReproCycle,
+    startCrashReproMode,
+  ])
   const onCameraStopped = useCallback(() => {
     if (!START_CRASH_REPRO) return
     setStartCrashReproCycle((cycle) => {

--- a/apps/simple-camera/src/screens/CameraScreen.tsx
+++ b/apps/simple-camera/src/screens/CameraScreen.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native-vision-camera'
 import { useLocation } from 'react-native-vision-camera-location'
 import { useResizer } from 'react-native-vision-camera-resizer'
+import { SkiaCamera } from 'react-native-vision-camera-skia'
 import { CameraSelectorButton } from '../components/CameraSelectorButton'
 import { CameraView } from '../components/CameraView'
 import { CaptureButton } from '../components/CaptureButton'
@@ -24,6 +25,10 @@ import { useSafeAreaPadding } from '../hooks/useSafeAreaPadding'
 import { logDevices } from '../logDevices'
 
 const START_CRASH_REPRO = true
+
+function getStartCrashMode(cycle: number): 'photo' | 'video' {
+  return cycle % 2 === 1 ? 'video' : 'photo'
+}
 
 export function CameraScreen() {
   const navigation = useNavigation()
@@ -85,9 +90,13 @@ export function CameraScreen() {
     targetBitRate: startCrashReproVariant % 2 === 0 ? 20_000_000 : 12_000_000,
     enableAudio: false,
   })
+  const startCrashReproMode = getStartCrashMode(startCrashReproCycle)
   const cameraOutputs = useMemo(
-    () => (START_CRASH_REPRO ? [photoOutput, videoOutput] : [photoOutput]),
-    [photoOutput, videoOutput],
+    () =>
+      START_CRASH_REPRO && startCrashReproMode === 'video'
+        ? [videoOutput]
+        : [photoOutput],
+    [photoOutput, startCrashReproMode, videoOutput],
   )
   const cameraConstraints = useMemo<Constraint[]>(() => {
     if (!START_CRASH_REPRO) return []
@@ -95,14 +104,21 @@ export function CameraScreen() {
     if (device?.supportsFPS(60)) {
       nextConstraints.push({ fps: 60 })
     }
-    if (device?.supportsVideoStabilizationMode('cinematic-extended')) {
+    if (
+      startCrashReproMode === 'video' &&
+      device?.supportsVideoStabilizationMode('cinematic-extended')
+    ) {
       nextConstraints.push({ videoStabilizationMode: 'cinematic-extended' })
     }
-    if (startCrashReproHDR && device?.supportsPhotoHDR) {
+    if (
+      startCrashReproMode === 'photo' &&
+      startCrashReproHDR &&
+      device?.supportsPhotoHDR
+    ) {
       nextConstraints.unshift({ photoHDR: true })
     }
     return nextConstraints
-  }, [device, startCrashReproHDR])
+  }, [device, startCrashReproHDR, startCrashReproMode])
   const { resizer, error } = useResizer({
     width: 192,
     height: 192,
@@ -259,16 +275,17 @@ export function CameraScreen() {
   const onCameraStarted = useCallback(() => {
     if (!START_CRASH_REPRO) return
     console.log(
-      `[START_CRASH_REPRO] cycle ${startCrashReproCycle} started; stopping before next reconfigure/start`,
+      `[START_CRASH_REPRO] ${startCrashReproMode} cycle ${startCrashReproCycle} started; stopping before next reconfigure/start`,
     )
     setStartCrashReproActive(false)
-  }, [startCrashReproCycle])
+  }, [startCrashReproCycle, startCrashReproMode])
   const onCameraStopped = useCallback(() => {
     if (!START_CRASH_REPRO) return
     setStartCrashReproCycle((cycle) => {
       const nextCycle = cycle + 1
+      const nextMode = getStartCrashMode(nextCycle)
       console.log(
-        `[START_CRASH_REPRO] cycle ${cycle} stopped; swapping output/constraints and immediately restarting cycle ${nextCycle}`,
+        `[START_CRASH_REPRO] cycle ${cycle} stopped; switching to ${nextMode} outputs and immediately restarting cycle ${nextCycle}`,
       )
       return nextCycle
     })
@@ -288,24 +305,48 @@ export function CameraScreen() {
     <View style={[styles.container, safePadding]}>
       <StatusBar barStyle="light-content" />
 
-      <CameraView
-        isActive={
-          isAppActive &&
-          isScreenFocused &&
-          (!START_CRASH_REPRO || startCrashReproActive)
-        }
-        device={device}
-        outputs={cameraOutputs}
-        mirrorMode={device.position === 'front' ? 'on' : 'off'}
-        constraints={cameraConstraints}
-        onStarted={onCameraStarted}
-        onStopped={onCameraStopped}
-        onInterruptionStarted={(reason) =>
-          console.log(`Camera interrupted! Reason: ${reason}`)
-        }
-        onInterruptionEnded={() => console.log(`Camera interruption over.`)}
-        onError={(error) => console.error(`Camera error:`, error)}
-      />
+      {START_CRASH_REPRO ? (
+        <SkiaCamera
+          isActive={isAppActive && isScreenFocused && startCrashReproActive}
+          style={styles.camera}
+          device={device}
+          outputs={cameraOutputs}
+          mirrorMode={device.position === 'front' ? 'on' : 'off'}
+          constraints={cameraConstraints}
+          enablePreviewSizedOutputBuffers={true}
+          onFrame={(frame, render) => {
+            'worklet'
+            render(({ canvas, frameTexture }) => {
+              canvas.drawImage(frameTexture, 0, 0)
+            })
+            frame.dispose()
+          }}
+          onStarted={onCameraStarted}
+          onStopped={onCameraStopped}
+          onSessionConfigSelected={(config) => {
+            console.log(`Given Constraints:`, cameraConstraints)
+            console.log(`Resolved SessionConfig:`, config.toString())
+          }}
+          onInterruptionStarted={(reason) =>
+            console.log(`Camera interrupted! Reason: ${reason}`)
+          }
+          onInterruptionEnded={() => console.log(`Camera interruption over.`)}
+          onError={(error) => console.error(`Camera error:`, error)}
+        />
+      ) : (
+        <CameraView
+          isActive={isAppActive && isScreenFocused}
+          device={device}
+          outputs={cameraOutputs}
+          mirrorMode={device.position === 'front' ? 'on' : 'off'}
+          constraints={cameraConstraints}
+          onInterruptionStarted={(reason) =>
+            console.log(`Camera interrupted! Reason: ${reason}`)
+          }
+          onInterruptionEnded={() => console.log(`Camera interruption over.`)}
+          onError={(error) => console.error(`Camera error:`, error)}
+        />
+      )}
 
       <FullOverlay style={safePadding}>
         <Row>
@@ -337,6 +378,11 @@ const styles = StyleSheet.create({
   },
   flex: {
     flex: 1,
+  },
+  camera: {
+    flex: 1,
+    borderRadius: 25,
+    overflow: 'hidden',
   },
   textContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary

- adds an event-driven simple-camera repro loop for #3773
- adds a high-level `<Camera>` Harness test that repeatedly replaces outputs/constraints and immediately restarts from lifecycle callbacks
- documents current crash-stack analysis, local device observations, and evidence boundaries in `START_CRASH_FINDINGS.md`

## Current findings

The issue stack proves `AVCaptureSession.startRunning()` overlaps AVFoundation/CoreMedia's private configuration-commit notification path on `FigCaptureSessionNotificationQueue`. VisionCamera serializes `configure()` and `start()` on its own queue, so the current root-cause candidate is that `commitConfiguration()` returns before AVFoundation has fully drained its private "make configuration live" work, and the next queued `startRunning()` can race output attachment.

I have not reproduced the exact assertion locally yet. The iPhone SE 3rd gen completed roughly 480 cycles without crashing; the iPhone 15 Pro was later locked and denied further launches. The Harness test is intended to make CI the next real-device signal.

## Verification

- `bun run build`
- `bunx tsc --noEmit --project apps/simple-camera/tsconfig.json`
- `git diff --check`
- `bun --cwd apps/simple-camera react-native bundle --platform ios --dev true --entry-file index.js --bundle-output /tmp/simple-camera-start-crash.bundle --assets-dest /tmp/simple-camera-start-crash-assets --reset-cache`

Biome reported only pre-existing unused-variable warnings in `CameraScreen.tsx`; the new Harness file had no Biome diagnostics.
