### PR TITLE
feat: Add `allowHapticsAndSystemSoundsPlayback`

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.session.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.session.harness.ts
@@ -1,9 +1,5 @@
-import {
-  beforeAll,
-  describe,
-  expect,
-  it,
-} from 'react-native-harness'
+import { Platform } from 'react-native'
+import { beforeAll, describe, expect, it } from 'react-native-harness'
 import type {
   CameraDeviceFactory,
   TargetCameraPosition,
@@ -229,6 +225,114 @@ describe('VisionCamera - Session', () => {
     a.remove()
     b.remove()
     await session.stop()
+  })
+
+  it('starts and reconfigures a session with haptics and system sounds playback enabled', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip('allowHapticsAndSystemSoundsPlayback: iOS only')
+    }
+    const device = factory.getDefaultCamera('back')
+    expect(device).toBeDefined()
+    if (device == null) throw new Error('no back camera')
+
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const connection = {
+      input: device,
+      outputs: [{ output: photoOutput, mirrorMode: 'auto' as const }],
+      constraints: [],
+    }
+
+    const started = deferred()
+    const stopped = deferred()
+    const startSub = session.addOnStartedListener(started.resolve)
+    const stopSub = session.addOnStoppedListener(stopped.resolve)
+    const errorSub = session.addOnErrorListener((error) => {
+      started.reject(error)
+      stopped.reject(error)
+    })
+
+    try {
+      const controllers = await session.configure([connection], {
+        allowHapticsAndSystemSoundsPlayback: true,
+      })
+      expect(controllers).toHaveLength(1)
+
+      await session.start()
+      await withTimeout(started.promise, 10_000, 'session start')
+
+      const reconfiguredControllers = await session.configure([connection], {
+        allowHapticsAndSystemSoundsPlayback: false,
+      })
+      expect(reconfiguredControllers).toHaveLength(1)
+
+      await session.stop()
+      await withTimeout(stopped.promise, 10_000, 'session stop')
+    } finally {
+      await session.stop()
+      startSub.remove()
+      stopSub.remove()
+      errorSub.remove()
+    }
+  })
+
+  it('starts and reconfigures a session with background audio playback enabled', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip('allowBackgroundAudioPlayback: iOS only')
+    }
+    const device = factory.getDefaultCamera('back')
+    expect(device).toBeDefined()
+    if (device == null) throw new Error('no back camera')
+
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const connection = {
+      input: device,
+      outputs: [{ output: photoOutput, mirrorMode: 'auto' as const }],
+      constraints: [],
+    }
+
+    const started = deferred()
+    const stopped = deferred()
+    const startSub = session.addOnStartedListener(started.resolve)
+    const stopSub = session.addOnStoppedListener(stopped.resolve)
+    const errorSub = session.addOnErrorListener((error) => {
+      started.reject(error)
+      stopped.reject(error)
+    })
+
+    try {
+      const controllers = await session.configure([connection], {
+        allowBackgroundAudioPlayback: true,
+      })
+      expect(controllers).toHaveLength(1)
+
+      await session.start()
+      await withTimeout(started.promise, 10_000, 'session start')
+
+      const reconfiguredControllers = await session.configure([connection], {
+        allowBackgroundAudioPlayback: false,
+      })
+      expect(reconfiguredControllers).toHaveLength(1)
+
+      await session.stop()
+      await withTimeout(stopped.promise, 10_000, 'session stop')
+    } finally {
+      await session.stop()
+      startSub.remove()
+      stopSub.remove()
+      errorSub.remove()
+    }
   })
 
   it('reconfigures a running session with a new output set', async () => {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
@@ -90,6 +90,13 @@ final class HybridCameraSession: HybridCameraSessionSpec {
       }
       self.session.automaticallyConfiguresCaptureDeviceForWideColor = !hasCustomDynamicRangeConstraint
 
+      // Haptics and System Sounds Playback
+      if let allowHapticsAndSystemSoundsPlayback = config?.allowHapticsAndSystemSoundsPlayback {
+        let audioSession = AVAudioSession.sharedInstance()
+        if audioSession.allowHapticsAndSystemSoundsDuringRecording != allowHapticsAndSystemSoundsPlayback {
+          audioSession.setAllowHapticsAndSystemSoundsDuringRecording(allowHapticsAndSystemSoundsPlayback)
+        }
+      }
       // Background Audio Playback
       if #available(iOS 18.0, *) {
         if let allowBackgroundAudioPlayback = config?.allowBackgroundAudioPlayback {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
@@ -94,7 +94,7 @@ final class HybridCameraSession: HybridCameraSessionSpec {
       if let allowHapticsAndSystemSoundsPlayback = config?.allowHapticsAndSystemSoundsPlayback {
         let audioSession = AVAudioSession.sharedInstance()
         if audioSession.allowHapticsAndSystemSoundsDuringRecording != allowHapticsAndSystemSoundsPlayback {
-          audioSession.setAllowHapticsAndSystemSoundsDuringRecording(allowHapticsAndSystemSoundsPlayback)
+          try audioSession.setAllowHapticsAndSystemSoundsDuringRecording(allowHapticsAndSystemSoundsPlayback)
         }
       }
       // Background Audio Playback

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JCameraSessionConfiguration.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JCameraSessionConfiguration.hpp
@@ -31,9 +31,12 @@ namespace margelo::nitro::camera {
     [[nodiscard]]
     CameraSessionConfiguration toCpp() const {
       static const auto clazz = javaClassStatic();
+      static const auto fieldAllowHapticsAndSystemSoundsPlayback = clazz->getField<jni::JBoolean>("allowHapticsAndSystemSoundsPlayback");
+      jni::local_ref<jni::JBoolean> allowHapticsAndSystemSoundsPlayback = this->getFieldValue(fieldAllowHapticsAndSystemSoundsPlayback);
       static const auto fieldAllowBackgroundAudioPlayback = clazz->getField<jni::JBoolean>("allowBackgroundAudioPlayback");
       jni::local_ref<jni::JBoolean> allowBackgroundAudioPlayback = this->getFieldValue(fieldAllowBackgroundAudioPlayback);
       return CameraSessionConfiguration(
+        allowHapticsAndSystemSoundsPlayback != nullptr ? std::make_optional(static_cast<bool>(allowHapticsAndSystemSoundsPlayback->value())) : std::nullopt,
         allowBackgroundAudioPlayback != nullptr ? std::make_optional(static_cast<bool>(allowBackgroundAudioPlayback->value())) : std::nullopt
       );
     }
@@ -44,11 +47,12 @@ namespace margelo::nitro::camera {
      */
     [[maybe_unused]]
     static jni::local_ref<JCameraSessionConfiguration::javaobject> fromCpp(const CameraSessionConfiguration& value) {
-      using JSignature = JCameraSessionConfiguration(jni::alias_ref<jni::JBoolean>);
+      using JSignature = JCameraSessionConfiguration(jni::alias_ref<jni::JBoolean>, jni::alias_ref<jni::JBoolean>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
+        value.allowHapticsAndSystemSoundsPlayback.has_value() ? jni::JBoolean::valueOf(value.allowHapticsAndSystemSoundsPlayback.value()) : nullptr,
         value.allowBackgroundAudioPlayback.has_value() ? jni::JBoolean::valueOf(value.allowBackgroundAudioPlayback.value()) : nullptr
       );
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/CameraSessionConfiguration.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/CameraSessionConfiguration.kt
@@ -20,6 +20,9 @@ import java.util.Objects
 data class CameraSessionConfiguration(
   @DoNotStrip
   @Keep
+  val allowHapticsAndSystemSoundsPlayback: Boolean?,
+  @DoNotStrip
+  @Keep
   val allowBackgroundAudioPlayback: Boolean?
 ) {
   /* primary constructor */
@@ -27,11 +30,13 @@ data class CameraSessionConfiguration(
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is CameraSessionConfiguration) return false
-    return Objects.deepEquals(this.allowBackgroundAudioPlayback, other.allowBackgroundAudioPlayback)
+    return Objects.deepEquals(this.allowHapticsAndSystemSoundsPlayback, other.allowHapticsAndSystemSoundsPlayback)
+      && Objects.deepEquals(this.allowBackgroundAudioPlayback, other.allowBackgroundAudioPlayback)
   }
 
   override fun hashCode(): Int {
     return arrayOf<Any?>(
+      allowHapticsAndSystemSoundsPlayback,
       allowBackgroundAudioPlayback
     ).contentDeepHashCode()
   }
@@ -44,8 +49,8 @@ data class CameraSessionConfiguration(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(allowBackgroundAudioPlayback: Boolean?): CameraSessionConfiguration {
-      return CameraSessionConfiguration(allowBackgroundAudioPlayback)
+    private fun fromCpp(allowHapticsAndSystemSoundsPlayback: Boolean?, allowBackgroundAudioPlayback: Boolean?): CameraSessionConfiguration {
+      return CameraSessionConfiguration(allowHapticsAndSystemSoundsPlayback, allowBackgroundAudioPlayback)
     }
   }
 }

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/CameraSessionConfiguration.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/CameraSessionConfiguration.swift
@@ -18,8 +18,14 @@ public extension CameraSessionConfiguration {
   /**
    * Create a new instance of `CameraSessionConfiguration`.
    */
-  init(allowBackgroundAudioPlayback: Bool?) {
+  init(allowHapticsAndSystemSoundsPlayback: Bool?, allowBackgroundAudioPlayback: Bool?) {
     self.init({ () -> bridge.std__optional_bool_ in
+      if let __unwrappedValue = allowHapticsAndSystemSoundsPlayback {
+        return bridge.create_std__optional_bool_(__unwrappedValue)
+      } else {
+        return .init()
+      }
+    }(), { () -> bridge.std__optional_bool_ in
       if let __unwrappedValue = allowBackgroundAudioPlayback {
         return bridge.create_std__optional_bool_(__unwrappedValue)
       } else {
@@ -28,6 +34,18 @@ public extension CameraSessionConfiguration {
     }())
   }
 
+  @inline(__always)
+  var allowHapticsAndSystemSoundsPlayback: Bool? {
+    return { () -> Bool? in
+      if bridge.has_value_std__optional_bool_(self.__allowHapticsAndSystemSoundsPlayback) {
+        let __unwrapped = bridge.get_std__optional_bool_(self.__allowHapticsAndSystemSoundsPlayback)
+        return __unwrapped
+      } else {
+        return nil
+      }
+    }()
+  }
+  
   @inline(__always)
   var allowBackgroundAudioPlayback: Bool? {
     return { () -> Bool? in

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/CameraSessionConfiguration.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/CameraSessionConfiguration.hpp
@@ -39,11 +39,12 @@ namespace margelo::nitro::camera {
    */
   struct CameraSessionConfiguration final {
   public:
+    std::optional<bool> allowHapticsAndSystemSoundsPlayback     SWIFT_PRIVATE;
     std::optional<bool> allowBackgroundAudioPlayback     SWIFT_PRIVATE;
 
   public:
     CameraSessionConfiguration() = default;
-    explicit CameraSessionConfiguration(std::optional<bool> allowBackgroundAudioPlayback): allowBackgroundAudioPlayback(allowBackgroundAudioPlayback) {}
+    explicit CameraSessionConfiguration(std::optional<bool> allowHapticsAndSystemSoundsPlayback, std::optional<bool> allowBackgroundAudioPlayback): allowHapticsAndSystemSoundsPlayback(allowHapticsAndSystemSoundsPlayback), allowBackgroundAudioPlayback(allowBackgroundAudioPlayback) {}
 
   public:
     friend bool operator==(const CameraSessionConfiguration& lhs, const CameraSessionConfiguration& rhs) = default;
@@ -59,11 +60,13 @@ namespace margelo::nitro {
     static inline margelo::nitro::camera::CameraSessionConfiguration fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::camera::CameraSessionConfiguration(
+        JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "allowHapticsAndSystemSoundsPlayback"))),
         JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "allowBackgroundAudioPlayback")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::camera::CameraSessionConfiguration& arg) {
       jsi::Object obj(runtime);
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "allowHapticsAndSystemSoundsPlayback"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.allowHapticsAndSystemSoundsPlayback));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "allowBackgroundAudioPlayback"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.allowBackgroundAudioPlayback));
       return obj;
     }
@@ -75,6 +78,7 @@ namespace margelo::nitro {
       if (!nitro::isPlainObject(runtime, obj)) {
         return false;
       }
+      if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "allowHapticsAndSystemSoundsPlayback")))) return false;
       if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "allowBackgroundAudioPlayback")))) return false;
       return true;
     }

