### PR TITLE
docs: fix incorrect API examples and default in camera docs

### DIFF
--- a/docs/content/docs/photo-quality.mdx
+++ b/docs/content/docs/photo-quality.mdx
@@ -32,7 +32,7 @@ const photoOutput = usePhotoOutput({
 ### Configure JPEG `quality`
 
 Processed [`PhotoContainerFormat`](/api/react-native-vision-camera/type-aliases/PhotoContainerFormat)s (such as [`'jpeg'`](/api/react-native-vision-camera/type-aliases/PhotoContainerFormat) or [`'heic'`](/api/react-native-vision-camera/type-aliases/PhotoContainerFormat)) compress captured [`Photo`](/api/react-native-vision-camera/hybrid-objects/Photo)s.
-By default, a compression of `0.95` (meaning 95% quality) is used, which can be adjusted via [`quality`](/api/react-native-vision-camera/interfaces/PhotoOutputOptions#quality) - for example, to capture in maximum quality set it to `1.0`:
+By default, a compression of `0.9` (meaning 90% quality) is used, which can be adjusted via [`quality`](/api/react-native-vision-camera/interfaces/PhotoOutputOptions#quality) - for example, to capture in maximum quality set it to `1.0`:
 
 ```ts
 const photoOutput = usePhotoOutput({

--- a/docs/content/docs/recorder.mdx
+++ b/docs/content/docs/recorder.mdx
@@ -36,12 +36,12 @@ To start a Video Recording, use [`Recorder.startRecording(...)`](/api/react-nati
 
 ```ts
 const recorder = ...
-await recorder.startRecording({
+await recorder.startRecording(
   (path, reason) => console.log(`Recording finished! ${reason}`),
   (error) => console.error(`Recording error!`, error),
   () => console.log(`Recording paused!`),
   () => console.log(`Recording resumed!`)
-})
+)
 ```
 
 #### Inspecting Progress

--- a/packages/react-native-vision-camera/src/devices/getCameraDevice.ts
+++ b/packages/react-native-vision-camera/src/devices/getCameraDevice.ts
@@ -29,9 +29,9 @@ export interface DeviceFilter {
    * @example
    * ```ts
    * // This device is simpler, so it starts up faster.
-   * getCameraDevice({ physicalDevices: ['wide-angle'] })
+   * getCameraDevice(devices, 'back', { physicalDevices: ['wide-angle'] })
    * // This device is more complex, so it starts up slower, but you can switch between devices on 0.5x, 1x and 2x zoom.
-   * getCameraDevice({ physicalDevices: ['ultra-wide-angle', 'wide-angle', 'telephoto'] })
+   * getCameraDevice(devices, 'back', { physicalDevices: ['ultra-wide-angle', 'wide-angle', 'telephoto'] })
    * ```
    */
   physicalDevices?: PhysicalDeviceType[]


### PR DESCRIPTION
While reading the docs I hit three example snippets that don't match the actual API. Each fix below is checked against the source of truth in the repo.

### 1. `startRecording` example is a SyntaxError (`docs/content/docs/recorder.mdx`)

The "Starting a Recording" snippet passes the callbacks inside an object literal:

```ts
await recorder.startRecording({
  (path, reason) => ...,
  (error) => ...,
})
```

Bare arrow functions as object members aren't valid JS, so this throws `SyntaxError: Unexpected token '('`. `startRecording` actually takes positional arguments: `startRecording(onRecordingFinished, onRecordingError, onRecordingPaused?, onRecordingResumed?)` (see `Recorder.nitro.ts`). The positional form is already used correctly in `video-output.mdx`, so this just makes `recorder.mdx` consistent with it.

### 2. Wrong default JPEG quality (`docs/content/docs/photo-quality.mdx`)

The page says the default compression is `0.95` (95% quality). The real default is `0.9`: `usePhotoOutput` destructures `quality = 0.9` (`src/hooks/usePhotoOutput.ts`), and the Nitro spec documents `@default 0.9` (`CameraPhotoOutput.nitro.ts`). Updated `0.95` to `0.9` and `95%` to `90%`.

### 3. `getCameraDevice` `@example` uses the wrong call shape (`src/devices/getCameraDevice.ts`)

The `DeviceFilter.physicalDevices` JSDoc `@example` calls `getCameraDevice({ physicalDevices: [...] })` (a single object), but the function signature is `getCameraDevice(devices, position, filter)`. The function-level `@example` in the same file already shows the correct 3-argument form, so I updated the two `physicalDevices` example lines to match: `getCameraDevice(devices, 'back', { physicalDevices: [...] })`.

Docs-only change, no runtime code touched.