### PR TITLE
test: Add failing Harness test — square Frame region maps to a 3.16:1 strip in View space on iOS

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
@@ -512,6 +512,146 @@ describe('VisionCamera - Coordinates', () => {
     }
   })
 
+  // The end-to-end test above projects a single point, and the frame center
+  // is a fixed point of any axis-scaling error — an anisotropic Frame ->
+  // View mapping still lands the center on the center. Projecting a region
+  // catches what a point cannot: a square in Frame space must stay square
+  // in View space, because every transform between them (sensor scale,
+  // orientation, the preview's aspect-preserving crop) preserves aspect.
+  //
+  // Camera space itself is allowed to be anisotropic — iOS normalizes
+  // per-axis to [0, 1], so a square is not square there — but that is an
+  // intermediate representation, and converting out of it must undo the
+  // same per-axis scaling it applied. Composing the two public conversions
+  // is exactly how callers map a region of interest (a scan guide, a
+  // detection box) between the preview and the pixels, so the composition
+  // is the contract under test, not either half alone.
+  it('maps a square Frame region onto a square View region', async () => {
+    const session = await VisionCamera.createCameraSession(false)
+    const previewOutput = VisionCamera.createPreviewOutput()
+    const frameOutput = VisionCamera.createFrameOutput({
+      targetResolution: CommonResolutions.HD_16_9,
+      pixelFormat: 'native',
+      enablePreviewSizedOutputBuffers: false,
+      enablePhysicalBufferRotation: false,
+      enableCameraMatrixDelivery: false,
+      allowDeferredStart: false,
+      dropFramesWhileBusy: true,
+    })
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [
+          { output: previewOutput, mirrorMode: 'auto' },
+          { output: frameOutput, mirrorMode: 'auto' },
+        ],
+        constraints: [],
+      },
+    ])
+
+    let previewRef: PreviewView | undefined
+    const previewStarted = deferred()
+    const layout = deferred<{ width: number; height: number }>()
+    let sessionError: Error | undefined
+    const errorSub = session.addOnErrorListener((error) => {
+      sessionError = error
+      previewStarted.reject(error)
+      layout.reject(error)
+    })
+
+    await render(
+      <NativePreviewView
+        style={StyleSheet.absoluteFill}
+        previewOutput={previewOutput}
+        hybridRef={callback((r: PreviewView) => {
+          previewRef = r
+        })}
+        onPreviewStarted={callback(() => {
+          previewStarted.resolve()
+        })}
+        onLayout={(e: LayoutChangeEvent) => {
+          layout.resolve({
+            width: e.nativeEvent.layout.width,
+            height: e.nativeEvent.layout.height,
+          })
+        }}
+      />,
+    )
+
+    // Three corners are enough to measure two adjacent edges of the square.
+    type SquareCorners = {
+      topLeft: Point
+      topRight: Point
+      bottomLeft: Point
+    }
+    let cameraCorners: SquareCorners | undefined
+    const onCorners = (corners: SquareCorners) => {
+      cameraCorners = corners
+    }
+
+    const runtime = workletsProvider.createRuntimeForThread(frameOutput.thread)
+    runtime.setOnFrameCallback(frameOutput, (frame) => {
+      'worklet'
+      // A square centered in the frame, kept small so it stays inside the
+      // preview's `resizeMode='cover'` crop on any view aspect ratio.
+      const side = Math.min(frame.width, frame.height) / 4
+      const left = frame.width / 2 - side / 2
+      const right = frame.width / 2 + side / 2
+      const top = frame.height / 2 - side / 2
+      const bottom = frame.height / 2 + side / 2
+      scheduleOnRN(onCorners, {
+        topLeft: frame.convertFramePointToCameraPoint({ x: left, y: top }),
+        topRight: frame.convertFramePointToCameraPoint({ x: right, y: top }),
+        bottomLeft: frame.convertFramePointToCameraPoint({
+          x: left,
+          y: bottom,
+        }),
+      })
+      frame.dispose()
+    })
+
+    await session.start()
+    try {
+      await withTimeout(layout.promise, 10_000, 'preview view onLayout')
+      await withTimeout(previewStarted.promise, 15_000, 'preview started')
+      await waitUntil(() => cameraCorners != null || sessionError != null, {
+        timeout: 15_000,
+      })
+      expect(sessionError).toBe(undefined)
+      if (previewRef == null) throw new Error('no preview ref')
+      const corners = cameraCorners
+      if (corners == null) throw new Error('no square corner samples')
+
+      const view = {
+        topLeft: previewRef.convertCameraPointToViewPoint(corners.topLeft),
+        topRight: previewRef.convertCameraPointToViewPoint(corners.topRight),
+        bottomLeft: previewRef.convertCameraPointToViewPoint(
+          corners.bottomLeft,
+        ),
+      }
+
+      // Edge *lengths*, not per-axis deltas: the orientation counter-rotation
+      // is free to map the frame's x edge onto the view's y axis, so only the
+      // distances are comparable across the two spaces.
+      const distance = (a: Point, b: Point) => Math.hypot(b.x - a.x, b.y - a.y)
+      const topEdge = distance(view.topLeft, view.topRight)
+      const leftEdge = distance(view.topLeft, view.bottomLeft)
+      expect(topEdge).toBeGreaterThan(0)
+      expect(leftEdge).toBeGreaterThan(0)
+
+      // A ratio rather than absolute lengths: the frame resolution and the
+      // view size differ per device, but a square is square everywhere.
+      // toBeCloseTo(1, 1) tolerates |ratio - 1| < 0.05, which absorbs dp /
+      // pixel rounding while still catching an axis-scaling regression.
+      const edgeRatio = leftEdge / topEdge
+      expect(edgeRatio).toBeCloseTo(1, 1)
+    } finally {
+      runtime.setOnFrameCallback(frameOutput, undefined)
+      errorSub.remove()
+      await session.stop()
+    }
+  })
+
   // Analyzer coordinates may be reported in the Frame's intended/oriented
   // image space, while Frame.convertFramePointToCameraPoint consumes raw
   // buffer-space points. The center-only test above cannot catch an


