### PR TITLE
fix: Fix `getSupportedResolutions('photo')` throwing on some Androids

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getDepthSizes.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getDepthSizes.kt
@@ -12,6 +12,6 @@ fun Camera2CameraInfo.getDepthSizes(): Array<Size> {
     this.getCameraCharacteristic(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
       ?: return emptyArray()
   val depthFormats = streams.outputFormats.filter { ImageFormatUtils.isDepthFormat(it) }
-  val sizes = depthFormats.flatMap { streams.getOutputSizes(it).toList() }
+  val sizes = depthFormats.flatMap { streams.getOutputSizes(it).toListOrEmpty() }
   return sizes.distinct().toTypedArray()
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getPhotoSizes.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getPhotoSizes.kt
@@ -12,8 +12,12 @@ fun Camera2CameraInfo.getPhotoSizes(): Array<Size> {
     this.getCameraCharacteristic(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
       ?: return emptyArray()
   val photoFormats = streams.outputFormats.filter { ImageFormatUtils.isPhotoFormat(it) }
-  val sizes = photoFormats.flatMap { streams.getOutputSizes(it).toList() }
-  val highResSizes = photoFormats.flatMap { streams.getHighResolutionOutputSizes(it).toList() }
+  val sizes = photoFormats.flatMap { streams.getOutputSizes(it).toListOrEmpty() }
+  val highResSizes = photoFormats.flatMap { streams.getHighResolutionOutputSizes(it).toListOrEmpty() }
   val combined = (sizes + highResSizes).distinct()
   return combined.toTypedArray()
+}
+
+private fun Array<Size>?.toListOrEmpty(): List<Size> {
+  return this?.toList() ?: emptyList()
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getPhotoSizes.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getPhotoSizes.kt
@@ -17,7 +17,3 @@ fun Camera2CameraInfo.getPhotoSizes(): Array<Size> {
   val combined = (sizes + highResSizes).distinct()
   return combined.toTypedArray()
 }
-
-private fun Array<Size>?.toListOrEmpty(): List<Size> {
-  return this?.toList() ?: emptyList()
-}

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getStreamSizes.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getStreamSizes.kt
@@ -11,6 +11,6 @@ fun Camera2CameraInfo.getStreamSizes(): Array<Size> {
   val streams =
     this.getCameraCharacteristic(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
       ?: return emptyArray()
-  val sizes = streams.getOutputSizes(ImageReader::class.java)
+  val sizes = streams.getOutputSizes(ImageReader::class.java).toListOrEmpty()
   return sizes.distinct().toTypedArray()
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getVideoSizes.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/Camera2CameraInfo+getVideoSizes.kt
@@ -13,6 +13,6 @@ fun Camera2CameraInfo.getVideoSizes(): Array<Size> {
     this.getCameraCharacteristic(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
       ?: return emptyArray()
   val videoFormats = streams.outputFormats.filter { ImageFormatUtils.isVideoFormat(it) }
-  val sizes = videoFormats.flatMap { streams.getOutputSizes(it).toList() }
+  val sizes = videoFormats.flatMap { streams.getOutputSizes(it).toListOrEmpty() }
   return sizes.distinct().toTypedArray()
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/SizeArray+toListOrEmpty.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/SizeArray+toListOrEmpty.kt
@@ -1,0 +1,7 @@
+package com.margelo.nitro.camera.extensions
+
+import android.util.Size
+
+internal fun Array<Size>?.toListOrEmpty(): List<Size> {
+  return this?.toList() ?: emptyList()
+}


### PR DESCRIPTION
`CameraDevice.getSupportedResolutions('photo')` threw on Android devices where `getHighResolutionOutputSizes(..)` returned `null`.

This is classic Android BS, since `getHighResolutionOutputSizes(..)` is **non-nullable** in Kotlin, but it can still return `null` on some phones. Impossible to work reliably in this ecosystem honestly - straight up bullshit.

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/4075