### PR TITLE
fix: Simplify microphone detection + adding

### DIFF
--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureInput+isMicrophone.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureInput+isMicrophone.swift
@@ -13,10 +13,6 @@ extension AVCaptureInput {
     guard let self = self as? AVCaptureDeviceInput else {
       return false
     }
-    if #available(iOS 17.0, *) {
-      return self.device.deviceType == .microphone
-    } else {
-      return self.device.deviceType == .builtInMicrophone
-    }
+    return self.device.hasMediaType(.audio)
   }
 }

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureSession+addAudioInput.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureSession+addAudioInput.swift
@@ -10,7 +10,9 @@ import NitroModules
 
 extension AVCaptureSession {
   func addAudioInput() throws {
-    let microphone = try getDefaultMicrophone()
+    guard let microphone = AVCaptureDevice.default(for: .audio) else {
+      throw RuntimeError.error(withMessage: "This device does not have a microphone!")
+    }
     let input = try AVCaptureDeviceInput(device: microphone)
     logger.info("Adding microphone \(input)...")
     self.addInputWithNoConnections(input)
@@ -33,23 +35,5 @@ extension AVCaptureSession {
         withMessage: "Audio Connection \"\(connection)\" cannot be added to Camera Session!")
     }
     self.addConnection(connection)
-  }
-
-  private func getDefaultMicrophone() throws -> AVCaptureDevice {
-    // TODO: Make microphone input selectable from JS
-    if #available(iOS 18.0, *) {
-      if let microphone = AVCaptureDevice.default(.microphone, for: .audio, position: .unspecified) {
-        return microphone
-      }
-    }
-    if let microphone = AVCaptureDevice.default(
-      .builtInMicrophone, for: .audio, position: .unspecified)
-    {
-      return microphone
-    }
-    if let microphone = AVCaptureDevice.default(for: .audio) {
-      return microphone
-    }
-    throw RuntimeError.error(withMessage: "This device does not have a microphone!")
   }
 }


### PR DESCRIPTION
Simplify the microphone detection and removal code.

Previously we checked against `deviceType` being `.microphone` or `.builtInMicrophone`, which under a specific Swift compiler bug was inlined, and on iOS 16 accidentally resolved to a `nil` value at runtime causing a crash.

This was reported in the Swift repo (https://github.com/swiftlang/swift/issues/90916) and a PR has already been created to fix this (https://github.com/swiftlang/swift/pull/90945) - but that will take a while before it lands in an Xcode release.

- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/4091