### PR TITLE
iOS: <Camera> records 4K — preview resolutionBias overrides the video output's targetResolution (failing repro)

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
@@ -16,6 +16,9 @@ import {
   CommonResolutions,
   VisionCamera,
 } from 'react-native-vision-camera'
+import { provider as workletsProvider } from 'react-native-vision-camera-worklets'
+import { scheduleOnRN } from 'react-native-worklets'
+import { deferred, withTimeout } from './test-utils'
 
 describe('VisionCamera - Constraints', () => {
   let factory: CameraDeviceFactory
@@ -29,6 +32,100 @@ describe('VisionCamera - Constraints', () => {
     expect(back).toBeDefined()
     if (back == null) throw new Error('no back camera')
     backDevice = back
+  })
+
+  // Reproduces: a capture output's `targetResolution` is ignored when a preview
+  // is attached. `<Camera>` always injects a preview output and auto-appends one
+  // `{ resolutionBias }` per output (useCameraController.ts). The preview output's
+  // bias is `.min(screenSize)`, which gives every >=screen-size format (e.g. 4K)
+  // zero penalty and penalizes the capture output's `.closestTo(720p)`. Because
+  // ConstraintResolver sums every bias into the total penalty, the preview's bias
+  // dominates and the resolver negotiates the device's max (4K) format.
+  //
+  // `CameraSessionConfig` exposes no resolution and `onRecordingFinished` returns
+  // only (path, reason), so a delivered Frame's width/height is the only
+  // device-readable proof of the negotiated format. A Frame output streams at
+  // that negotiated format, so an over-selected 4K format yields ~4K frames.
+  it('keeps the negotiated resolution near a capture output target when a preview is attached', async (context) => {
+    // Only reproducible on devices that expose a format larger than ~1080p, so a
+    // 4K over-selection is even possible. Skip otherwise.
+    const longestEdge = Math.max(
+      ...backDevice
+        .getSupportedResolutions('video')
+        .map((r) => Math.max(r.width, r.height)),
+    )
+    if (longestEdge <= 1920) {
+      return context.skip(
+        `device max video resolution is ${longestEdge}px long edge; cannot reproduce 4K over-selection`,
+      )
+    }
+
+    const session = await VisionCamera.createCameraSession(false)
+    const previewOutput = VisionCamera.createPreviewOutput()
+    const frameOutput = VisionCamera.createFrameOutput({
+      targetResolution: CommonResolutions.HD_16_9, // 1280x720
+      pixelFormat: 'native',
+      enablePreviewSizedOutputBuffers: false,
+      enablePhysicalBufferRotation: false,
+      enableCameraMatrixDelivery: false,
+      allowDeferredStart: false,
+      dropFramesWhileBusy: true,
+    })
+
+    // Exactly what <Camera> builds under the hood: preview output first, and one
+    // resolutionBias per output, so the preview's `.min(screenSize)` bias has the
+    // highest priority.
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [
+          { output: previewOutput, mirrorMode: 'auto' },
+          { output: frameOutput, mirrorMode: 'auto' },
+        ],
+        constraints: [
+          { resolutionBias: previewOutput },
+          { resolutionBias: frameOutput },
+        ],
+      },
+    ])
+
+    const firstFrame = deferred<{ width: number; height: number }>()
+    const reportFrame = (width: number, height: number) =>
+      firstFrame.resolve({ width, height })
+    const errorSub = session.addOnErrorListener(firstFrame.reject)
+
+    const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
+    runtime.setOnFrameCallback(frameOutput, (frame) => {
+      'worklet'
+      scheduleOnRN(reportFrame, frame.width, frame.height)
+      frame.dispose()
+    })
+
+    await session.start()
+    let negotiated: { width: number; height: number }
+    try {
+      negotiated = await withTimeout(
+        firstFrame.promise,
+        15_000,
+        'receive frame',
+      )
+    } finally {
+      runtime.setOnFrameCallback(frameOutput, undefined)
+      errorSub.remove()
+      await session.stop()
+    }
+
+    const negotiatedLongEdge = Math.max(negotiated.width, negotiated.height)
+    const negotiatedShortEdge = Math.min(negotiated.width, negotiated.height)
+    console.log(
+      `target=1280x720 negotiated=${negotiated.width}x${negotiated.height}`,
+    )
+
+    // A 1280x720 target must not negotiate a 4K (3840x2160) format just because a
+    // preview is attached. Allow up to 1080p to tolerate devices without an exact
+    // 720p format; fail on anything approaching 4K.
+    expect(negotiatedLongEdge).toBeLessThanOrEqual(1920)
+    expect(negotiatedShortEdge).toBeLessThanOrEqual(1080)
   })
 
   it('resolves a baseline config with no constraints', async () => {


### PR DESCRIPTION
Relates to #3963. Builds on #3965.

#3965 is a great root fix for the **imperative** case in #3963 — switching from a summed weighted penalty to a lexicographic penalty vector means a higher-priority constraint can't be numerically swamped by a lower-priority one. 👍

But it makes constraint **order** decisive, and that exposes a second path #3965 doesn't cover: the **auto-injected preview `resolutionBias`**. This PR adds a failing harness test for it (test-only — the Device Farm run is the reproduction). A proposed fix is in the `<details>` at the bottom.

### The gap

In real `<Camera>` usage the resolver receives constraints in roughly this order (`Camera.tsx` prepends the preview to `outputs`; `useCameraController.ts` appends one `{ resolutionBias }` per output):

```
[ ...userConstraints, { resolutionBias: previewOutput }, { resolutionBias: videoOutput }, ...internal ]
```

So the **preview** bias outranks the **video** bias. `HybridCameraPreviewOutput.targetResolution` is `.min(screenSize)` with `streamType = .video`, which gives every ≥screen-size format (4K) penalty `0` and penalizes the requested 720p/1080p. Under #3965's lexicographic comparison, for any formats that tie on fps the preview term is compared **before** the video term and still selects 4K — `targetResolution` is overridden again.

#3965's harness test uses `[{ resolutionBias: videoOutput }, { fps: 60 }]` with **no preview**, so this path is currently untested.

### Test

Adds an `it(...)` to `visioncamera.constraints.harness.ts` that mirrors `<Camera>`: a preview output + a Frame output (`targetResolution` 720p), with `[{ resolutionBias: preview }, { resolutionBias: frame }]`. It asserts the delivered Frame is not ~4K. Frame dimensions are the only device-readable proof of the negotiated format (`CameraSessionConfig` exposes no resolution). **Expected to fail on `main` and also with #3965 applied** — happy to rebase onto #3965's branch to show that directly. Repro device: iPhone 17 Pro / iOS 26.5.1, front camera (camera-agnostic — any device with a format larger than the screen).

<details>
<summary><b>Proposed fix (preview should not outrank capture outputs) — direction for discussion, not verified</b></summary>

The `.min(screenSize)` rule is correct for a **preview-only** session (you want a screen-sized format there), so the fix is about **priority, not the rule**: when a capture output is present, its resolution target should outrank the preview's.

Under #3965's lexicographic model that just means ordering the auto-appended biases so **capture outputs come before preview outputs**. In `useCameraController.ts`:

```ts
const stableConstraints = useMemo<Constraint[]>(() => {
  const captureBiases = stableOutputs
    .filter((o) => !isPreviewOutput(o))
    .map<Constraint>((o) => ({ resolutionBias: o }))
  const previewBiases = stableOutputs
    .filter(isPreviewOutput)
    .map<Constraint>((o) => ({ resolutionBias: o }))
  // capture targets first (higher priority), preview last
  return [...constraints, ...captureBiases, ...previewBiases]
}, [/* ... */])
```

(Equivalently, drop the preview's `resolutionBias` entirely when a capture output is present — a preview can downscale from any format.) I haven't verified the exact JS predicate/ordering on a device, so treat this as the direction rather than a finished patch.