### PR TITLE
feat: Allocate GPU-sampleable YUV buffers on Android for zero-copy GPU Frame import

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridFrameOutput.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/outputs/HybridFrameOutput.kt
@@ -1,6 +1,7 @@
 package com.margelo.nitro.camera.hybrids.outputs
 
 import android.annotation.SuppressLint
+import android.os.Build
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import com.margelo.nitro.camera.CameraOrientation
@@ -23,6 +24,7 @@ import com.margelo.nitro.camera.hybrids.instances.HybridFrame
 import com.margelo.nitro.camera.public.NativeCameraOutput
 import com.margelo.nitro.camera.utils.IdentifiableExecutor
 import com.margelo.nitro.camera.utils.PrivateImageReaderProxy
+import com.margelo.nitro.camera.utils.YuvImageReaderProxy
 
 class HybridFrameOutput(
   private val options: FrameOutputOptions,
@@ -84,6 +86,17 @@ class HybridFrameOutput(
             TargetVideoPixelFormat.YUV -> {
               // Use YUV_420_888 (CPU)
               setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_YUV_420_888)
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                // Allocate YUV buffers with GPU_SAMPLED_IMAGE usage (when the device
+                // supports it) so Frames stay CPU-readable but can additionally be
+                // imported zero-copy as GPU textures via `Frame.getNativeBuffer()`
+                // (e.g. Vulkan/WebGPU/Skia). CameraX's default ImageReader allocates
+                // CPU-only buffers, which GPU APIs cannot import.
+                @SuppressLint("RestrictedApi")
+                setImageReaderProxyProvider { width, height, _, queueDepth, _ ->
+                  YuvImageReaderProxy(width, height, queueDepth)
+                }
+              }
             }
             TargetVideoPixelFormat.RGB -> {
               // Use RGBA_8888 (CPU + extra conversion)
@@ -93,8 +106,9 @@ class HybridFrameOutput(
               // Use PRIVATE (GPU)
               if (options.enablePhysicalBufferRotation) {
                 throw Error(
-                  "Cannot enable physical buffer rotation when `enableGpuBuffers` is set to true! " +
-                    "Set `enablePhysicalBufferRotation={false}` to use GPU buffers, or disable GPU buffers if physical buffer rotation is necessary.",
+                  "Cannot enable physical buffer rotation when `pixelFormat` is `native`! " +
+                    "Set `enablePhysicalBufferRotation: false` to use native GPU buffers, " +
+                    "or use a different `pixelFormat` if physical buffer rotation is necessary.",
                 )
               }
               @SuppressLint("RestrictedApi")

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/utils/YuvImageProxy.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/utils/YuvImageProxy.kt
@@ -1,0 +1,95 @@
+package com.margelo.nitro.camera.utils
+
+import android.annotation.SuppressLint
+import android.graphics.Matrix
+import android.graphics.Rect
+import android.media.Image
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.FlashState
+import androidx.camera.core.ImageInfo
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.ImmutableImageInfo
+import androidx.camera.core.impl.TagBundle
+import java.nio.ByteBuffer
+
+/**
+ * An implementation of [ImageProxy] that holds an [Image]
+ * in [android.graphics.ImageFormat.YUV_420_888].
+ */
+class YuvImageProxy(
+  private val image: Image,
+) : ImageProxy {
+  private val imageInfo: ImageInfo
+  private val planes: Array<ImageProxy.PlaneProxy> by lazy {
+    image.planes.map { plane -> PlaneProxy(plane) }.toTypedArray()
+  }
+
+  init {
+    // rotationDegrees and transformMatrix are placeholder values here.
+    // CameraX's ImageAnalysis wraps this proxy in a SettableImageProxy
+    // with the correct relative rotation and sensor-to-buffer transform
+    // before delivering it to the analyzer callback.
+    @SuppressLint("RestrictedApi")
+    imageInfo =
+      ImmutableImageInfo.create(
+        TagBundle.emptyBundle(),
+        image.timestamp,
+        0,
+        Matrix(),
+        FlashState.NOT_FIRED,
+      )
+  }
+
+  private class PlaneProxy(
+    private val plane: Image.Plane,
+  ) : ImageProxy.PlaneProxy {
+    override fun getRowStride(): Int {
+      return plane.rowStride
+    }
+
+    override fun getPixelStride(): Int {
+      return plane.pixelStride
+    }
+
+    override fun getBuffer(): ByteBuffer {
+      return plane.buffer
+    }
+  }
+
+  override fun close() {
+    image.close()
+  }
+
+  override fun getCropRect(): Rect {
+    return image.cropRect
+  }
+
+  override fun setCropRect(rect: Rect?) {
+    image.cropRect = rect
+  }
+
+  override fun getFormat(): Int {
+    return image.format
+  }
+
+  override fun getHeight(): Int {
+    return image.height
+  }
+
+  override fun getWidth(): Int {
+    return image.width
+  }
+
+  override fun getPlanes(): Array<out ImageProxy.PlaneProxy> {
+    return planes
+  }
+
+  override fun getImageInfo(): ImageInfo {
+    return imageInfo
+  }
+
+  @ExperimentalGetImage
+  override fun getImage(): Image {
+    return image
+  }
+}

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/utils/YuvImageReaderProxy.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/utils/YuvImageReaderProxy.kt
@@ -1,0 +1,100 @@
+package com.margelo.nitro.camera.utils
+
+import android.annotation.SuppressLint
+import android.graphics.ImageFormat
+import android.hardware.HardwareBuffer
+import android.media.ImageReader
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.view.Surface
+import androidx.annotation.RequiresApi
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.impl.ImageReaderProxy
+import java.util.concurrent.Executor
+
+/**
+ * An implementation of [ImageReaderProxy] that streams [android.media.Image]s
+ * in [ImageFormat.YUV_420_888], allocated with
+ * [HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE] when the device supports it.
+ *
+ * CameraX's default ImageReader allocates CPU-only buffers, whose
+ * `HardwareBuffer`s cannot be imported and sampled by GPU APIs
+ * (Vulkan/OpenGL/WebGPU/Skia). By additionally requesting
+ * [HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE], the Frames streamed by this
+ * reader stay CPU-readable *and* can be imported zero-copy as GPU textures
+ * via their `HardwareBuffer` (see `Frame.getNativeBuffer()`).
+ */
+@SuppressLint("RestrictedApi")
+@RequiresApi(Build.VERSION_CODES.Q)
+class YuvImageReaderProxy : ImageReaderProxy {
+  private val imageReaderThread = HandlerThread("YuvImageReaderProxy").apply { start() }
+  private val imageReaderHandler = Handler(imageReaderThread.looper)
+  private val imageReader: ImageReader
+
+  constructor(width: Int, height: Int, maxImages: Int) {
+    val usage = HardwareBuffer.USAGE_CPU_READ_OFTEN or HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
+    imageReader =
+      if (HardwareBuffer.isSupported(width, height, HardwareBuffer.YCBCR_420_888, 1, usage)) {
+        ImageReader.newInstance(width, height, ImageFormat.YUV_420_888, maxImages, usage)
+      } else {
+        // This device cannot allocate GPU-sampleable YUV buffers - fall back
+        // to CPU-only buffers, same as CameraX's default ImageReader.
+        ImageReader.newInstance(width, height, ImageFormat.YUV_420_888, maxImages)
+      }
+  }
+
+  override fun acquireLatestImage(): ImageProxy? {
+    val image =
+      imageReader.acquireLatestImage()
+        ?: return null
+    return YuvImageProxy(image)
+  }
+
+  override fun acquireNextImage(): ImageProxy? {
+    val image =
+      imageReader.acquireNextImage()
+        ?: return null
+    return YuvImageProxy(image)
+  }
+
+  override fun close() {
+    imageReader.close()
+    imageReaderThread.quitSafely()
+  }
+
+  override fun getHeight(): Int {
+    return imageReader.height
+  }
+
+  override fun getWidth(): Int {
+    return imageReader.width
+  }
+
+  override fun getImageFormat(): Int {
+    return imageReader.imageFormat
+  }
+
+  override fun getMaxImages(): Int {
+    return imageReader.maxImages
+  }
+
+  override fun getSurface(): Surface? {
+    return imageReader.surface
+  }
+
+  override fun setOnImageAvailableListener(
+    listener: ImageReaderProxy.OnImageAvailableListener,
+    executor: Executor,
+  ) {
+    imageReader.setOnImageAvailableListener({ reader ->
+      executor.execute {
+        listener.onImageAvailable(this)
+      }
+    }, imageReaderHandler)
+  }
+
+  override fun clearOnImageAvailableListener() {
+    imageReader.setOnImageAvailableListener(null, null)
+  }
+}


### PR DESCRIPTION
## What

On Android, `pixelFormat: 'yuv'` Frame Outputs now allocate their `YUV_420_888` buffers with `USAGE_CPU_READ_OFTEN | USAGE_GPU_SAMPLED_IMAGE` (API 29+, when `HardwareBuffer.isSupported(...)` says the device can), via a new `YuvImageReaderProxy` mirroring the existing `PrivateImageReaderProxy`. Frames stay fully CPU-readable (planes are exposed unchanged), and can now **additionally** be imported zero-copy as GPU textures through `Frame.getNativeBuffer()`.

Also fixes a stale error message: the physical-buffer-rotation error in `HybridFrameOutput.kt` referenced `enableGpuBuffers`, an option that no longer exists; it now points at `pixelFormat: 'native'` / `enablePhysicalBufferRotation`.

## Why

CameraX's default ImageReaders allocate CPU-only gralloc buffers. Vulkan derives importable texture usages from the `AHardwareBuffer` usage bits, so without `USAGE_GPU_SAMPLED_IMAGE` the buffer cannot be sampled by the GPU. Concretely, Dawn (WebGPU) maps AHB usage to WebGPU usages in [`AHBFunctions.cpp`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/dawn/src/dawn/native/AHBFunctions.cpp) and only grants `TextureBinding` when `USAGE_GPU_SAMPLED_IMAGE` is present. The same applies to Skia's Vulkan backend and any `SamplerYcbcrConversion`-based import.

Today this means the docs' promise of zero-copy GPU import of Frames (via `NativeBuffer`) only holds for `pixelFormat: 'native'` on Android. ML/vision pipelines that want CPU access **and** a GPU preview/effects pass (e.g. react-native-webgpu, Skia) have no working format. With this change, `'yuv'` serves both.

## Behavior / compatibility

- API < 29, or devices where `HardwareBuffer.isSupported` returns false for the GPU-sampled combination: falls back to a plain `ImageReader`, identical behavior to today.
- CPU consumers are unaffected: `getPlanes()` works as before.
- `'rgb'` is unchanged (CameraX's RGBA conversion writes via CPU into its own reader; that pipeline isn't compatible with a custom GPU-usage reader).
- Like the existing `PrivateImageReaderProxy`, this uses CameraX's restricted `ImageReaderProxyProvider` API and a placeholder `ImageInfo` (CameraX wraps the proxy in a `SettableImageProxy` with the correct rotation before delivering it).

## Testing

Untested on a physical device so far; review with that in mind. The structure deliberately mirrors the proven `PrivateImageReaderProxy`/`PrivateImageProxy` pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)