### PR TITLE
chore: Add Harness test for `focus(…, { adaptiveness: 'locked' })`

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -1,6 +1,5 @@
 import { beforeAll, describe, expect, it } from 'react-native-harness'
 import type {
-  CameraController,
   CameraDevice,
   CameraDeviceFactory,
   MeteringMode,
@@ -19,28 +18,6 @@ const getSupportedMeteringModes = (device: CameraDevice): MeteringMode[] => {
     modes.push('AWB')
   }
   return modes
-}
-
-const expectMeteringModes = (
-  controller: CameraController,
-  modes: MeteringMode[],
-  expected: 'continuous' | 'locked',
-) => {
-  if (modes.includes('AF')) {
-    expect(controller.focusMode).toBe(
-      expected === 'locked' ? 'locked' : 'continuous-auto-focus',
-    )
-  }
-  if (modes.includes('AE')) {
-    expect(controller.exposureMode).toBe(
-      expected === 'locked' ? 'locked' : 'continuous-auto-exposure',
-    )
-  }
-  if (modes.includes('AWB')) {
-    expect(controller.whiteBalanceMode).toBe(
-      expected === 'locked' ? 'locked' : 'continuous-auto-white-balance',
-    )
-  }
 }
 
 describe('VisionCamera - Controller', () => {
@@ -556,10 +533,28 @@ describe('VisionCamera - Controller', () => {
         autoResetAfter: null,
       })
 
-      expectMeteringModes(controller, modes, 'locked')
+      if (modes.includes('AF')) {
+        expect(controller.focusMode).toBe('locked')
+      }
+      if (modes.includes('AE')) {
+        expect(controller.exposureMode).toBe('locked')
+      }
+      if (modes.includes('AWB')) {
+        expect(controller.whiteBalanceMode).toBe('locked')
+      }
 
       await controller.resetFocus()
-      expectMeteringModes(controller, modes, 'continuous')
+      if (modes.includes('AF')) {
+        expect(controller.focusMode).toBe('continuous-auto-focus')
+      }
+      if (modes.includes('AE')) {
+        expect(controller.exposureMode).toBe('continuous-auto-exposure')
+      }
+      if (modes.includes('AWB')) {
+        expect(controller.whiteBalanceMode).toBe(
+          'continuous-auto-white-balance',
+        )
+      }
     } finally {
       await session.stop()
     }

--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -1,9 +1,47 @@
 import { beforeAll, describe, expect, it } from 'react-native-harness'
 import type {
+  CameraController,
   CameraDevice,
   CameraDeviceFactory,
+  MeteringMode,
 } from 'react-native-vision-camera'
 import { CommonResolutions, VisionCamera } from 'react-native-vision-camera'
+
+const getSupportedMeteringModes = (device: CameraDevice): MeteringMode[] => {
+  const modes: MeteringMode[] = []
+  if (device.supportsExposureMetering) {
+    modes.push('AE')
+  }
+  if (device.supportsFocusMetering) {
+    modes.push('AF')
+  }
+  if (device.supportsWhiteBalanceMetering) {
+    modes.push('AWB')
+  }
+  return modes
+}
+
+const expectMeteringModes = (
+  controller: CameraController,
+  modes: MeteringMode[],
+  expected: 'continuous' | 'locked',
+) => {
+  if (modes.includes('AF')) {
+    expect(controller.focusMode).toBe(
+      expected === 'locked' ? 'locked' : 'continuous-auto-focus',
+    )
+  }
+  if (modes.includes('AE')) {
+    expect(controller.exposureMode).toBe(
+      expected === 'locked' ? 'locked' : 'continuous-auto-exposure',
+    )
+  }
+  if (modes.includes('AWB')) {
+    expect(controller.whiteBalanceMode).toBe(
+      expected === 'locked' ? 'locked' : 'continuous-auto-white-balance',
+    )
+  }
+}
 
 describe('VisionCamera - Controller', () => {
   let factory: CameraDeviceFactory
@@ -482,6 +520,46 @@ describe('VisionCamera - Controller', () => {
         responsiveness: 'snappy',
       })
       await controller.resetFocus()
+    } finally {
+      await session.stop()
+    }
+  })
+
+  it('locks metering modes after focusTo with locked adaptiveness', async (context) => {
+    const modes = getSupportedMeteringModes(backDevice)
+    if (modes.length === 0) {
+      return context.skip('focusTo locked: no supported metering modes')
+    }
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const [controller] = await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    if (controller == null) throw new Error('no controller')
+    await session.start()
+
+    try {
+      const point = VisionCamera.createNormalizedMeteringPoint(0.5, 0.5)
+      await controller.focusTo(point, {
+        modes,
+        responsiveness: 'snappy',
+        adaptiveness: 'locked',
+        autoResetAfter: null,
+      })
+
+      expectMeteringModes(controller, modes, 'locked')
+
+      await controller.resetFocus()
+      expectMeteringModes(controller, modes, 'continuous')
     } finally {
       await session.stop()
     }


### PR DESCRIPTION
The test will probably fail on Android as we don't have an implementation for `whiteBalanceMode`, `focusMode` and `exposureMode` yet. 

iOS _should_ work. We'll see.