### PR TITLE
fix(android): treat ERROR_SOURCE_INACTIVE as a successful finish (don't discard a valid file)

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/recording/HybridVideoRecorder.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/recording/HybridVideoRecorder.kt
@@ -77,6 +77,9 @@ class HybridVideoRecorder(
                   VideoRecordEvent.Finalize.ERROR_NONE -> RecordingFinishedReason.STOPPED
                   VideoRecordEvent.Finalize.ERROR_DURATION_LIMIT_REACHED -> RecordingFinishedReason.MAX_DURATION_REACHED
                   VideoRecordEvent.Finalize.ERROR_FILE_SIZE_LIMIT_REACHED -> RecordingFinishedReason.MAX_FILE_SIZE_REACHED
+                  // Source went inactive (e.g. Activity stopped mid-recording). Unlike
+                  // ERROR_NO_VALID_DATA, CameraX still finalizes a valid file, so keep it.
+                  VideoRecordEvent.Finalize.ERROR_SOURCE_INACTIVE -> RecordingFinishedReason.STOPPED
                   else -> null
                 }
               if (finishReason != null) {


### PR DESCRIPTION
### Problem

On Android, when a recording finalizes with `VideoRecordEvent.Finalize.ERROR_SOURCE_INACTIVE`, `HybridVideoRecorder` reports it via `onRecordingError`, so callers treat the recording as failed and discard it.

But `ERROR_SOURCE_INACTIVE` is **not** a no-output error. CameraX finalizes a valid, playable file (containing every frame produced before the source went inactive) *before* delivering the `Finalize` event. This commonly fires when the host `Activity` is stopped/destroyed mid-recording during normal app lifecycle (backgrounding, deep-link relaunch, config change) — so the user *did* record usable footage, and it's being thrown away.

### Evidence it produces a usable file

Per the CameraX [`VideoRecordEvent.Finalize` reference](https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.Finalize):

- [**`ERROR_SOURCE_INACTIVE`**](https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.Finalize#ERROR_SOURCE_INACTIVE): *"The recording failed because the source becomes inactive and stops sending frames. One case is that if camera is closed due to lifecycle stopped, the active recording will be finalized with this error, **and the output will be generated, containing the frames produced before camera closing.**"*
- [**`ERROR_NO_VALID_DATA`**](https://developer.android.com/reference/androidx/camera/video/VideoRecordEvent.Finalize#ERROR_NO_VALID_DATA): *"… **The application will need to clean up the output file, such as deleting the file.**"*

So `ERROR_SOURCE_INACTIVE` ⇒ usable file; `ERROR_NO_VALID_DATA` ⇒ no usable file.

### Precedent

`expo-camera` treats `ERROR_SOURCE_INACTIVE` as a success and resolves with `event.outputResults.outputUri` — see [`ExpoCameraView.kt` L382-L394](https://github.com/expo/expo/blob/3b8295d709a31fba4993fa7cb4a66d9ba61958ec/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt#L382-L394). This change brings VisionCamera in line with that contract.

The intent to keep the file even predates the Nitro rewrite. VisionCamera v4's [`VideoRecordEvent+toCameraError.kt` L13-L20](https://github.com/mrousavy/react-native-vision-camera/blob/d1cef7f16837173c542958556c8cc8bc964f438b/package/android/src/main/java/com/mrousavy/camera/core/extensions/VideoRecordEvent%2BtoCameraError.kt#L13-L20) grouped this code under a comment that reads *"errors where the recording still gets saved (so we can probably ignore them)"* — but mapped it to `NoDataError(cause)` (`wasVideoRecorded = false`), so [`CameraSession+Video.kt` L67-L76](https://github.com/mrousavy/react-native-vision-camera/blob/d1cef7f16837173c542958556c8cc8bc964f438b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession%2BVideo.kt#L67-L76) still took the fatal branch and dropped the file. The Nitro rewrite collapsed the `wasVideoRecorded` distinction, so the file is lost either way — this PR realizes the originally-intended behavior.

### Change

Map `ERROR_SOURCE_INACTIVE` to a successful finish (`RecordingFinishedReason.STOPPED`). `ERROR_NO_VALID_DATA` and other no-output errors stay on the error path.

> Open question: reuse `STOPPED`, or would you prefer a dedicated `RecordingFinishedReason.SOURCE_INACTIVE` so callers can distinguish a lifecycle-truncated recording from a clean stop while still receiving the file? Happy to adjust.

### Testing

`ERROR_SOURCE_INACTIVE` is delivered by CameraX when the frame source dies, which is impractical to trigger deterministically in the unit harness (needs a real camera/lifecycle teardown). Verified manually on devices (Android 12–16): backgrounding to destroy the Activity mid-recording previously hit `onRecordingError` with a valid file left on disk; with this change the file is delivered via `onRecordingFinished`. Happy to add a harness test if you can point me at the right seam to inject a `Finalize` event with a given error code.

`bun run lint-kotlin` produces no diff.
