### PR TITLE
fix: Change `'yuv'` from `-full` to `-video` range

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/Converters/AV+TargetVideoPixelFormat.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/Converters/AV+TargetVideoPixelFormat.swift
@@ -14,7 +14,7 @@ extension TargetVideoPixelFormat {
     case .native:
       return .native
     case .yuv:
-      return .specific(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
+      return .specific(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)
     case .rgb:
       return .specific(kCVPixelFormatType_32BGRA)
     }

--- a/packages/react-native-vision-camera/src/specs/common-types/VideoPixelFormat.ts
+++ b/packages/react-native-vision-camera/src/specs/common-types/VideoPixelFormat.ts
@@ -55,7 +55,7 @@ export type VideoPixelFormat =
  *    {@linkcode VideoPixelFormat | 'raw-bayer-packed96-12-bit'}, or a private
  *    format ({@linkcode PixelFormat | 'private'}) and requires zero conversion.
  * - `'yuv'`: Choose the YUV format closest to the Camera's native format. Often YUV 4:2:0
- *    8-bit full-range like {@linkcode VideoPixelFormat | 'yuv-420-8-bit-full'}.
+ *    8-bit video-range like {@linkcode VideoPixelFormat | 'yuv-420-8-bit-video'}.
  * - `'rgb'`: Choose an RGB format. Often 8-bit BGRA like
  *   {@linkcode VideoPixelFormat | 'rgb-bgra-8-bit'}.
  */


### PR DESCRIPTION
Based on the discussion with @wcandillon in https://github.com/mrousavy/react-native-vision-camera/pull/4022, I discovered that the de-facto default on iOS is actually `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`, not `kCVPixelFormatType_420YpCbCr8BiPlanarFullRange`.

So in this PR we change that - if you pass `'yuv'` to your `FrameOutput` it now represents video range, not full range 8-bit YUV 4:2:0 buffers.

Technically a breaking change, although pretty much all libraries handle both full and video range. So I doubt anybody will notice anything.