### PR TITLE
fix(resizer): bound the AHardwareBuffer import cache and guard dispose() against in-flight resize()

### DIFF
--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.cpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.cpp
@@ -38,6 +38,10 @@ namespace {
 HybridResizer::HybridResizer(const ResizerOptions& options) : HybridObject(TAG), _pipeline(std::make_unique<vulkan::VulkanResizerPipeline>(options)) {}
 
 std::shared_ptr<HybridGPUFrameSpec> HybridResizer::resize(const std::shared_ptr<camera::HybridFrameSpec>& frame) {
+  // Held for the whole call - `dispose()` destroys `_pipeline`, so releasing the lock before `run()`
+  // returns would let the pipeline be freed underneath us.
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+
   if (_pipeline == nullptr) [[unlikely]] {
     throw std::runtime_error("This Resizer has already been disposed!");
   }
@@ -59,6 +63,9 @@ std::shared_ptr<HybridGPUFrameSpec> HybridResizer::resize(const std::shared_ptr<
 }
 
 void HybridResizer::dispose() {
+  // Blocks until any in-flight `resize()` has returned, so the pipeline is never destroyed while it is running.
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+
   if (_pipeline == nullptr) {
     return;
   }
@@ -71,6 +78,10 @@ void HybridResizer::dispose() {
 }
 
 size_t HybridResizer::getExternalMemorySize() noexcept {
+  // Nitro calls this from `HybridObject::toObject(...)`, i.e. on whichever Thread converts the Resizer
+  // into a Runtime - including a Frame Processor's `unbox()` on the camera Thread.
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+
   return _pipeline != nullptr ? _pipeline->getOutputBufferAllocationSize() : 0;
 }
 

--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.hpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.hpp
@@ -11,6 +11,7 @@
 #include "vulkan/VulkanResizerPipeline.hpp"
 
 #include <memory>
+#include <mutex>
 
 namespace margelo::nitro::camera::resizer {
 
@@ -28,6 +29,15 @@ public:
   size_t getExternalMemorySize() noexcept override;
 
 private:
+  /**
+   * Serializes `resize()` against `dispose()`.
+   *
+   * `resize()` dereferences `_pipeline` on the Frame Processor Thread while `dispose()` can reset the
+   * same `unique_ptr` from JS - which runs `~VulkanResizerPipeline()` and tears down the VkDevice out
+   * from under an in-flight `run()`. That is a use-after-free, not the catchable "already been
+   * disposed" error callers are written against.
+   */
+  std::mutex _lifecycleMutex;
   std::unique_ptr<vulkan::VulkanResizerPipeline> _pipeline;
 };
 

--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.cpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.cpp
@@ -54,6 +54,7 @@ const VulkanHardwareBufferInterop::ImportedImage& VulkanHardwareBufferInterop::i
 
   // Camera streaming tends to recycle a small set of AHardwareBuffer objects, so cache their Vulkan wrappers by
   // buffer address and reuse them across frames instead of recreating the import/image-view state every time.
+  // The cache is LRU-ordered (front = most recently used) and bounded by kMaxCachedImages - see there for why.
   for (auto iterator = _cachedImages.begin(); iterator != _cachedImages.end();) {
     if (iterator->hardwareBuffer != hardwareBuffer) {
       // Different AHardwareBuffer* - look into next cached image...
@@ -65,12 +66,25 @@ const VulkanHardwareBufferInterop::ImportedImage& VulkanHardwareBufferInterop::i
                                iterator->width == description.width && iterator->height == description.height && iterator->format == description.format;
     if (canReuseImage) {
       // We can re-use this Vulkan ImportedImage because it's the same AHardwareBuffer + config as before!
-      return iterator->importedImage;
+      // Promote it to the front so the LRU eviction below never drops a hot buffer. `splice(..)` moves the
+      // node itself, so the returned reference stays valid.
+      _cachedImages.splice(_cachedImages.begin(), _cachedImages, iterator);
+      return _cachedImages.front().importedImage;
     }
 
     // We can not re-use this Vulkan ImportedImage because the config has changed. Destroy it from cache.
     destroyImportedImage(iterator->importedImage);
     iterator = _cachedImages.erase(iterator);
+  }
+
+  // Evict least-recently-used entries before inserting, so the cache converges onto the current camera session's
+  // working set and releases the previous session's buffers.
+  //
+  // Safe to destroy here: `VulkanResizerPipeline::run(..)` holds `_stateMutex` across import -> dispatch ->
+  // submit-and-wait, so no other imported image is in flight on the GPU at this point.
+  while (_cachedImages.size() >= kMaxCachedImages) {
+    destroyImportedImage(_cachedImages.back().importedImage);
+    _cachedImages.pop_back();
   }
 
   // No suitable ImportedImage was found in our cache - we have to create a new one.
@@ -83,8 +97,8 @@ const VulkanHardwareBufferInterop::ImportedImage& VulkanHardwareBufferInterop::i
       .format = description.format,
       .importedImage = createImportedImage(hardwareBuffer, description, properties, conversion),
   };
-  _cachedImages.push_back(std::move(cachedImage));
-  return _cachedImages.back().importedImage;
+  _cachedImages.push_front(std::move(cachedImage));
+  return _cachedImages.front().importedImage;
 }
 
 void VulkanHardwareBufferInterop::clearCachedImages() noexcept {

--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.hpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.hpp
@@ -10,7 +10,7 @@
 
 #include <android/hardware_buffer.h>
 
-#include <vector>
+#include <list>
 
 #include <vulkan/vulkan.h>
 #include <vulkan/vulkan_android.h>
@@ -70,6 +70,22 @@ private:
     ImportedImage importedImage{};
   };
 
+  /**
+   * Upper bound on cached imported images (LRU-evicted).
+   *
+   * Importing an AHardwareBuffer into Vulkan ACQUIRES A REFERENCE on it (per the
+   * VK_ANDROID_external_memory_android_hardware_buffer spec), so every cached entry pins a full camera buffer
+   * alive. Unbounded, that means the Resizer pins every AHardwareBuffer it has ever seen for its whole lifetime:
+   * each camera session restart (fps/constraints change, pause/resume, ...) makes CameraX allocate a fresh buffer
+   * set, so the pinned set grows by a whole set per restart and is never released.
+   *
+   * A single streaming session's working set is small (ImageAnalysis with maxImages=4 cycles through ~4-6
+   * buffers), so 12 leaves generous slack while still converging onto the CURRENT session's buffers within a few
+   * frames of a restart. The cache is a pure optimization - the pipeline submits and waits synchronously in
+   * `run(..)`, so a miss only costs one import.
+   */
+  static inline constexpr size_t kMaxCachedImages = 12;
+
   static inline constexpr VkFormatFeatureFlags kRequiredExternalFormatFeatures = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
   static inline constexpr VkFormatFeatureFlags kLinearFilterFeatureMask =
       VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT;
@@ -82,7 +98,10 @@ private:
   VkPhysicalDevice _physicalDevice{VK_NULL_HANDLE};
   VkDevice _device{VK_NULL_HANDLE};
   const VulkanDeviceDispatch* _deviceDispatch{nullptr};
-  std::vector<CachedImage> _cachedImages{};
+  // `std::list`, not `std::vector`: `importImage(..)` hands out a reference INTO this container, and the LRU now
+  // reorders on every hit and evicts on misses. List nodes have stable addresses, so `splice(..)`-to-front and
+  // `pop_back()` provably never move the entry being returned. Front = most recently used.
+  std::list<CachedImage> _cachedImages{};
 };
 
 } // namespace margelo::nitro::camera::resizer::vulkan

