### PR TITLE
Remove Harness test logs

### DIFF
--- a/apps/simple-camera/__tests__/README.md
+++ b/apps/simple-camera/__tests__/README.md
@@ -154,7 +154,7 @@ Tests should read like a small executable spec for one behavior. A few patterns 
 - **Use matcher assertions instead of boolean arithmetic.** Prefer `toBeCloseTo`, `toHaveLength`, `toContain`, `toEqual`, and `rejects.toThrow` over manually computing booleans inline and asserting on those - this makes it easier to read tests, especially when they fail in CI outputs. This is especially important for Harness/Vitest logs from AWS Device Farm: rich matchers preserve the received and expected values, while aggregate checks such as max/min deltas usually only show the derived number.
 - **Loop over repeated dimensions or cases.** For edges, axes, formats, or corner points, a tiny inline array plus one expectation is clearer than four copy-pasted assertions that can drift.
 - **Keep local math behind local names.** Small functions inside an `it` block are fine when they name a one-off transform or assertion, such as `getBounds(...)`. Do not put arithmetic, boolean expressions, `map(...)`, or other transformations directly inside `expect(...)`; assign them to descriptive local names first. Do not collapse multiple facts into one computed assertion like `expect(a + b).toBeGreaterThan(0)` — assert `a` and `b` separately so CI failures identify the broken value. Do not extract shared setup helpers; the camera session still needs to be built inline.
-- **Log the facts needed to debug a CI failure.** One final `console.log` with orientation, resolution, or compared values is useful. Per-frame or per-step logs usually make Harness output harder to read.
+- **Keep Harness output quiet.** Do not add `console.log` calls to tests. Use focused matcher assertions so failures report the relevant received and expected values.
 
 ## Running the tests
 

--- a/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
@@ -56,7 +56,6 @@ describe('VisionCamera - Constraints', () => {
     const config = received
     if (config == null) throw new Error('no config')
     expect(backDevice.supportedPixelFormats).toContain(config.nativePixelFormat)
-    console.log(`baseline config: ${config.toString()}`)
     await session.stop()
   })
 
