### PR TITLE
fix: Enable deferred start on Barcode/Object Output for faster startup

### DIFF
--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
@@ -51,6 +51,11 @@ final class HybridBarcodeScannerOutput: HybridCameraOutputSpec, NativeCameraOutp
     })
     self.output.setSampleBufferDelegate(delegate, queue: queue)
     self.output.alwaysDiscardsLateVideoFrames = true
+    if #available(iOS 26.0, *), output.isDeferredStartSupported {
+      // Deferred start allows the session to delay this output's startup in favor
+      // of preview-related outputs to make preview appear faster.
+      output.isDeferredStartEnabled = true
+    }
     if #available(iOS 17.0, *), options.outputResolution != .full {
       self.output.automaticallyConfiguresOutputBufferDimensions = false
       self.output.deliversPreviewSizedOutputBuffers = true

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraObjectOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraObjectOutput.swift
@@ -36,6 +36,12 @@ final class HybridCameraObjectOutput: HybridCameraObjectOutputSpec, NativeCamera
     self.output = AVCaptureMetadataOutput()
     self.delegate = MetadataDelegate()
 
+    if #available(iOS 26.0, *), output.isDeferredStartSupported {
+      // Deferred start allows the session to delay this output's startup in favor
+      // of preview-related outputs to make preview appear faster.
+      output.isDeferredStartEnabled = true
+    }
+
     output.setMetadataObjectsDelegate(delegate, queue: queue)
   }
 

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
@@ -55,6 +55,12 @@ final class HybridCameraPhotoOutput: HybridCameraPhotoOutputSpec, NativeCameraOu
     self.options = options
     super.init()
 
+    if #available(iOS 26.0, *), output.isDeferredStartSupported {
+      // Deferred start allows the session to delay this output's startup in favor
+      // of preview-related outputs to make preview appear faster.
+      output.isDeferredStartEnabled = true
+    }
+
     output.maxPhotoQualityPrioritization = options.qualityPrioritization.toAVQualityPrioritization()
 
     if options.containerFormat == .dng {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
@@ -55,12 +55,6 @@ final class HybridCameraPhotoOutput: HybridCameraPhotoOutputSpec, NativeCameraOu
     self.options = options
     super.init()
 
-    if #available(iOS 26.0, *), output.isDeferredStartSupported {
-      // Deferred start allows the session to delay this output's startup in favor
-      // of preview-related outputs to make preview appear faster.
-      output.isDeferredStartEnabled = true
-    }
-
     output.maxPhotoQualityPrioritization = options.qualityPrioritization.toAVQualityPrioritization()
 
     if options.containerFormat == .dng {
@@ -73,6 +67,12 @@ final class HybridCameraPhotoOutput: HybridCameraPhotoOutputSpec, NativeCameraOu
     {
       // Don't rotate Photo buffers - we handle orientation later on in file capture or toImage().
       output.isCameraSensorOrientationCompensationEnabled = false
+    }
+
+    if #available(iOS 26.0, *), output.isDeferredStartSupported {
+      // Deferred start allows the session to delay this output's startup in favor
+      // of preview-related outputs to make preview appear faster.
+      output.isDeferredStartEnabled = true
     }
 
     // Prepare the default Photo Settings to make the pipeline ready - some things (like flashMode)

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoOutput.swift
@@ -41,6 +41,11 @@ final class HybridCameraVideoOutput: HybridCameraVideoOutputSpec, NativeCameraOu
     self.fileType = options.fileType ?? .mov
     super.init()
     self.setMetadataTag(.libraryTag)
+    if #available(iOS 26.0, *), output.isDeferredStartSupported {
+      // Deferred start allows the session to delay this output's startup in favor
+      // of preview-related outputs to make preview appear faster.
+      output.isDeferredStartEnabled = true
+    }
   }
 
   private func setMetadataTag(_ tag: AVMetadataItem) {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoOutput.swift
@@ -40,6 +40,7 @@ final class HybridCameraVideoOutput: HybridCameraVideoOutputSpec, NativeCameraOu
     self.options = options
     self.fileType = options.fileType ?? .mov
     super.init()
+
     self.setMetadataTag(.libraryTag)
     if #available(iOS 26.0, *), output.isDeferredStartSupported {
       // Deferred start allows the session to delay this output's startup in favor


### PR DESCRIPTION
Previously, deferred `AVCaptureOutput` startup was only enabled on `AVCapturePhotoOutput` and all `AVCaptureFileOutput` subclasses.

Now we also enable it on the barcode scanner and Object Output - which makes the preview start faster.