### PR TITLE
fix: Don't remove from `session` collections while enumerating them

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.session.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.session.harness.ts
@@ -5,6 +5,7 @@ import {
   it,
   waitUntil,
 } from 'react-native-harness'
+import { Platform } from 'react-native'
 import type {
   CameraDeviceFactory,
   TargetCameraPosition,
@@ -888,6 +889,151 @@ describe('VisionCamera - Session', () => {
     } finally {
       await session.stop()
       await session.configure([])
+    }
+  })
+
+  it('re-uses the same outputs across re-created sessions (#3773)', async () => {
+    const device = factory.getDefaultCamera('back')
+    expect(device).toBeDefined()
+    if (device == null) throw new Error('no back camera')
+
+    // Outputs are created ONCE and re-used across all sessions - exactly like
+    // hook-created outputs surviving a <Camera> re-mount (e.g. a review screen
+    // that unmounts the Camera and re-mounts it on "Retake").
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const videoOutput = VisionCamera.createVideoOutput({
+      targetResolution: CommonResolutions.HD_16_9,
+      enableAudio: false,
+    })
+    const outputs = [
+      { output: photoOutput, mirrorMode: 'auto' as const },
+      { output: videoOutput, mirrorMode: 'auto' as const },
+    ]
+
+    // Cycle quickly: each iteration tears its session down exactly like
+    // `useCameraSession`'s unmount cleanup does (fire-and-forget stop +
+    // configure([]) + dispose), and the next iteration immediately attaches
+    // the same outputs to a brand-new session. The dispose() is what makes
+    // this safe: releasing the native session detaches its outputs at the
+    // CoreMedia level synchronously, before the next session's configure runs
+    // on the same native queue. Without it, the outputs could still be
+    // attached to the previous session at the CoreMedia level, which crashes
+    // in `attachToFigCaptureSession:` with a SIGABRT assertion (#3773).
+    for (let i = 0; i < 8; i++) {
+      const session = await VisionCamera.createCameraSession(false)
+      const started = deferred()
+      const startSub = session.addOnStartedListener(started.resolve)
+      const errorSub = session.addOnErrorListener(started.reject)
+      try {
+        await session.configure([{ input: device, outputs, constraints: [] }])
+        await session.start()
+        // Wait until the outputs are actually attached & streaming before
+        // tearing down - a stale attachment needs a live session to exist.
+        await withTimeout(started.promise, 10_000, `session #${i} start`)
+      } finally {
+        startSub.remove()
+        errorSub.remove()
+        session.stop().catch(() => {})
+        session.configure([]).catch(() => {})
+        session.dispose()
+      }
+    }
+
+    // After all those cross-session moves, the outputs must still be fully
+    // functional: configure them into one final session and take a photo.
+    const session = await VisionCamera.createCameraSession(false)
+    const started = deferred()
+    const startSub = session.addOnStartedListener(started.resolve)
+    const errorSub = session.addOnErrorListener(started.reject)
+    try {
+      await session.configure([{ input: device, outputs, constraints: [] }])
+      await session.start()
+      await withTimeout(started.promise, 10_000, 'final session start')
+
+      const photo = await photoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      expect(photo.width).toBeGreaterThan(0)
+      expect(photo.height).toBeGreaterThan(0)
+      photo.dispose()
+    } finally {
+      startSub.remove()
+      errorSub.remove()
+      await session.stop()
+      await session.configure([])
+    }
+  })
+
+  it('rejects re-using outputs while their previous session is still alive (iOS)', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip(
+        'output re-use guard: AVFoundation-specific, iOS only',
+      )
+    }
+    const device = factory.getDefaultCamera('back')
+    expect(device).toBeDefined()
+    if (device == null) throw new Error('no back camera')
+
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+
+    // Attach the output to session A...
+    const sessionA = await VisionCamera.createCameraSession(false)
+    await sessionA.configure([
+      {
+        input: device,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+
+    // ...then try to attach the same output to session B while A is still
+    // alive. AVFoundation detaches outputs asynchronously, so this is not
+    // provably safe and must fail deterministically instead of racing.
+    const sessionB = await VisionCamera.createCameraSession(false)
+    await expect(
+      sessionB.configure([
+        {
+          input: device,
+          outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+          constraints: [],
+        },
+      ]),
+    ).rejects.toThrow()
+
+    // Once A is released, its native teardown has detached the output
+    // synchronously - now B may use it.
+    await sessionA.configure([])
+    sessionA.dispose()
+    const controllers = await sessionB.configure([
+      {
+        input: device,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    expect(controllers).toHaveLength(1)
+
+    try {
+      await sessionB.start()
+      const photo = await photoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      expect(photo.width).toBeGreaterThan(0)
+      photo.dispose()
+    } finally {
+      await sessionB.stop()
     }
   })
 })

--- a/apps/simple-camera/__tests__/visioncamera.session.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.session.harness.ts
@@ -519,6 +519,272 @@ describe('VisionCamera - Session', () => {
     }
   })
 
+  it('switches a running session to a different camera device', async (context) => {
+    const backDevice = factory.getDefaultCamera('back')
+    expect(backDevice).toBeDefined()
+    if (backDevice == null) throw new Error('no back camera')
+    const frontDevice = factory.getDefaultCamera('front')
+    if (frontDevice == null) {
+      return context.skip('device switch: no front camera on this device')
+    }
+
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+
+    let sessionError: Error | undefined
+    const errorSub = session.addOnErrorListener((error) => {
+      sessionError = error
+    })
+
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    await session.start()
+
+    try {
+      // Reconfiguring to a different device removes the back camera input from
+      // the running session and adds the front camera input in a single
+      // configure call.
+      const controllers = await session.configure([
+        {
+          input: frontDevice,
+          outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+          constraints: [],
+        },
+      ])
+      expect(controllers).toHaveLength(1)
+      expect(controllers[0]?.device.position).toBe('front')
+
+      const photo = await photoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      expect(photo.width).toBeGreaterThan(0)
+      expect(photo.height).toBeGreaterThan(0)
+      photo.dispose()
+
+      expect(sessionError).toBe(undefined)
+    } finally {
+      errorSub.remove()
+      await session.stop()
+    }
+  })
+
+  it('removes multiple outputs from a running session in a single reconfigure', async () => {
+    const device = factory.getDefaultCamera('back')
+    expect(device).toBeDefined()
+    if (device == null) throw new Error('no back camera')
+
+    const session = await VisionCamera.createCameraSession(false)
+    const previewOutput = VisionCamera.createPreviewOutput()
+    const firstPhotoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const videoOutput = VisionCamera.createVideoOutput({
+      targetResolution: CommonResolutions.HD_16_9,
+      enableAudio: false,
+    })
+
+    let sessionError: Error | undefined
+    const errorSub = session.addOnErrorListener((error) => {
+      sessionError = error
+    })
+
+    await session.configure([
+      {
+        input: device,
+        outputs: [
+          { output: previewOutput, mirrorMode: 'auto' },
+          { output: firstPhotoOutput, mirrorMode: 'auto' },
+          { output: videoOutput, mirrorMode: 'auto' },
+        ],
+        constraints: [],
+      },
+    ])
+    await session.start()
+
+    try {
+      // Dropping the preview, photo and video outputs at once removes multiple
+      // outputs (and the preview connection) from the running session in a
+      // single configure call.
+      const secondPhotoOutput = VisionCamera.createPhotoOutput({
+        targetResolution: CommonResolutions.HD_4_3,
+        containerFormat: 'jpeg',
+        quality: 0.8,
+        qualityPrioritization: 'balanced',
+      })
+      await session.configure([
+        {
+          input: device,
+          outputs: [{ output: secondPhotoOutput, mirrorMode: 'auto' }],
+          constraints: [],
+        },
+      ])
+
+      const photo = await secondPhotoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      expect(photo.width).toBeGreaterThan(0)
+      expect(photo.height).toBeGreaterThan(0)
+      photo.dispose()
+
+      expect(sessionError).toBe(undefined)
+    } finally {
+      errorSub.remove()
+      await session.stop()
+    }
+  })
+
+  it('removes the camera and audio inputs in a single reconfigure while running', async (context) => {
+    const backDevice = factory.getDefaultCamera('back')
+    expect(backDevice).toBeDefined()
+    if (backDevice == null) throw new Error('no back camera')
+    const frontDevice = factory.getDefaultCamera('front')
+    if (frontDevice == null) {
+      return context.skip('input removal: no front camera on this device')
+    }
+    await VisionCamera.requestMicrophonePermission()
+    if (VisionCamera.microphonePermissionStatus !== 'authorized') {
+      return context.skip('input removal: no microphone permission')
+    }
+
+    const session = await VisionCamera.createCameraSession(false)
+    const videoOutput = VisionCamera.createVideoOutput({
+      targetResolution: CommonResolutions.HD_16_9,
+      enableAudio: true,
+    })
+
+    let sessionError: Error | undefined
+    const errorSub = session.addOnErrorListener((error) => {
+      sessionError = error
+    })
+
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: videoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    await session.start()
+
+    try {
+      // Switching to the front camera without audio removes both the back
+      // camera input and the microphone input in a single configure call.
+      const photoOutput = VisionCamera.createPhotoOutput({
+        targetResolution: CommonResolutions.HD_4_3,
+        containerFormat: 'jpeg',
+        quality: 0.8,
+        qualityPrioritization: 'balanced',
+      })
+      const controllers = await session.configure([
+        {
+          input: frontDevice,
+          outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+          constraints: [],
+        },
+      ])
+      expect(controllers).toHaveLength(1)
+      expect(controllers[0]?.device.position).toBe('front')
+
+      const photo = await photoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      expect(photo.width).toBeGreaterThan(0)
+      expect(photo.height).toBeGreaterThan(0)
+      photo.dispose()
+
+      expect(sessionError).toBe(undefined)
+    } finally {
+      errorSub.remove()
+      await session.stop()
+    }
+  })
+
+  it('tears down a running session with configure([]) and reconfigures it afterwards', async () => {
+    const device = factory.getDefaultCamera('back')
+    expect(device).toBeDefined()
+    if (device == null) throw new Error('no back camera')
+
+    const session = await VisionCamera.createCameraSession(false)
+    const previewOutput = VisionCamera.createPreviewOutput()
+    const firstPhotoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+
+    let sessionError: Error | undefined
+    const errorSub = session.addOnErrorListener((error) => {
+      sessionError = error
+    })
+
+    await session.configure([
+      {
+        input: device,
+        outputs: [
+          { output: previewOutput, mirrorMode: 'auto' },
+          { output: firstPhotoOutput, mirrorMode: 'auto' },
+        ],
+        constraints: [],
+      },
+    ])
+    await session.start()
+
+    try {
+      // This is the `useCameraSession` unmount path: a single configure([])
+      // on a running session that removes the input, all outputs and all
+      // connections at once.
+      const controllers = await session.configure([])
+      expect(controllers).toHaveLength(0)
+      expect(sessionError).toBe(undefined)
+
+      // The same session must be fully usable again afterwards.
+      const secondPhotoOutput = VisionCamera.createPhotoOutput({
+        targetResolution: CommonResolutions.HD_4_3,
+        containerFormat: 'jpeg',
+        quality: 0.8,
+        qualityPrioritization: 'balanced',
+      })
+      await session.configure([
+        {
+          input: device,
+          outputs: [{ output: secondPhotoOutput, mirrorMode: 'auto' }],
+          constraints: [],
+        },
+      ])
+      await session.start()
+
+      const photo = await secondPhotoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      expect(photo.width).toBeGreaterThan(0)
+      expect(photo.height).toBeGreaterThan(0)
+      photo.dispose()
+
+      expect(sessionError).toBe(undefined)
+    } finally {
+      errorSub.remove()
+      await session.stop()
+    }
+  })
+
   it('supports a multi-cam session when the platform allows it', async (context) => {
     if (!VisionCamera.supportsMultiCamSessions) {
       return context.skip('multi-cam session: not supported on this platform')

--- a/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
+++ b/packages/react-native-vision-camera-barcode-scanner/ios/HybridBarcodeScannerOutput.swift
@@ -19,6 +19,7 @@ final class HybridBarcodeScannerOutput: HybridCameraOutputSpec, NativeCameraOutp
   private var delegate: BarcodeScannerDelegate? = nil
   private let queue: DispatchQueue
   let output: AVCaptureVideoDataOutput
+  weak var attachedSession: AVCaptureSession?
   let requiresAudioInput: Bool = false
   let requiresDepthFormat: Bool = false
   let mediaType: MediaType = .video

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
@@ -228,26 +228,22 @@ final class HybridCameraSession: HybridCameraSessionSpec {
   private func updateInputs(_ targetConnections: [ResolvedCameraSessionConnection]) throws {
     let requiresAudioInput = targetConnections.contains { $0.requiresAudioInput }
 
-    // 1. Loop through all existing inputs in the session - if it's not in our `connections` array, we remove it
-    for currentlyAttachedInput in self.session.inputs {
+    // 1. Loop through all existing inputs in the session - if it's not in our `connections` array, we remove it.
+    //    Collect and remove in two separate steps so we never remove from the collection we are iterating over.
+    let inputsToRemove = self.session.inputs.filter { currentlyAttachedInput in
       if currentlyAttachedInput.isMicrophone {
-        // It's a microphone/audio input - let's check if we want audio in any connection.
-        if !requiresAudioInput {
-          // 1.1.a. We don't want any audio input - remove it!
-          logger.info("Removing audio input \(currentlyAttachedInput)...")
-          self.session.removeInput(currentlyAttachedInput)
-        }
+        // 1.1.a. It's a microphone/audio input - remove it if no connection wants audio.
+        return !requiresAudioInput
       } else {
-        // It's a normal camera device - let's check if we want it in connections.
-        let containsCurrentlyAttachedInput = targetConnections.contains { connection in
+        // 1.1.b. It's a normal camera device - remove it if it's not in `connections`.
+        return !targetConnections.contains { connection in
           return connection.isConnectedTo(input: currentlyAttachedInput)
         }
-        if !containsCurrentlyAttachedInput {
-          // 1.1.b. We don't want this input - remove it!
-          logger.info("Removing input \(currentlyAttachedInput)...")
-          self.session.removeInput(currentlyAttachedInput)
-        }
       }
+    }
+    for inputToRemove in inputsToRemove {
+      logger.info("Removing input \(inputToRemove)...")
+      self.session.removeInput(inputToRemove)
     }
     // 2. Loop through all connection inputs - if it's not yet attached to the session, add it
     for connection in targetConnections {
@@ -288,16 +284,16 @@ final class HybridCameraSession: HybridCameraSessionSpec {
    * This includes special handling for `NativePreviewViewOutput`.
    */
   private func updateOutputs(_ targetConnections: [ResolvedCameraSessionConnection]) throws {
-    // 1. Loop through all current CameraSession outputs - if it's not in our array, we remove it
-    for currentlyAttachedOutput in self.session.outputs {
-      let containsAttachedOutput = targetConnections.contains { connection in
+    // 1. Loop through all current CameraSession outputs - if it's not in our array, we remove it.
+    //    Collect and remove in two separate steps so we never remove from the collection we are iterating over.
+    let outputsToRemove = self.session.outputs.filter { currentlyAttachedOutput in
+      return !targetConnections.contains { connection in
         return connection.isConnectedTo(output: currentlyAttachedOutput)
       }
-      if !containsAttachedOutput {
-        // 1.1. We don't want this output - remove it!
-        logger.info("Removing output \(currentlyAttachedOutput)...")
-        self.session.removeOutput(currentlyAttachedOutput)
-      }
+    }
+    for outputToRemove in outputsToRemove {
+      logger.info("Removing output \(outputToRemove)...")
+      self.session.removeOutput(outputToRemove)
     }
     // 2. Loop through all connections
     for connection in targetConnections {
@@ -318,14 +314,14 @@ final class HybridCameraSession: HybridCameraSessionSpec {
     // or output is removed from the session, the connection will also automatically be removed.
     // So we only need to worry about removing preview layer connections.
 
-    // 1. Loop through all current CameraSession connections - if it's not in our array, we remove it
-    for currentConnection in self.session.connections {
-      let containsConnection = targetConnections.contains { $0.contains(connection: currentConnection) }
-      if !containsConnection {
-        // 1.1. We don't want this connection - remove it!
-        logger.info("Removing connection \(currentConnection)...")
-        self.session.removeConnection(currentConnection)
-      }
+    // 1. Loop through all current CameraSession connections - if it's not in our array, we remove it.
+    //    Collect and remove in two separate steps so we never remove from the collection we are iterating over.
+    let connectionsToRemove = self.session.connections.filter { currentConnection in
+      return !targetConnections.contains { $0.contains(connection: currentConnection) }
+    }
+    for connectionToRemove in connectionsToRemove {
+      logger.info("Removing connection \(connectionToRemove)...")
+      self.session.removeConnection(connectionToRemove)
     }
 
     // 2. Add all new connections that we don't have yet:

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
@@ -299,9 +299,15 @@ final class HybridCameraSession: HybridCameraSessionSpec {
     for connection in targetConnections {
       // 2.1. Loop through each output
       for output in connection.outputs {
+        if case .output(let nativeOutput) = output.output {
+          // 2.2. An `AVCaptureOutput` may still be attached to a previous session at the
+          //      CoreMedia level (attach/detach is asynchronous) - only allow attaching
+          //      it here if it isn't owned by a different, still-alive session (#3773).
+          try nativeOutput.prepareForAttaching(to: self.session)
+        }
         let containsOutput = self.session.containsOutput(output.output)
         if !containsOutput {
-          // 2.2. It doesn't exist yet - add it to the session..
+          // 2.3. It doesn't exist yet - add it to the session..
           try session.addOutputWithNoConnections(output.output)
         }
       }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraDepthFrameOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraDepthFrameOutput.swift
@@ -18,6 +18,7 @@ final class HybridCameraDepthFrameOutput: HybridCameraDepthFrameOutputSpec, Nati
   let requiresAudioInput: Bool = false
   let requiresDepthFormat: Bool = true
   let output: AVCaptureDepthDataOutput
+  weak var attachedSession: AVCaptureSession?
   lazy var thread: any HybridNativeThreadSpec = {
     return HybridNativeThread(queue: queue)
   }()

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraFrameOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraFrameOutput.swift
@@ -18,6 +18,7 @@ final class HybridCameraFrameOutput: HybridCameraFrameOutputSpec, NativeCameraOu
   let requiresAudioInput: Bool = false
   let requiresDepthFormat: Bool = false
   let output: AVCaptureVideoDataOutput
+  weak var attachedSession: AVCaptureSession?
   lazy var thread: any HybridNativeThreadSpec = {
     return HybridNativeThread(queue: queue)
   }()

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraObjectOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraObjectOutput.swift
@@ -14,6 +14,7 @@ final class HybridCameraObjectOutput: HybridCameraObjectOutputSpec, NativeCamera
   private let options: ObjectOutputOptions
   let mediaType: MediaType = .metadata
   let output: AVCaptureMetadataOutput
+  weak var attachedSession: AVCaptureSession?
   let requiresAudioInput: Bool = false
   let requiresDepthFormat: Bool = false
   var outputOrientation: CameraOrientation = .up {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
@@ -16,6 +16,7 @@ final class HybridCameraPhotoOutput: HybridCameraPhotoOutputSpec, NativeCameraOu
   // TODO: If depth data delivery is configured, we probably should return `true` here
   let requiresDepthFormat: Bool = false
   let output: AVCapturePhotoOutput
+  weak var attachedSession: AVCaptureSession?
 
   var supportsDepthDataDelivery: Bool {
     return output.isDepthDataDeliverySupported

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoFrameOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoFrameOutput.swift
@@ -18,6 +18,7 @@ final class HybridCameraVideoFrameOutput: HybridCameraVideoOutputSpec, NativeCam
   let requiresAudioInput: Bool = false
   let requiresDepthFormat: Bool = false
   let output: AVCaptureVideoDataOutput
+  weak var attachedSession: AVCaptureSession?
   private var recorders = WeakArray<HybridFrameRecorder>()
   private let fileType: RecorderFileType
 

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoOutput.swift
@@ -14,6 +14,7 @@ final class HybridCameraVideoOutput: HybridCameraVideoOutputSpec, NativeCameraOu
   private let fileType: RecorderFileType
   let mediaType: MediaType = .video
   let output: AVCaptureMovieFileOutput
+  weak var attachedSession: AVCaptureSession?
   var requiresAudioInput: Bool {
     return options.enableAudio == true
   }

--- a/packages/react-native-vision-camera/ios/Public/NativeCameraOutput.swift
+++ b/packages/react-native-vision-camera/ios/Public/NativeCameraOutput.swift
@@ -6,6 +6,7 @@
 
 import AVFoundation
 import Foundation
+import NitroModules
 
 // TODO: Try to figure out if we can get the Preview Output conform to the `NativeCameraOutput` protocol too somehow.
 //       We have a lot of conditional code that checks `NativeCameraOutput` first, `NativePreviewViewOutput` second.
@@ -33,6 +34,16 @@ public protocol NativeCameraOutput: AnyObject, ResolutionNegotiationParticipant 
    */
   var output: Output { get }
   /**
+   * The `AVCaptureSession` this output's `output` was last attached to.
+   *
+   * This is fully managed by `prepareForAttaching(to:)` - implementations only
+   * need to provide the stored property (`weak var attachedSession: AVCaptureSession?`).
+   * It is deliberately `weak`: once the previous session deallocates, its `deinit`
+   * has synchronously detached this output at the CoreMedia level, so a `nil`
+   * value proves the output is safe to attach to a new session.
+   */
+  var attachedSession: AVCaptureSession? { get set }
+  /**
    * Whether this `NativeCameraOutput` requires
    * an audio input attached to its `AVCaptureOutput`.
    *
@@ -56,4 +67,32 @@ public protocol NativeCameraOutput: AnyObject, ResolutionNegotiationParticipant 
    * such as orientation or mirroring settings in here.
    */
   func configure(config: OutputConfiguration)
+}
+
+extension NativeCameraOutput {
+  /**
+   * Ensures this output's `output` can safely be attached to the given [session].
+   *
+   * An `AVCaptureOutput` is attached to/detached from the underlying `FigCaptureSession`
+   * asynchronously (via CoreMedia commit notifications), so after being removed from a
+   * previous `AVCaptureSession` it may still be attached at the CoreMedia level - adding
+   * it to a second `AVCaptureSession` in that state crashes with an
+   * `attachToFigCaptureSession:` assertion failure (SIGABRT).
+   * See https://github.com/mrousavy/react-native-vision-camera/issues/3773
+   *
+   * The only point where the detach is *guaranteed* to have happened is the previous
+   * session's `deinit`, which detaches synchronously. So re-attaching to the same
+   * session is always allowed, and attaching to a new session is only allowed once the
+   * previous session has been deallocated (`attachedSession` is `weak` and reads `nil`).
+   */
+  func prepareForAttaching(to session: AVCaptureSession) throws {
+    if let previousSession = attachedSession, previousSession !== session {
+      throw RuntimeError.error(
+        withMessage:
+          "\(type(of: self)) is still attached to a different CameraSession! "
+          + "An output can only be re-used in a new CameraSession after the previous CameraSession "
+          + "has been released - call `dispose()` on the previous CameraSession first.")
+    }
+    self.attachedSession = session
+  }
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraSession.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraSession.ts
@@ -31,9 +31,18 @@ export function useCameraSession({
   // session teardown
   useEffect(() => {
     return () => {
-      // remove all connections
-      session?.stop()
-      session?.configure([])
+      if (session == null) return
+      // stop the session and remove all connections.
+      // failures during teardown are not actionable, so ignore them.
+      session.stop().catch(() => {})
+      session.configure([]).catch(() => {})
+      // ...then release the native session deterministically instead of waiting
+      // for GC. The native session's destructor is what fully detaches outputs
+      // at the CoreMedia level - a re-mounted <Camera> re-uses output objects in
+      // a new session, and attaching them while they are still attached to this
+      // session crashes (see #3773). All three calls run in order on the native
+      // session queue; the native object stays alive until they completed.
+      session.dispose()
     }
   }, [session])
 


### PR DESCRIPTION
Two fixes for `CameraSession` reconfigure/teardown crashes:

1. Reworks `updateInputs`/`updateOutputs`/`updateConnections` to collect-then-remove in two separate steps instead of removing from `session.inputs`/`outputs`/`connections` while enumerating them.
2. Fixes the #3773/#3730/#4026 SIGABRT family: an `AVCaptureOutput` is attached/detached to the underlying `FigCaptureSession` asynchronously, so an output removed from one session (e.g. hook-owned outputs surviving a `<Camera>` re-mount) can still be attached at the CoreMedia level - adding it to a second session then crashes in `attachToFigCaptureSession:`. The only point where the detach is guaranteed is the previous session's `deinit`, which detaches synchronously. `useCameraSession` now `dispose()`s the session on unmount (deterministic, ordered on the session queue before any re-mount work), and outputs track their session via a `weak` reference so `configure()` fails with a clear error if an output is moved to a new session while the previous one is still alive - instead of racing CoreMedia. Inner `AVCaptureOutput` instances stay stable for the output's whole lifetime.

Adds Harness tests for the previously uncovered removal paths (device switch while running, multi-output removal in one reconfigure, camera + microphone input removal in one pass, `configure([])` teardown + reconfigure), a regression test re-using the same outputs across 9 re-created sessions (#3773), and a deterministic test of the new output re-use guard.

Note: a deterministic crash repro for the Fig race is not possible from JS - the attach/detach ordering inversion happens inside mediaserverd's per-session queues (verified by disassembly), which is also why the guard exists: the safe re-use point is only provable at session deinit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)