### PR TITLE
fix: catch rejections in torch/zoom/exposure control updaters

### DIFF
--- a/packages/react-native-vision-camera/src/hooks/internal/useExposureUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useExposureUpdater.ts
@@ -11,13 +11,20 @@ export function useExposureUpdater(
     if (controller == null) return
     if (exposure == null) return
 
+    // `setExposureBias` rejects if the session became inactive before the
+    // update applied (e.g. during teardown). This is recoverable, so catch the
+    // rejection here — otherwise it surfaces as an unhandled promise rejection.
+    const onExposureError = (error: unknown): void => {
+      console.warn('Failed to set exposure bias:', error)
+    }
+
     if (typeof exposure === 'number') {
       // number
-      controller.setExposureBias(exposure)
+      controller.setExposureBias(exposure).catch(onExposureError)
       return
     } else {
       // SharedValue<number>
-      controller.setExposureBias(exposure.get())
+      controller.setExposureBias(exposure.get()).catch(onExposureError)
       const listener = VisionCameraWorkletsProxy.bindUIUpdatesToController(
         exposure,
         controller,

--- a/packages/react-native-vision-camera/src/hooks/internal/useTorchModeUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useTorchModeUpdater.ts
@@ -10,6 +10,12 @@ export function useTorchModeUpdater(
     if (controller == null) return
     if (torchMode == null) return
 
-    controller.setTorchMode(torchMode)
+    // `setTorchMode` rejects if the device has no torch (e.g. front camera, or
+    // many emulators), or if the session became inactive before the update
+    // applied (e.g. during teardown). These are recoverable, so catch the
+    // rejection here — otherwise it surfaces as an unhandled promise rejection.
+    controller.setTorchMode(torchMode).catch((error) => {
+      console.warn(`Failed to set torch mode to "${torchMode}":`, error)
+    })
   }, [controller, torchMode])
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useZoomUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useZoomUpdater.ts
@@ -11,13 +11,21 @@ export function useZoomUpdater(
     if (controller == null) return
     if (zoom == null) return
 
+    // `setZoom` rejects if the session became inactive before the update
+    // applied (e.g. during teardown), throwing `OperationCanceledException:
+    // Camera is not active`. This is recoverable, so catch the rejection here —
+    // otherwise it surfaces as an unhandled promise rejection.
+    const onZoomError = (error: unknown): void => {
+      console.warn('Failed to set zoom:', error)
+    }
+
     if (typeof zoom === 'number') {
       // number
-      controller.setZoom(zoom)
+      controller.setZoom(zoom).catch(onZoomError)
       return
     } else {
       // SharedValue<number>
-      controller.setZoom(zoom.get())
+      controller.setZoom(zoom.get()).catch(onZoomError)
       const listener = VisionCameraWorkletsProxy.bindUIUpdatesToController(
         zoom,
         controller,


### PR DESCRIPTION
## What

The internal control-updater hooks fire the nitro controller's promise-returning setters without a `.catch()`:

- `useTorchModeUpdater` → `controller.setTorchMode(...)`
- `useZoomUpdater` → `controller.setZoom(...)`
- `useExposureUpdater` → `controller.setExposureBias(...)`

This PR catches those rejections and `console.warn`s instead, matching the existing logging convention in `useCamera` / `useFrameOutput`.

## Why

These setters reject under recoverable, real-world conditions, and the un-caught promise bubbles to the JS global unhandled-rejection handler — polluting crash reporters (Sentry etc.) even though the app keeps running fine:

- **`setTorchMode`** → `java.lang.IllegalStateException: No flash unit` when the active device/lens has no torch (front camera, many emulators). Reproduce: render `<Camera torchMode="on" />` on a device whose active lens has no flash.
- **`setZoom` / `setExposureBias`** → `androidx.camera.core.CameraControl$OperationCanceledException: Camera is not active.` when the `zoom`/`exposure` prop updates while the session is inactive or tearing down (common race when a camera screen unmounts).

Example unhandled rejection seen in production (v5.0.11, Android):

```
Error: androidx.camera.core.CameraControl$OperationCanceledException: Camera is not active.
    at androidx.camera.camera2.impl.ZoomControl.applyZoomState(ZoomControl.kt:160)
    ...
    at com.margelo.nitro.camera.hybrids.HybridCameraController$setZoom$1.invokeSuspend(HybridCameraController.kt:134)

Error: java.lang.IllegalStateException: No flash unit
    at androidx.camera.camera2.impl.TorchControl.setTorchAsync(TorchControl.kt:128)
    ...
    at com.margelo.nitro.camera.hybrids.HybridCameraController$setTorchMode$1.invokeSuspend(HybridCameraController.kt:205)
```

## Changes

Each updater catches the setter rejection and logs a warning. No behavior change beyond not leaking the rejection — the failures are transient/recoverable and the existing `controller == null` / value-`null` guards are untouched.

## Notes

`setTorchMode`'s own doc already states `@throws If the device does not have a torch` — so a thrown/rejected promise here is expected, and the hook should own it rather than letting it escape.