### PR TITLE
fix: Catch routine CameraX cancellation rejections in internal updater hooks

### DIFF
--- a/packages/react-native-vision-camera/src/hooks/internal/ignoreCameraCancellation.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/ignoreCameraCancellation.ts
@@ -1,0 +1,25 @@
+/**
+ * Ignores routine cancellation rejections from a fire-and-forget
+ * {@linkcode CameraController} call (e.g. `setZoom(..)`, `setTorchMode(..)`).
+ *
+ * On Android, CameraX rejects a pending camera control operation with an
+ * `OperationCanceledException` when a newer value supersedes an in-flight one
+ * ("Cancelled due to another zoom value being set") or when the camera is not
+ * currently active ("Camera is not active"). Those are expected lifecycle
+ * events, not errors — but when a hook fires the call without awaiting it,
+ * the rejection surfaces as an unhandled promise rejection in the app.
+ *
+ * Any non-cancellation error is re-thrown so it keeps its previous
+ * unhandled-rejection visibility instead of being silently swallowed.
+ */
+export function ignoreCameraCancellation(promise: Promise<void>): void {
+  promise.catch((error: unknown) => {
+    const message = String((error as Error | undefined)?.message ?? error)
+    const isRoutineCancellation =
+      message.includes('OperationCanceled') ||
+      message.includes('Camera is not active') ||
+      message.includes('Cancelled due to another')
+    if (isRoutineCancellation) return
+    throw error
+  })
+}

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraControllerConfiguration.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraControllerConfiguration.ts
@@ -3,6 +3,7 @@ import type {
   CameraController,
   CameraControllerConfiguration,
 } from '../../specs/CameraController.nitro'
+import { ignoreCameraCancellation } from './ignoreCameraCancellation'
 
 export function useCameraControllerConfiguration(
   controller: CameraController | undefined,
@@ -30,6 +31,6 @@ export function useCameraControllerConfiguration(
     const load = async () => {
       await controller.configure(memoizedConfig)
     }
-    load()
+    ignoreCameraCancellation(load())
   }, [memoizedConfig, controller])
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useExposureUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useExposureUpdater.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import type { SharedValue } from 'react-native-reanimated'
 import type { CameraController } from '../../specs/CameraController.nitro'
 import { VisionCameraWorkletsProxy } from '../../third-party/VisionCameraWorkletsProxy'
+import { ignoreCameraCancellation } from './ignoreCameraCancellation'
 
 export function useExposureUpdater(
   controller: CameraController | undefined,
@@ -13,11 +14,11 @@ export function useExposureUpdater(
 
     if (typeof exposure === 'number') {
       // number
-      controller.setExposureBias(exposure)
+      ignoreCameraCancellation(controller.setExposureBias(exposure))
       return
     } else {
       // SharedValue<number>
-      controller.setExposureBias(exposure.get())
+      ignoreCameraCancellation(controller.setExposureBias(exposure.get()))
       const listener = VisionCameraWorkletsProxy.bindUIUpdatesToController(
         exposure,
         controller,

--- a/packages/react-native-vision-camera/src/hooks/internal/useTorchModeUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useTorchModeUpdater.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import type { CameraController } from '../../specs/CameraController.nitro'
 import type { TorchMode } from '../../specs/common-types/TorchMode'
+import { ignoreCameraCancellation } from './ignoreCameraCancellation'
 
 export function useTorchModeUpdater(
   controller: CameraController | undefined,
@@ -10,6 +11,6 @@ export function useTorchModeUpdater(
     if (controller == null) return
     if (torchMode == null) return
 
-    controller.setTorchMode(torchMode)
+    ignoreCameraCancellation(controller.setTorchMode(torchMode))
   }, [controller, torchMode])
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useZoomUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useZoomUpdater.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import type { SharedValue } from 'react-native-reanimated'
 import type { CameraController } from '../../specs/CameraController.nitro'
 import { VisionCameraWorkletsProxy } from '../../third-party/VisionCameraWorkletsProxy'
+import { ignoreCameraCancellation } from './ignoreCameraCancellation'
 
 export function useZoomUpdater(
   controller: CameraController | undefined,
@@ -13,11 +14,11 @@ export function useZoomUpdater(
 
     if (typeof zoom === 'number') {
       // number
-      controller.setZoom(zoom)
+      ignoreCameraCancellation(controller.setZoom(zoom))
       return
     } else {
       // SharedValue<number>
-      controller.setZoom(zoom.get())
+      ignoreCameraCancellation(controller.setZoom(zoom.get()))
       const listener = VisionCameraWorkletsProxy.bindUIUpdatesToController(
         zoom,
         controller,


### PR DESCRIPTION
## What

The internal prop-sync hooks fire `CameraController` calls without awaiting or catching them:

- `useZoomUpdater` → `controller.setZoom(..)`
- `useTorchModeUpdater` → `controller.setTorchMode(..)`
- `useExposureUpdater` → `controller.setExposureBias(..)`
- `useCameraControllerConfiguration` → uncaught `load()` around `controller.configure(..)`

On Android, CameraX rejects a pending control operation with `OperationCanceledException` when a newer value supersedes an in-flight one ("Cancelled due to another zoom value being set") or when the camera is not currently active ("Camera is not active"). Because the hooks fire-and-forget, every such routine cancellation surfaces as an **unhandled promise rejection** in the app — which error reporters (Sentry etc.) capture as an error flood.

This PR adds a small shared helper, `ignoreCameraCancellation(promise)`, and routes all four call sites through it. Routine cancellations are swallowed; **any other error is re-thrown inside the catch**, so non-cancellation failures keep exactly their previous unhandled-rejection visibility — nothing new gets silently hidden.

## Why #3901 doesn't fully cover this

#3909 was closed pointing to #3901 (awaitable `start()`/`stop()`, merged pre-5.1.0). That fix helps the session lifecycle, but the JS hooks still fire the controller calls unawaited, and "Camera is not active" / supersede cancellations still legitimately occur (e.g. a `torch` prop write while the session isn't running yet, or rapid pinch-zoom superseding in-flight zoom values).

Production evidence on 5.1.0 (which includes #3901): in our app (React Native 0.83, new architecture, Android 15 devices incl. Samsung S23 and Lenovo TB352XU) we see continuous Sentry unhandled-rejection events from both `ZoomControl.applyZoomState` ("Cancelled due to another zoom value being set" / "Camera is not active") and `TorchControl.setTorchAsync` ("Camera is not active" — we only ever set `torch="off"`). The `lib/hooks/internal` code in 5.1.1 is unchanged, so the leak persists on latest.

Closes #3907 (torch variant of #3909).

## Notes

- The worklet-side path (`VisionCameraWorkletsProxy.bindUIUpdatesToController`) is untouched — this PR only covers the JS effect call sites.
- Message-string matching is limited to the Android CameraX cancellation texts; iOS rejections don't match and keep their current behavior.
- We've been running the zoom+torch variant of this change as a `pnpm patch` in production and it eliminates the rejection flood without masking real errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01846JqK8mH4c3BrQyksjwbz