### PR TITLE
fix: Fix connections not being removed

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureSession+containsConnection.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureSession+containsConnection.swift
@@ -20,7 +20,7 @@ extension AVCaptureSession {
     output: ResolvedCameraSessionConnection.Output
   ) -> Bool {
     return self.connections.contains { connection in
-      return connection.deviceInput == input && connection.isConnectedTo(output: output)
+      return connection.deviceInput?.device == input && connection.isConnectedTo(output: output)
     }
   }
 }


### PR DESCRIPTION
I noticed that the CI fails with these issues:

```
Connection "<AVCaptureConnection: 0x302841da0 (AVCaptureDeviceInput: 0x302844060 Back Camera) -> (AVCapturePhotoOutput: 0x302845820) [type:vide][enabled:1][active:1]>" cannot be added to Camera Session!
```

This was because the previous connections were never removed as our `deviceInput` comparison was wrong.