### PR TITLE
feat: add targetResolution prop to skia camera

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.skia-camera.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.skia-camera.harness.tsx
@@ -1,0 +1,192 @@
+import { StyleSheet } from 'react-native'
+import {
+  afterEach,
+  beforeAll,
+  cleanup,
+  describe,
+  expect,
+  it,
+  render,
+} from 'react-native-harness'
+import type { CameraDevice, Size } from 'react-native-vision-camera'
+import { CommonResolutions, VisionCamera } from 'react-native-vision-camera'
+import { SkiaCamera } from 'react-native-vision-camera-skia'
+import { provider as workletsProvider } from 'react-native-vision-camera-worklets'
+import { scheduleOnRN } from 'react-native-worklets'
+import { deferred, withTimeout } from './test-utils'
+
+interface Edges {
+  short: number
+  long: number
+}
+
+function getEdges(size: Size): Edges {
+  return {
+    short: Math.min(size.width, size.height),
+    long: Math.max(size.width, size.height),
+  }
+}
+
+function supportsResolution(device: CameraDevice, size: Size): boolean {
+  const target = getEdges(size)
+  return device.getSupportedResolutions('video').some((resolution) => {
+    const edges = getEdges(resolution)
+    return edges.short === target.short && edges.long === target.long
+  })
+}
+
+/**
+ * Renders a `<SkiaCamera />` with the given `targetResolution` and resolves
+ * with the dimensions of the first Frame it actually streams.
+ */
+async function streamFrameSize(
+  device: CameraDevice,
+  targetResolution: Size | undefined,
+): Promise<Size> {
+  const received = deferred<Size>()
+  const report = (width: number, height: number) => {
+    if (width > 0 && height > 0) received.resolve({ width, height })
+  }
+
+  await render(
+    <SkiaCamera
+      device={device}
+      isActive={true}
+      style={StyleSheet.absoluteFill}
+      targetResolution={targetResolution}
+      onError={received.reject}
+      onFrame={(frame, renderFrame) => {
+        'worklet'
+        scheduleOnRN(report, frame.width, frame.height)
+        renderFrame(({ frameTexture, canvas }) => {
+          'worklet'
+          canvas.drawImage(frameTexture, 0, 0)
+        })
+        frame.dispose()
+      }}
+    />,
+  )
+
+  try {
+    return await withTimeout(
+      received.promise,
+      15_000,
+      `SkiaCamera Frame at ${targetResolution?.width}x${targetResolution?.height}`,
+    )
+  } finally {
+    cleanup()
+  }
+}
+
+/**
+ * Configures a bare `CameraFrameOutput` (the same primitive `<Camera />` uses)
+ * with the given `targetResolution` and resolves with its negotiated resolution.
+ */
+async function nativeFrameOutputSize(
+  device: CameraDevice,
+  targetResolution: Size,
+): Promise<Size> {
+  const session = await VisionCamera.createCameraSession(false)
+  const frameOutput = VisionCamera.createFrameOutput({
+    targetResolution,
+    pixelFormat: 'yuv',
+    dropFramesWhileBusy: true,
+    allowDeferredStart: false,
+    enablePhysicalBufferRotation: false,
+    enableCameraMatrixDelivery: false,
+    enablePreviewSizedOutputBuffers: false,
+  })
+  await session.configure([
+    {
+      input: device,
+      outputs: [{ output: frameOutput, mirrorMode: 'auto' }],
+      constraints: [{ resolutionBias: frameOutput }],
+    },
+  ])
+
+  const received = deferred<Size>()
+  const report = (width: number, height: number) => {
+    if (width > 0 && height > 0) received.resolve({ width, height })
+  }
+  const errorSub = session.addOnErrorListener(received.reject)
+
+  const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
+  runtime.setOnFrameCallback(frameOutput, (frame) => {
+    'worklet'
+    scheduleOnRN(report, frame.width, frame.height)
+    frame.dispose()
+  })
+
+  await session.start()
+  try {
+    return await withTimeout(
+      received.promise,
+      15_000,
+      `CameraFrameOutput Frame at ${targetResolution.width}x${targetResolution.height}`,
+    )
+  } finally {
+    runtime.setOnFrameCallback(frameOutput, undefined)
+    errorSub.remove()
+    await session.stop()
+  }
+}
+
+describe('VisionCamera - SkiaCamera targetResolution', () => {
+  let backDevice: CameraDevice
+
+  beforeAll(async () => {
+    await VisionCamera.requestCameraPermission()
+    expect(VisionCamera.cameraPermissionStatus).toBe('authorized')
+    const factory = await VisionCamera.createDeviceFactory()
+    const back = factory.getDefaultCamera('back')
+    if (back == null) throw new Error('no back camera')
+    backDevice = back
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('streams Frames at the requested targetResolution', async (context) => {
+    const targetResolution = CommonResolutions.FHD_4_3
+    if (!supportsResolution(backDevice, targetResolution)) {
+      return context.skip('FHD 4:3 video resolution not supported on this device')
+    }
+
+    const streamed = await streamFrameSize(backDevice, targetResolution)
+
+    console.log(
+      `SkiaCamera requested=${targetResolution.width}x${targetResolution.height} streamed=${streamed.width}x${streamed.height}`,
+    )
+    expect(getEdges(streamed)).toEqual(getEdges(targetResolution))
+  })
+
+  it('falls back to the useFrameOutput default when targetResolution is omitted', async (context) => {
+    const defaultResolution = CommonResolutions.HD_16_9
+    if (!supportsResolution(backDevice, defaultResolution)) {
+      return context.skip('HD 16:9 video resolution not supported on this device')
+    }
+
+    const streamed = await streamFrameSize(backDevice, undefined)
+
+    console.log(
+      `SkiaCamera (no targetResolution) streamed=${streamed.width}x${streamed.height}`,
+    )
+    expect(getEdges(streamed)).toEqual(getEdges(defaultResolution))
+  })
+
+  it('negotiates the same resolution as a bare CameraFrameOutput', async (context) => {
+    const targetResolution = CommonResolutions.FHD_4_3
+    if (!supportsResolution(backDevice, targetResolution)) {
+      return context.skip('FHD 4:3 video resolution not supported on this device')
+    }
+
+    const skia = await streamFrameSize(backDevice, targetResolution)
+    const native = await nativeFrameOutputSize(backDevice, targetResolution)
+
+    console.log(
+      `parity requested=${targetResolution.width}x${targetResolution.height} skia=${skia.width}x${skia.height} native=${native.width}x${native.height}`,
+    )
+    expect(getEdges(skia)).toEqual(getEdges(native))
+  })
+})

--- a/apps/simple-camera/__tests__/visioncamera.skia-camera.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.skia-camera.harness.tsx
@@ -150,7 +150,9 @@ describe('VisionCamera - SkiaCamera targetResolution', () => {
   it('streams Frames at the requested targetResolution', async (context) => {
     const targetResolution = CommonResolutions.FHD_4_3
     if (!supportsResolution(backDevice, targetResolution)) {
-      return context.skip('FHD 4:3 video resolution not supported on this device')
+      return context.skip(
+        'FHD 4:3 video resolution not supported on this device',
+      )
     }
 
     const streamed = await streamFrameSize(backDevice, targetResolution)
@@ -164,7 +166,9 @@ describe('VisionCamera - SkiaCamera targetResolution', () => {
   it('falls back to the useFrameOutput default when targetResolution is omitted', async (context) => {
     const defaultResolution = CommonResolutions.HD_16_9
     if (!supportsResolution(backDevice, defaultResolution)) {
-      return context.skip('HD 16:9 video resolution not supported on this device')
+      return context.skip(
+        'HD 16:9 video resolution not supported on this device',
+      )
     }
 
     const streamed = await streamFrameSize(backDevice, undefined)
@@ -178,7 +182,9 @@ describe('VisionCamera - SkiaCamera targetResolution', () => {
   it('negotiates the same resolution as a bare CameraFrameOutput', async (context) => {
     const targetResolution = CommonResolutions.FHD_4_3
     if (!supportsResolution(backDevice, targetResolution)) {
-      return context.skip('FHD 4:3 video resolution not supported on this device')
+      return context.skip(
+        'FHD 4:3 video resolution not supported on this device',
+      )
     }
 
     const skia = await streamFrameSize(backDevice, targetResolution)

--- a/packages/react-native-vision-camera-skia/src/views/SkiaCamera.tsx
+++ b/packages/react-native-vision-camera-skia/src/views/SkiaCamera.tsx
@@ -28,6 +28,7 @@ import {
   type PixelFormat,
   type Point,
   type ResolutionBiasConstraint,
+  type Size,
   type TargetVideoPixelFormat,
   useCamera,
   useFrameOutput,
@@ -195,6 +196,23 @@ export interface SkiaCameraProps
    * @default false
    */
   enablePreviewSizedOutputBuffers?: boolean
+  /**
+   * The target Frame Resolution to use.
+   *
+   * @discussion
+   * The {@linkcode CameraSession} will negotiate all
+   * output {@linkcode targetResolution}s and constraints (such
+   * as HDR, FPS, etc) in a {@linkcode CameraSessionConfig} to
+   * finalize the Resolution used for the Output.
+   * This is therefore merely a resolution _target_, and may
+   * not be exactly met.
+   *
+   * If the given {@linkcode targetResolution} cannot be met
+   * exactly, its aspect ratio (computed by
+   * {@linkcode Size.width} / {@linkcode Size.height}) will
+   * be prioritized over pixel count.
+   */
+  targetResolution?: Size
 }
 
 const DEFAULT_PIXEL_FORMAT = Platform.select<TargetVideoPixelFormat>({
@@ -210,6 +228,7 @@ function SkiaCameraImpl({
   pixelFormat = DEFAULT_PIXEL_FORMAT,
   enablePhysicalBufferRotation,
   enablePreviewSizedOutputBuffers,
+  targetResolution,
   device,
   orientationSource,
   warnIfRenderSkipped = true,
@@ -253,6 +272,7 @@ function SkiaCameraImpl({
     allowDeferredStart: false,
     enablePhysicalBufferRotation: enablePhysicalBufferRotation,
     enablePreviewSizedOutputBuffers: enablePreviewSizedOutputBuffers,
+    targetResolution: targetResolution,
     onFrame: (frame) => {
       'worklet'
       let renderCount = 0


### PR DESCRIPTION
This PR adds the `targetResolution` prop to `<SkiaCamera />`



## How this was tested

Ran the new Harness test on a physical iPhone 16 (iOS 26.5):

✓ streams Frames at the requested targetResolution 
✓ falls back to the useFrameOutput default when targetResolution is omitted 
✓ negotiates the same resolution as a bare CameraFrameOutput 

from logs:

SkiaCamera requested=1440x1920 streamed=1920x1440
SkiaCamera (no targetResolution) streamed=1280x720
parity requested=1440x1920 skia=1920x1440 native=1920x1440

- Passing `targetResolution` drives the negotiated Frame resolution.
- Omitting it still resolves to the `useFrameOutput` default (`HD_16_9`), so this is non-breaking.
- A `<SkiaCamera />` and a bare `CameraFrameOutput` given the same target negotiate the **same** resolution, confirming the prop reaches the same negotiation path rather than being dropped or altered.

Resolutions are compared on short/long edges, since negotiation compares aspect ratio orientation-independently (`1440x1920` is legitimately satisfied by `1920x1440`).

Not yet run on Android.