@@ -215,10 +214,6 @@ describe('VisionCamera - Constraints', () => {
       withPreview.resolution.width,
       withPreview.resolution.height,
     )
-    console.log(
-      `4k@60 video-only=${videoOnly.resolution.width}x${videoOnly.resolution.height}@${videoOnly.selectedFPS ?? 'default'}fps ` +
-        `with-preview=${withPreview.resolution.width}x${withPreview.resolution.height}@${withPreview.selectedFPS ?? 'default'}fps`,
-    )
 
     expect(withPreview.selectedFPS).toBe(60)
     expect(previewShortEdge).toBe(targetShortEdge)
@@ -318,10 +313,6 @@ describe('VisionCamera - Constraints', () => {
 
     const withPreview = await resolveLowTargetSession(true)
     const previewEdges = getEdges(withPreview)
-    console.log(
-      `720p target video-only=${videoOnly.width}x${videoOnly.height} ` +
-        `with-preview=${withPreview.width}x${withPreview.height}`,
-    )
 
     expect(previewEdges.short).toBeLessThanOrEqual(maxAllowedEdges.short)
     expect(previewEdges.long).toBeLessThanOrEqual(maxAllowedEdges.long)
@@ -422,10 +413,6 @@ describe('VisionCamera - Constraints', () => {
 
     const withPreview = await resolveExplicitBiasSession(true)
     const withPreviewEdges = getEdges(withPreview.resolution)
-    console.log(
-      `1080p@30 explicit bias video-only=${videoOnly.resolution.width}x${videoOnly.resolution.height} ` +
-        `with-preview=${withPreview.resolution.width}x${withPreview.resolution.height}`,
-    )
 
     expect(withPreview.selectedFPS).toBe(30)
     expect(withPreviewEdges.short).toBe(targetEdges.short)
@@ -487,10 +474,6 @@ describe('VisionCamera - Constraints', () => {
     const withPreview = await resolvePhotoSession(true)
     const photoOnlyEdges = getEdges(photoOnly)
     const withPreviewEdges = getEdges(withPreview)
-    console.log(
-      `photo target photo-only=${photoOnly.width}x${photoOnly.height} ` +
-        `with-preview=${withPreview.width}x${withPreview.height}`,
-    )
 
     expect(withPreviewEdges.short).toBe(photoOnlyEdges.short)
     expect(withPreviewEdges.long).toBe(photoOnlyEdges.long)
@@ -684,47 +667,11 @@ describe('VisionCamera - Constraints', () => {
     await session.stop()
   })
 
-  it('applies constraint priority ordering for resolutionBias', async () => {
-    const photoOutput = VisionCamera.createPhotoOutput({
-      targetResolution: CommonResolutions.HIGHEST_4_3,
-      containerFormat: 'jpeg',
-      quality: 0.8,
-      qualityPrioritization: 'balanced',
-    })
-    const videoOutput = VisionCamera.createVideoOutput({
-      targetResolution: CommonResolutions.VGA_16_9,
-      enableAudio: false,
-    })
-
-    const photoFirst = await VisionCamera.resolveConstraints(
-      backDevice,
-      [
-        { output: photoOutput, mirrorMode: 'auto' },
-        { output: videoOutput, mirrorMode: 'auto' },
-      ],
-      [{ resolutionBias: photoOutput }, { resolutionBias: videoOutput }],
-    )
-    const videoFirst = await VisionCamera.resolveConstraints(
-      backDevice,
-      [
-        { output: photoOutput, mirrorMode: 'auto' },
-        { output: videoOutput, mirrorMode: 'auto' },
-      ],
-      [{ resolutionBias: videoOutput }, { resolutionBias: photoOutput }],
-    )
-    console.log(
-      `resolutionBias photo-first: nativePixelFormat=${photoFirst.nativePixelFormat} binned=${photoFirst.isBinned}`,
-    )
-    console.log(
-      `resolutionBias video-first: nativePixelFormat=${videoFirst.nativePixelFormat} binned=${videoFirst.isBinned}`,
-    )
-  })
-
   // Verifies the resolver's priority mechanism by running the same pair of
   // constraints in both orderings and asserting that the first-listed (= highest
   // priority) one wins in each direction. The lower-priority constraint may or
   // may not survive depending on device combination support — that's a hardware
-  // capability question, not a priority-ordering question, so we only log it.
+  // capability question, not a priority-ordering question, so it is not asserted.
   //
   // This catches regressions like "resolver always drops the first constraint
   // instead of the last" or "priority order is silently reversed", without
@@ -767,10 +714,6 @@ describe('VisionCamera - Constraints', () => {
     expect(stabFirst.selectedVideoStabilizationMode).toBe(
       chosenStabilizationMode,
     )
-    console.log(
-      `priority [stab, HDR]: stab=${stabFirst.selectedVideoStabilizationMode} ` +
-        `hdr=${stabFirst.selectedVideoDynamicRange?.bitDepth}`,
-    )
 
     // [HDR, stab] — HDR has higher priority and must be honored. Stabilization
     // may legitimately fall back to off/auto if the device can't combine them.
@@ -783,10 +726,6 @@ describe('VisionCamera - Constraints', () => {
       ],
     )
     expect(hdrFirst.selectedVideoDynamicRange?.bitDepth).toBe('hdr-10-bit')
-    console.log(
-      `priority [HDR, stab]: stab=${hdrFirst.selectedVideoStabilizationMode} ` +
-        `hdr=${hdrFirst.selectedVideoDynamicRange?.bitDepth}`,
-    )
   })
 
   it('reconfigures the running session with a different constraint set', async (context) => {

--- a/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.controller.harness.ts
@@ -619,11 +619,6 @@ describe('VisionCamera - Controller', () => {
       expect(controller.minZoom).toBeLessThanOrEqual(controller.maxZoom)
       expect(controller.zoom).toBeGreaterThanOrEqual(controller.minZoom)
       expect(controller.zoom).toBeLessThanOrEqual(controller.maxZoom)
-      console.log(
-        `controller: zoom=${controller.zoom} displayable=${controller.displayableZoomFactor} ` +
-          `focusMode=${controller.focusMode} exposureMode=${controller.exposureMode} wbMode=${controller.whiteBalanceMode} ` +
-          `isConnected=${controller.isConnected}`,
-      )
     } finally {
       await session.stop()
     }

--- a/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
@@ -123,9 +123,6 @@ describe('VisionCamera - Coordinates', () => {
         expect(roundTripped.x).toBeCloseTo(input.x, 0)
         expect(roundTripped.y).toBeCloseTo(input.y, 0)
       }
-      console.log(
-        `frame ${r.width}x${r.height} round-trip points: ${JSON.stringify(r.points)}`,
-      )
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       errorSub.remove()
@@ -191,9 +188,6 @@ describe('VisionCamera - Coordinates', () => {
         expect(s.x).toBeCloseTo(first.x, 0)
         expect(s.y).toBeCloseTo(first.y, 0)
       }
-      console.log(
-        `frame center camera point samples: ${JSON.stringify(samples)}`,
-      )
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       errorSub.remove()
@@ -271,7 +265,6 @@ describe('VisionCamera - Coordinates', () => {
         expect(roundTripped.x).toBeCloseTo(input.x, 0)
         expect(roundTripped.y).toBeCloseTo(input.y, 0)
       }
-      console.log(`preview round-trip ok on ${w}x${h}`)
     } finally {
       errorSub.remove()
       await session.stop()
@@ -336,9 +329,6 @@ describe('VisionCamera - Coordinates', () => {
       const back = previewRef.convertCameraPointToViewPoint(cameraPoint)
       expect(back.x).toBeCloseTo(viewCenter.x, 0)
       expect(back.y).toBeCloseTo(viewCenter.y, 0)
-      console.log(
-        `preview center round-trip: ${JSON.stringify(viewCenter)} -> ${JSON.stringify(cameraPoint)} -> ${JSON.stringify(back)}`,
-      )
     } finally {
       errorSub.remove()
       await session.stop()
@@ -418,9 +408,6 @@ describe('VisionCamera - Coordinates', () => {
       // symmetric around the center. numDigits=1 tolerates |x - 0.5| < 0.05.
       expect(mp.normalizedX).toBeCloseTo(0.5, 1)
       expect(mp.normalizedY).toBeCloseTo(0.5, 1)
-      console.log(
-        `metering point at view center: relative=(${mp.relativeX}, ${mp.relativeY}) normalized=(${mp.normalizedX}, ${mp.normalizedY})`,
-      )
     } finally {
       errorSub.remove()
       await session.stop()
@@ -481,10 +468,8 @@ describe('VisionCamera - Coordinates', () => {
     )
 
     let frameCenterCamera: Point | undefined
-    let observedOrientation: string | undefined
-    const onSample = (cameraPoint: Point, orientation: string) => {
+    const onSample = (cameraPoint: Point) => {
       frameCenterCamera = cameraPoint
-      observedOrientation = orientation
     }
 
     const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
@@ -492,7 +477,7 @@ describe('VisionCamera - Coordinates', () => {
       'worklet'
       const center = { x: frame.width / 2, y: frame.height / 2 }
       const cameraPoint = frame.convertFramePointToCameraPoint(center)
-      scheduleOnRN(onSample, cameraPoint, frame.orientation)
+      scheduleOnRN(onSample, cameraPoint)
       frame.dispose()
     })
 
@@ -520,9 +505,6 @@ describe('VisionCamera - Coordinates', () => {
       // view dimension or more.
       expect(projected.x).toBeCloseTo(viewCenter.x, -2)
       expect(projected.y).toBeCloseTo(viewCenter.y, -2)
-      console.log(
-        `frame.orientation=${observedOrientation} frame-center camera=${JSON.stringify(frameCenterCamera)} -> view=${JSON.stringify(projected)} (view center ${JSON.stringify(viewCenter)})`,
-      )
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       errorSub.remove()
@@ -652,10 +634,6 @@ describe('VisionCamera - Coordinates', () => {
       for (const edge of ['left', 'top', 'right', 'bottom'] as const) {
         expect(r.reported[edge]).toBeCloseTo(r.expected[edge], 0)
       }
-
-      console.log(
-        `oriented rectangle projection orientation=${r.orientation} expected=${JSON.stringify(r.expected)} reported=${JSON.stringify(r.reported)}`,
-      )
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       errorSub.remove()

--- a/apps/simple-camera/__tests__/visioncamera.devices.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.devices.harness.ts
@@ -1,6 +1,5 @@
 import { beforeAll, describe, expect, it } from 'react-native-harness'
 import type {
-  CameraDevice,
   CameraDeviceFactory,
   TargetCameraPosition,
 } from 'react-native-vision-camera'
@@ -48,20 +47,6 @@ describe('VisionCamera - Devices', () => {
     }
   })
 
-  it('logs external cameras when present (optional)', (context) => {
-    const external = factory.cameraDevices.filter(
-      (d) => d.position === 'external',
-    )
-    if (external.length === 0) {
-      return context.skip('external cameras: none available on this device')
-    }
-    for (const device of external) {
-      console.log(
-        `external camera: id=${device.id} name=${device.localizedName}`,
-      )
-    }
-  })
-
   it('returns the same device when calling getCameraForId with a known id', () => {
     const first = factory.cameraDevices[0]
     expect(first).toBeDefined()
@@ -84,9 +69,7 @@ describe('VisionCamera - Devices', () => {
     expect(device).toBeDefined()
     if (device == null) throw new Error('no back camera')
     const extensions = await factory.getSupportedExtensions(device)
-    console.log(
-      `back camera extensions: ${extensions.map((e) => e.type).join(', ') || '(none)'}`,
-    )
+    expect(extensions).toBeInstanceOf(Array)
   })
 
   it('subscribes and unsubscribes a devices-changed listener', () => {
@@ -98,20 +81,6 @@ describe('VisionCamera - Devices', () => {
   it('does not expose unknown fallback values in enumerated device capabilities', () => {
     for (const device of factory.cameraDevices) {
       for (const inspectedDevice of [device, ...device.physicalDevices]) {
-        const label = `${inspectedDevice.position}:${inspectedDevice.id}`
-
-        console.log(
-          `known values ${label}: type=${inspectedDevice.type} ` +
-            `mediaTypes=${inspectedDevice.mediaTypes.join(',')} ` +
-            `pixelFormats=${inspectedDevice.supportedPixelFormats.join(',')} ` +
-            `dynamicRanges=${inspectedDevice.supportedVideoDynamicRanges
-              .map(
-                (range) =>
-                  `${range.bitDepth}/${range.colorSpace}/${range.colorRange}`,
-              )
-              .join(',')}`,
-        )
-
         expect(inspectedDevice.position).not.toBe('unspecified')
         expect(inspectedDevice.type).not.toBe('unknown')
         expect(inspectedDevice.mediaTypes).not.toContain('other')
@@ -128,8 +97,6 @@ describe('VisionCamera - Devices', () => {
 
   it('reports sane capability invariants for each device', () => {
     for (const device of factory.cameraDevices) {
-      const label = `${device.position}:${device.id}`
-
       expect(device.minZoom).toBeLessThanOrEqual(device.maxZoom)
 
       if (device.supportsExposureBias) {
@@ -145,42 +112,6 @@ describe('VisionCamera - Devices', () => {
           expect(range.min).toBeLessThanOrEqual(range.max)
         }
       }
-
-      console.log(
-        `device ${label}: type=${device.type} virtual=${device.isVirtualDevice} ` +
-          `zoom=${device.minZoom}-${device.maxZoom} fpsRanges=${device.supportedFPSRanges
-            .map((r) => `${r.min}-${r.max}`)
-            .join(',')}`,
-      )
-    }
-  })
-
-  it('logs optional hardware capabilities per device', () => {
-    const capabilities: Array<{
-      device: CameraDevice
-      caps: Record<string, boolean | number | string>
-    }> = factory.cameraDevices.map((device) => ({
-      device,
-      caps: {
-        hasFlash: device.hasFlash,
-        hasTorch: device.hasTorch,
-        supportsPhotoHDR: device.supportsPhotoHDR,
-        supportsLowLightBoost: device.supportsLowLightBoost,
-        supportsFocusMetering: device.supportsFocusMetering,
-        supportsExposureBias: device.supportsExposureBias,
-        supports60fps: device.supportsFPS(60),
-        supports120fps: device.supportsFPS(120),
-        supportsCinematicStab:
-          device.supportsVideoStabilizationMode('cinematic'),
-        supportsPreviewImage: device.supportsPreviewImage,
-        hdrRanges: device.supportedVideoDynamicRanges.length,
-      },
-    }))
-
-    for (const { device, caps } of capabilities) {
-      console.log(
-        `caps ${device.position}:${device.id}: ${JSON.stringify(caps)}`,
-      )
     }
   })
 
@@ -227,19 +158,6 @@ describe('VisionCamera - Devices', () => {
       for (const device of combination) {
         expect(knownIds).toContain(device.id)
       }
-    }
-  })
-
-  it('logs every supported multi-cam device combination', () => {
-    const combinations = factory.supportedMultiCamDeviceCombinations
-    console.log(
-      `supportedMultiCamDeviceCombinations: ${combinations.length} combinations`,
-    )
-    for (const [index, combination] of combinations.entries()) {
-      const description = combination
-        .map((d) => `${d.position}:${d.id}`)
-        .join(', ')
-      console.log(`  [${index}] ${description}`)
     }
   })
 })

--- a/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.frame.harness.ts
@@ -163,7 +163,6 @@ describe('VisionCamera - Frame', () => {
           15_000,
           `receive ${targetPixelFormat} frame pixel format`,
         )
-        console.log(`${targetPixelFormat} frame pixel format: ${pixelFormat}`)
         expect(expectedPixelFormats).toContain(pixelFormat)
       } finally {
         runtime.setOnFrameCallback(frameOutput, undefined)
@@ -443,9 +442,6 @@ describe('VisionCamera - Frame', () => {
       errorSub.remove()
       await session.stop()
     }
-    console.log(
-      `yuv frame reported ${reportedWidth}x${reportedHeight} planes=${reportedPlanes} pixelFormat=${reportedPixelFormat}`,
-    )
     expect(reportedWidth).toBeGreaterThan(0)
     expect(reportedHeight).toBeGreaterThan(0)
     expect(reportedPlanes).toBeGreaterThanOrEqual(1)
@@ -621,9 +617,6 @@ describe('VisionCamera - Frame', () => {
       expect(reportedShortEdge).toBe(streamedShortEdge)
       expect(reportedLongEdge).toBe(streamedLongEdge)
 
-      console.log(
-        `max device stream res=${max.width}x${max.height} reported=${reported.width}x${reported.height} streamed=${receivedWidth}x${receivedHeight}`,
-      )
       expect(streamedShortEdge).toBe(requestedShortEdge)
       expect(streamedLongEdge).toBe(requestedLongEdge)
     } finally {
@@ -698,9 +691,6 @@ describe('VisionCamera - Frame', () => {
       expect(reportedShortEdge).toBe(streamedShortEdge)
       expect(reportedLongEdge).toBe(streamedLongEdge)
 
-      console.log(
-        `min device stream res=${min.width}x${min.height} reported=${reported.width}x${reported.height} streamed=${receivedWidth}x${receivedHeight}`,
-      )
       expect(streamedShortEdge).toBe(requestedShortEdge)
       expect(streamedLongEdge).toBe(requestedLongEdge)
     } finally {
@@ -752,7 +742,6 @@ describe('VisionCamera - Frame', () => {
     await session.start()
     try {
       await waitUntil(() => droppedReason != null, { timeout: 15_000 })
-      console.log(`frame dropped reason: ${droppedReason}`)
     } finally {
       runtime.setOnFrameCallback(frameOutput, undefined)
       frameOutput.setOnFrameDroppedCallback(undefined)
@@ -807,9 +796,6 @@ describe('VisionCamera - Frame', () => {
       runtime.setOnFrameCallback(frameOutput, undefined)
       await session.stop()
     }
-    console.log(
-      `preview-sized frame: ${reportedWidth}x${reportedHeight} (requested target ${CommonResolutions.UHD_16_9.width}x${CommonResolutions.UHD_16_9.height})`,
-    )
     const requestedPixels =
       CommonResolutions.UHD_16_9.width * CommonResolutions.UHD_16_9.height
     const actualPixels = reportedWidth * reportedHeight

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -286,9 +286,6 @@ describe('VisionCamera - Photo', () => {
           const savedData = await response.arrayBuffer()
           const savedOrientation = readJpegExifOrientation(savedData)
 
-          console.log(
-            `outputOrientation=${outputOrientation} photo.orientation=${photo.orientation} in-memory EXIF=${inMemoryOrientation} saved EXIF=${savedOrientation}`,
-          )
           expect(savedOrientation).toBe(inMemoryOrientation)
         } finally {
           photo.dispose()
@@ -452,9 +449,6 @@ describe('VisionCamera - Photo', () => {
         { flashMode: 'off', enableShutterSound: false },
         {},
       )
-      console.log(
-        `target=${targetResolution.width}x${targetResolution.height} => resolved=${photo.width}x${photo.height}`,
-      )
       expect(photo.width).toBeGreaterThan(0)
       expect(photo.height).toBeGreaterThan(0)
       photo.dispose()
@@ -527,9 +521,6 @@ describe('VisionCamera - Photo', () => {
       )
       const capturedShortEdge = Math.min(photo.width, photo.height)
       const capturedLongEdge = Math.max(photo.width, photo.height)
-      console.log(
-        `max device res=${maxPhotoResolution.width}x${maxPhotoResolution.height} reported=${reported.width}x${reported.height} captured=${photo.width}x${photo.height}`,
-      )
       expect(capturedShortEdge).toBe(requestedShortEdge)
       expect(capturedLongEdge).toBe(requestedLongEdge)
       photo.dispose()
@@ -585,9 +576,6 @@ describe('VisionCamera - Photo', () => {
       )
       const capturedShortEdge = Math.min(photo.width, photo.height)
       const capturedLongEdge = Math.max(photo.width, photo.height)
-      console.log(
-        `min device res=${minPhotoResolution.width}x${minPhotoResolution.height} reported=${reported.width}x${reported.height} captured=${photo.width}x${photo.height}`,
-      )
       expect(capturedShortEdge).toBe(requestedShortEdge)
       expect(capturedLongEdge).toBe(requestedLongEdge)
       photo.dispose()
@@ -757,8 +745,6 @@ describe('VisionCamera - Photo', () => {
     const preparedFlashModes: FlashMode[] = ['off', 'auto']
     if (backDevice.hasFlash) {
       preparedFlashModes.push('on')
-    } else {
-      console.log('[SKIP] prepareSettings flashMode on: device has no flash')
     }
 
     const session = await VisionCamera.createCameraSession(false)
@@ -883,9 +869,6 @@ describe('VisionCamera - Photo', () => {
         { flashMode: 'off', enableShutterSound: false },
         {},
       )
-      console.log(
-        `mirrorMode=${mirrorMode} => photo.isMirrored=${photo.isMirrored}`,
-      )
       switch (mirrorMode) {
         case 'off':
           expect(photo.isMirrored).toBe(false)
@@ -1000,9 +983,6 @@ describe('VisionCamera - Photo', () => {
       },
     ])
     try {
-      console.log(
-        `photoOutput support flags: depthData=${photoOutput.supportsDepthDataDelivery} calibrationData=${photoOutput.supportsCameraCalibrationDataDelivery}`,
-      )
       expect(photoOutput.supportsDepthDataDelivery).toBe(true)
     } finally {
       await session.stop()

--- a/apps/simple-camera/__tests__/visioncamera.session.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.session.harness.ts
@@ -68,9 +68,6 @@ describe('VisionCamera - Session', () => {
         stopSub.remove()
         errorSub.remove()
       }
-      console.log(
-        `session ok: ${device.position}:${device.id} (${device.localizedName})`,
-      )
     }
   })
 
@@ -613,11 +610,6 @@ describe('VisionCamera - Session', () => {
         )
         const expectedDeviceIds = combination.map((device) => device.id)
         expect(controllerDeviceIds).toEqual(expectedDeviceIds)
-
-        const description = combination
-          .map((device) => `${device.position}:${device.id}`)
-          .join(', ')
-        console.log(`multi-cam combination configured: [${description}]`)
       }
     } finally {
       await session.stop()

--- a/apps/simple-camera/__tests__/visioncamera.skia-camera.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.skia-camera.harness.tsx
@@ -157,9 +157,6 @@ describe('VisionCamera - SkiaCamera targetResolution', () => {
 
     const streamed = await streamFrameSize(backDevice, targetResolution)
 
-    console.log(
-      `SkiaCamera requested=${targetResolution.width}x${targetResolution.height} streamed=${streamed.width}x${streamed.height}`,
-    )
     expect(getEdges(streamed)).toEqual(getEdges(targetResolution))
   })
 
@@ -173,9 +170,6 @@ describe('VisionCamera - SkiaCamera targetResolution', () => {
 
     const streamed = await streamFrameSize(backDevice, undefined)
 
-    console.log(
-      `SkiaCamera (no targetResolution) streamed=${streamed.width}x${streamed.height}`,
-    )
     expect(getEdges(streamed)).toEqual(getEdges(defaultResolution))
   })
 
@@ -190,9 +184,6 @@ describe('VisionCamera - SkiaCamera targetResolution', () => {
     const skia = await streamFrameSize(backDevice, targetResolution)
     const native = await nativeFrameOutputSize(backDevice, targetResolution)
 
-    console.log(
-      `parity requested=${targetResolution.width}x${targetResolution.height} skia=${skia.width}x${skia.height} native=${native.width}x${native.height}`,
-    )
     expect(getEdges(skia)).toEqual(getEdges(native))
   })
 })

--- a/apps/simple-camera/__tests__/visioncamera.video.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.video.harness.ts
@@ -185,9 +185,6 @@ describe('VisionCamera - Video', () => {
         finished.reject,
       )
       const reason = await withTimeout(finished.promise, 30_000, 'maxFileSize')
-      console.log(
-        `maxFileSize duration=${recorder.recordedDuration}s, size=${recorder.recordedFileSize}B`,
-      )
       expect(reason).toBe('max-file-size-reached')
     } finally {
       await session.stop()
@@ -305,9 +302,6 @@ describe('VisionCamera - Video', () => {
       const midSize = recorder.recordedFileSize
       await recorder.stopRecording()
       await withTimeout(finished.promise, 10_000, 'finish')
-      console.log(
-        `recorded mid duration=${midDuration}s mid size=${midSize}B, final size=${recorder.recordedFileSize}B`,
-      )
       expect(midDuration).toBeGreaterThan(0)
       expect(midSize).toBeGreaterThan(0)
     } finally {
@@ -609,9 +603,6 @@ describe('VisionCamera - Video', () => {
       const requestedLongEdge = Math.max(max.width, max.height)
       const reportedShortEdge = Math.min(reported.width, reported.height)
       const reportedLongEdge = Math.max(reported.width, reported.height)
-      console.log(
-        `max device video res=${max.width}x${max.height} reported=${reported.width}x${reported.height}`,
-      )
       expect(reportedShortEdge).toBe(requestedShortEdge)
       expect(reportedLongEdge).toBe(requestedLongEdge)
     } finally {
@@ -652,9 +643,6 @@ describe('VisionCamera - Video', () => {
       const requestedLongEdge = Math.max(min.width, min.height)
       const reportedShortEdge = Math.min(reported.width, reported.height)
       const reportedLongEdge = Math.max(reported.width, reported.height)
-      console.log(
-        `min device video res=${min.width}x${min.height} reported=${reported.width}x${reported.height}`,
-      )
       expect(reportedShortEdge).toBe(requestedShortEdge)
       expect(reportedLongEdge).toBe(requestedLongEdge)
     } finally {
@@ -681,7 +669,6 @@ describe('VisionCamera - Video', () => {
     const codecs = videoOutput.getSupportedVideoCodecs()
     expect(codecs.length).toBeGreaterThan(0)
     expect(codecs).not.toContain('unknown')
-    console.log(`supported video codecs: ${codecs.join(', ')}`)
     await session.stop()
   })
 })


### PR DESCRIPTION
## Summary

- Remove all `console.log` calls from the Harness test suite.
- Remove tests and local computations whose only purpose was diagnostic logging.
- Update the Harness test guidance to keep output quiet and rely on focused matcher failures.

## Why

Successful Harness runs emitted large amounts of diagnostic output, making failures and the overall test summary difficult to read.

## Impact

Harness output is substantially quieter while behavioral assertions and skip reasons remain intact.

## Validation

- Focused Biome check passes for all changed test files and the Harness README.
- `git diff --check` passes.
- Verified no console or logger calls remain in `*.harness.*`.

A full TypeScript check could not resolve the React Native workspace dependencies and extended config in this isolated worktree.