### PR DESCRIPTION
Adds one failing Harness test reproducing an iOS-only anisotropy when composing the two public coordinate conversions. Per the harness README, this PR is the reproduction — the issue will reference it.

## What's wrong

Composing the library's own two transforms produces a distorted mapping on iOS:

```
PreviewView.convertViewPointToCameraPoint()  ->  Frame.convertCameraPointToFramePoint()
```

A square region — the natural thing to map when you have a scan guide or a detection box — comes back as a wide, short strip. Each sample smears across its neighbours.

## Measured

iPhone 15 Pro Max, iOS 26.5.2, frame 3840×2160, `orientation: "left"`. A square guide cell, identical ±19.7 dp in both view axes:

```
sensor Δx 0.0562  ->  frame Δy 121.4 px
sensor Δy 0.0999  ->  frame Δx 383.6 px
```

**383.6 × 121.4 px — ratio 3.159**, where a correct mapping gives **1.000**. Pixel 8 (1280×720) composes correctly at 1.000, so this is iOS-only.

`convertViewPointToCameraPoint` looks right on its own: for the square patch it returns Δx/Δy = 0.5625 = exactly 9/16, consistent with per-axis normalisation over a 16:9 image.

## Suspected cause

`ios/Utils/FrameCoordinateSystemConverter.getFrameToCameraMatrix` rotates within `[0, 1]²` in step 1, then normalises in step 3:

```swift
// 1. Counter-rotate by the orientation to get it up-right
case .left: matrix = matrix.translatedBy(x: 1, y: 0).rotated(by: .pi / 2)
...
// 3. Our Matrix is in [0, 1], so let's scale it to [0, width|height] now
matrix = matrix.scaledBy(x: 1 / width, y: 1 / height)
```

`scaledBy` post-concatenates, so a point is normalised by the buffer's own width/height *before* the rotation swaps the axes — and the extents never swap with it. The measured numbers match that reading exactly: `0.0562 × 2160 = 121.4` and `0.0999 × 3840 = 383.6`, i.e. each output axis is scaled by its own extent after the swap, where the swap should have transposed them. Predicted anisotropy for a 16:9 frame at `orientation: left` is (16/9)² = **3.1605**, against the measured **3.159**.

One candidate shape for the fix, though the test is the arbiter:

```swift
switch orientation {
case .left, .right: matrix = matrix.scaledBy(x: 1 / height, y: 1 / width)
case .up, .down:    matrix = matrix.scaledBy(x: 1 / width, y: 1 / height)
}
```

Corner and round-trip behaviour stay correct under the bug, which is why the existing tests don't catch it:

- `round-trips Frame -> Camera -> Frame` passes because the error is self-inverse — `getCameraToFrameMatrix` is literally `getFrameToCameraMatrix().inverted()`.
- `round-trips Frame center -> Camera -> View center end-to-end` passes because the frame center maps to camera `(0.5, 0.5)` under both a correct and an anisotropic matrix, so it lands on the view center either way. The center is a fixed point of the error.

Only an off-center *region* exposes it.

## The test

`maps a square Frame region onto a square View region` in `visioncamera.coordinates.harness.tsx`, next to the existing end-to-end test. It runs the square the other way round — Frame → Camera → View — so the frame callback is installed before `start()` exactly like the neighbouring tests, and no new setup shape is introduced.

- Takes a square centered in the frame, side `min(width, height) / 4`, kept small so it stays inside the preview's `resizeMode='cover'` crop on any view aspect ratio.
- Converts three corners to camera space in the worklet, then to view space through the mounted `PreviewView`.
- Compares the two adjacent **edge lengths**, not per-axis deltas — the orientation counter-rotation is free to map the frame's x edge onto the view's y axis, so only distances are comparable.
- Asserts `leftEdge / topEdge` is `toBeCloseTo(1, 1)` — a ratio rather than absolute lengths, since frame resolution and view size differ per device, but a square is square everywhere.

No platform guard, per README §8: the behaviour should hold on both platforms, so the shared test should show the discrepancy rather than hide it. Expect **red on iOS, green on Android**.

## What I could not verify myself

I have not executed this test. I don't have a rig for this monorepo (no `bun`, and the failure is iOS-only), so the CI run on this PR is the first real execution. The test is written against the conventions in `__tests__/README.md` and `biome check` is clean, but treat the exact tolerance as a starting point — if `toBeCloseTo(1, 1)` proves too tight for real device geometry on a correct implementation, it should be loosened rather than the invariant weakened.

Also worth flagging: fork PRs may not be able to assume the AWS Device Farm OIDC role, so the iOS leg might not run here without a maintainer-triggered run.

## Context

Found while mapping a Rubik's cube scan guide onto sampled frames in a shipping app. Our workaround validates the composed mapping with an isotropy check and falls back to deriving the geometry from the frame dimensions when it fails — no platform branch, it's measured at runtime. Android accepts the library transform; iOS rejects it at 3.159 and falls back. Happy to adjust anything here, and glad to re-run against a fix.
