### PR TITLE
fix: Fix `getDefaultCamera('external')` not returning external Cameras

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraDeviceFactory.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraDeviceFactory.swift
@@ -74,6 +74,18 @@ final class HybridCameraDeviceFactory: HybridCameraDeviceFactorySpec {
   }
 
   func getDefaultCamera(position: CameraPosition) throws -> (any HybridCameraDeviceSpec)? {
+    if #available(iOS 17.0, *), position == .external {
+      // On iOS, Position "external" is for some reason reflected on the .deviceType, not on .position.
+      let device = AVCaptureDevice.default(
+        .external,
+        for: .video,
+        position: .unspecified)
+      guard let device else {
+        return nil
+      }
+      return HybridCameraDevice(device: device)
+    }
+
     let device = AVCaptureDevice.default(
       .builtInWideAngleCamera,
       for: .video,


### PR DESCRIPTION
Previously `'external'` mapped to `'unspecified'`, which caused `getDefaultCamera('external')` to just give you any Camera, often just the default built in back Camera.

Since external UVC cameras are not reflected on the `.position` for some reason but rather on `.deviceType == .external`, we add a specific path for this to make `getDefaultCamera('external')` actually work