--- a/packages/react-native-vision-camera/src/specs/session/CameraSessionConfiguration.ts
+++ b/packages/react-native-vision-camera/src/specs/session/CameraSessionConfiguration.ts
@@ -5,12 +5,34 @@ import type { CameraSession } from './CameraSession.nitro'
  */
 export interface CameraSessionConfiguration {
   /**
-   * If enabled, the {@linkcode CameraSession} does not interrupt
-   * currently playing audio (e.g. music from a different app),
-   * while recording.
+   * If enabled, the device may play haptics/vibrations
+   * and system sounds during while the {@linkcode CameraSession}
+   * is active.
    *
-   * If disabled (the default), any playing audio will be stopped
-   * when a recording is started.
+   * If disabled (the default), all haptics and system
+   * sounds will be muted while the {@linkcode CameraSession}
+   * is active.
+   *
+   * @note If {@linkcode allowHapticsAndSystemSoundsPlayback}
+   * is true, haptics or system sounds may also be captured
+   * in Video recordings.
+   * Haptics may also affect stabilization or focus operations.
+   *
+   * @default false
+   * @platform iOS
+   */
+  allowHapticsAndSystemSoundsPlayback?: boolean
+  /**
+   * If enabled, the device may play background audio,
+   * possibly from another app (e.g. Apple Music) while
+   * the {@linkcode CameraSession} is active.
+   *
+   * If disabled (the default), any playing audio will be
+   * stopped while the {@linkcode CameraSession} is active.
+   *
+   * @note If {@linkcode allowBackgroundAudioPlayback} is true,
+   * background audio may also be captured in Video recordings.
+   *
    * @default false
    * @platform iOS
    */


### PR DESCRIPTION
Adds `allowHapticsAndSystemSoundsPlayback`, a boolean prop to configure whether haptics (vibrations) or system sounds (like alarms or ringtones) are allowed to play during "recording" (recording means CameraSession being active)

Default is `false`.

If `true`, [`setAllowHapticsAndSystemSoundsDuringRecording(true)`](https://developer.apple.com/documentation/avfaudio/avaudiosession/setallowhapticsandsystemsoundsduringrecording(_:)) will be called.

This is required in ShadowLens as we run haptics while the Camera is active for sliders or buttons. Or capture.