--- a/packages/react-native-vision-camera-resizer/ios/HybridResizer.swift
+++ b/packages/react-native-vision-camera-resizer/ios/HybridResizer.swift
@@ -12,6 +12,20 @@ import VisionCamera
 
 /// High-level iOS resizer that turns camera frames into GPU-backed JS-visible output frames.
 final class HybridResizer: HybridResizerSpec {
+  /// Serializes `resize()` against `dispose()` - the same lifecycle guard as the Android
+  /// `HybridResizer`'s `_lifecycleMutex`.
+  ///
+  /// `pipeline` is read on the Frame Processor Thread (`resize`, and `memorySize` via Nitro's
+  /// `toObject`) while `dispose()` can clear it from JS. A Swift stored-property load/store of a
+  /// class reference is not atomic, so an unguarded `pipeline = nil` racing the `guard let` load is
+  /// a data race on the possibly-last reference. Holding the lock across `run()` also means a
+  /// dispose landing mid-Frame waits for that resize to return, and every later call throws the
+  /// catchable "already been disposed" error instead.
+  ///
+  /// A `GPUFrame` that is still checked out is unaffected: its `MetalBufferView`'s `onRelease`
+  /// closure strongly captures the `MetalReusableBuffer`, so ARC keeps the output buffer alive
+  /// independently of the pipeline.
+  private let lifecycleLock = NSLock()
   private var pipeline: MetalResizerPipeline?
 
   init(options: ResizerOptions) throws {
@@ -20,14 +34,20 @@ final class HybridResizer: HybridResizerSpec {
   }
 
   var memorySize: Int {
+    lifecycleLock.lock()
+    defer { lifecycleLock.unlock() }
     return pipeline?.outputByteCount ?? 0
   }
 
   func dispose() {
+    lifecycleLock.lock()
+    defer { lifecycleLock.unlock() }
     pipeline = nil
   }
 
   func resize(frame: any HybridFrameSpec) throws -> any HybridGPUFrameSpec {
+    lifecycleLock.lock()
+    defer { lifecycleLock.unlock() }
     guard let pipeline else {
       throw RuntimeError.error(withMessage: "This Resizer has already been disposed!")
     }


### PR DESCRIPTION
Two independent lifetime bugs in the Resizer, both found while profiling a long-running Frame Processor that resizes every frame.

## 1. The AHardwareBuffer import cache is unbounded (Android)

`VulkanHardwareBufferInterop::_cachedImages` only ever grows. Importing an `AHardwareBuffer` into Vulkan **acquires a reference on it** (per the `VK_ANDROID_external_memory_android_hardware_buffer` spec), so every cached entry pins a full camera buffer alive for the lifetime of the `Resizer`.

That is fine while one camera session streams — CameraX recycles a small set of buffers, which is exactly what the cache is for. The problem is session restarts: an fps/constraints change, a pause/resume, a format change, etc. make CameraX allocate a **fresh** buffer set, and the old set stays pinned by the cache forever. Nothing ever evicts it, not even when the camera fully disconnects.

Measured on a Pixel 10 over ~49 min of ordinary use with periodic camera restarts:

| | start | end |
|---|---|---|
| retained 1920x1080 YUV buffers | 39 | 137 |
| gralloc held by them | ~120 MB | ~418 MB |
| total PSS | 588 MB | 1.21 GB |

Fix: the cache is now LRU-ordered (`splice` to front on a hit) and bounded by `kMaxCachedImages = 12`, evicting from the back before an insert. A single streaming session's working set is ~4-6 buffers (`ImageAnalysis` with `maxImages=4`), so 12 leaves generous slack while still converging onto the current session's buffers within a few frames of a restart. The cache is a pure optimization anyway — `VulkanResizerPipeline::run(..)` submits and waits synchronously, so a miss costs one import.

Storage changed from `std::vector` to `std::list` because `importImage(..)` hands out a reference *into* the container and the LRU now reorders on hits and evicts on misses; list nodes have stable addresses, so `splice(..)` and `pop_back()` provably never move the entry being returned.

Eviction is safe at that point: `run(..)` holds `_stateMutex` across import -> dispatch -> submit-and-wait, so no other imported image is in flight on the GPU.

## 2. `dispose()` races an in-flight `resize()` (both platforms)

`resize()` read `_pipeline`, null-checked it, then dereferenced it with no synchronization, while `dispose()` could concurrently reset the same `unique_ptr` — which runs `~VulkanResizerPipeline()` and tears down the `VkDevice` (and the pipeline's own `_stateMutex`) out from under an in-flight `run()`. That is a native use-after-free, not the catchable `"This Resizer has already been disposed!"` error callers are written against.

iOS has the same shape: a Swift stored-property load/store of a class reference is not atomic, so an unguarded `pipeline = nil` racing the `guard let` load is a data race on the possibly-last reference.

This is reachable whenever a consumer disposes eagerly rather than leaving the instance to the GC — `dispose()` then runs on the JS thread while `resize()` can still be running on the Frame Processor thread.

Fix: a `std::mutex` (Android) / `NSLock` (iOS) held across `resize()`, `dispose()` and the `memorySize` / `getExternalMemorySize()` getter. A dispose landing mid-frame now blocks until that resize returns, and every later call throws the catchable error.

`getExternalMemorySize()` needs the guard too — Nitro calls it from `HybridObject::toObject(..)`, i.e. on whichever thread converts the Resizer into a Runtime, including a Frame Processor's `unbox()` on the camera thread. It cannot self-deadlock: Nitro never calls it from inside `resize()`/`dispose()`.

A `GPUFrame` that is still checked out is unaffected by `dispose()` — on iOS its `MetalBufferView`'s `onRelease` closure strongly captures the `MetalReusableBuffer`, so ARC keeps the output buffer alive independently of the pipeline.

## Testing

Built and run on-device (Android, Vulkan path) with a per-frame Frame Processor. The buffer bound was A/B verified: with the LRU cap the retained-buffer count stays flat across repeated camera restarts instead of ratcheting, and PSS no longer climbs. The dispose guard was exercised by disposing from a React effect cleanup while frames were still being processed.

I have not been able to test the iOS Metal path on device — the iOS change is the mechanical equivalent of the Android one, so please review it with that in mind.
