### PR TITLE
fix: Apply `adaptiveness` metering modes before resolving `focusTo(…)`

### DIFF
--- a/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
+++ b/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
@@ -157,16 +157,17 @@ final class MeteringTask {
       logger.info(
         "All metering operations have been settled for at least \(self.minStableFocusDurationUntilResolve) seconds - completed!"
       )
-      onComplete?()
       isFinished = true
       destroy()
-      // After completion, update AE/AF/AWB to locked or continuous tracking
+      // Update AE/AF/AWB to locked or continuous tracking *before* resolving,
+      // so callers observe the final modes as soon as the Promise resolves.
       switch adaptiveness {
       case .continuous:
         try? setMeteringValuesToContinuous()
       case .locked:
         try? setMeteringValuesToLocked()
       }
+      onComplete?()
       // Start the timer for auto reset (if enabled)
       if case .after(let seconds) = self.autoReset {
         self.queue.asyncAfter(deadline: .now() + seconds) { [weak self] in


### PR DESCRIPTION
Fixes the Harness iOS failure on `main` introduced with the test from #4078 (`locks metering modes after focusTo with locked adaptiveness`, `expected 'continuous-auto-white-balance' to be 'locked'`).

**Root cause:** In `MeteringTask.update()`, once all metering states settled, `onComplete?()` resolved the JS Promise *before* `setMeteringValuesToLocked()`/`...Continuous()` applied the final modes. The JS continuation's synchronous `controller.whiteBalanceMode` read raced ahead of the camera queue's `lockForConfiguration()` + mode set and still saw `continuous-auto-white-balance`. The AF/AE asserts masked this because snappy metering uses one-shot `.autoFocus`/`.autoExpose`, which AVFoundation auto-transitions to `.locked` on settle - AWB running in continuous mode only becomes `locked` through the explicit (late) set. This failed identically on #4078's own CI run, so it lost the race deterministically on the CI iPhone.

**Fix:** Reorder the completion sequence: mark `isFinished`, tear down KVO observers/timers, apply the `adaptiveness` modes, *then* resolve the Promise. `isFinished` is set first so `destroy()` doesn't fire `onError` and queued KVO callbacks bail out; observers are invalidated before the mode mutation so setting `.locked` can't re-enter the settle tracking.

Android needs no change - it bakes the locking mode into the CameraX `FocusMeteringAction` via `setLockingMode(...)` before starting, so the lock is already part of the action when its Promise resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)