### PR TITLE
fix: Simplify `isMicrophone` accessor to inspect ports

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureInput+isMicrophone.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureInput+isMicrophone.swift
@@ -10,13 +10,6 @@ import NitroModules
 
 extension AVCaptureInput {
   var isMicrophone: Bool {
-    guard let self = self as? AVCaptureDeviceInput else {
-      return false
-    }
-    if #available(iOS 17.0, *) {
-      return self.device.deviceType == .microphone
-    } else {
-      return self.device.deviceType == .builtInMicrophone
-    }
+    return ports.contains { $0.mediaType == .audio }
   }
 }


### PR DESCRIPTION
This diff avoids accessing the `AVCaptureDevice` just to inspect if it `isMicrophone`, and instead just checks if any of the `ports` are `audio` ports.