### PR TITLE
feat(resizer): dispose the Resizer in useResizer, and add an `enabled` option

### DIFF
--- a/packages/react-native-vision-camera-resizer/src/useResizer.ts
+++ b/packages/react-native-vision-camera-resizer/src/useResizer.ts
@@ -16,6 +16,23 @@ export type ResizerState =
   | { state: 'error'; resizer: undefined; error: Error }
 
 /**
+ * Releases a {@linkcode Resizer} now instead of leaving it to the garbage collector.
+ *
+ * This runs from an effect cleanup (including unmount), where a throw would surface as an unhandled
+ * error - and a `dispose()` failure is not recoverable from JS anyway. Reaching the catch just means
+ * the instance is left to the GC, which is the previous behaviour; warn so that stays visible.
+ */
+function disposeNow(resizer: Resizer): void {
+  try {
+    resizer.dispose()
+  } catch (error) {
+    console.warn(
+      `[Resizer] dispose() failed, leaving the instance to the GC: ${String((error as Error)?.message ?? error)}`,
+    )
+  }
+}
+
+/**
  * Use a {@linkcode Resizer} with the given options.
  *
  * The {@linkcode Resizer} can be used to resize and convert
@@ -59,7 +76,19 @@ export function useResizer({
   dataType,
   scaleMode,
   pixelLayout,
-}: ResizerOptions): ResizerState {
+  enabled = true,
+}: ResizerOptions & {
+  /**
+   * Whether a {@linkcode Resizer} should exist right now. Defaults to `true`.
+   *
+   * Pass `false` to release the underlying GPU resources (the device, its pipeline/shader caches,
+   * and on Android the imported camera buffers it holds references on) while nothing is being
+   * resized - e.g. while the Camera is paused or the screen is not visible. The hook returns
+   * `state: 'loading'` while disabled and creates a fresh {@linkcode Resizer} when re-enabled, so
+   * callers must already tolerate a momentarily absent `resizer` (as they do on first mount).
+   */
+  enabled?: boolean
+}): ResizerState {
   const [state, setState] = useState<ResizerState>({
     state: 'loading',
     resizer: undefined,
@@ -67,7 +96,14 @@ export function useResizer({
   })
 
   useEffect(() => {
+    if (!enabled) return
     let isCanceled = false
+    // The Resizer created by this effect run, so cleanup can dispose it. A Resizer owns a whole GPU
+    // device (a VkDevice + shader/pipeline caches on Android, a MTLDevice + CVMetalTextureCache on
+    // iOS) and, on Android, an import cache that holds a reference on every camera AHardwareBuffer
+    // it has sampled. Leaving that to the GC means those resources outlive the component by an
+    // unbounded amount, and every options change orphans another whole device.
+    let created: Resizer | undefined
     const load = async () => {
       try {
         const resizer = await createResizer({
@@ -78,17 +114,30 @@ export function useResizer({
           scaleMode: scaleMode,
           pixelLayout: pixelLayout,
         })
-        if (isCanceled) return
+        created = resizer
+        if (isCanceled) {
+          // Deps changed (or we unmounted) while this create was in flight, so nothing will ever
+          // reference this instance.
+          disposeNow(resizer)
+          created = undefined
+          return
+        }
         setState({ state: 'ready', resizer: resizer, error: undefined })
       } catch (error) {
+        if (isCanceled) return
         setState({ state: 'error', resizer: undefined, error: error as Error })
       }
     }
     load()
     return () => {
       isCanceled = true
+      if (created != null) {
+        disposeNow(created)
+        created = undefined
+      }
+      setState({ state: 'loading', resizer: undefined, error: undefined })
     }
-  }, [channelOrder, dataType, height, pixelLayout, scaleMode, width])
+  }, [channelOrder, dataType, height, pixelLayout, scaleMode, width, enabled])
 
   return state
 }


### PR DESCRIPTION
`useResizer` never disposes the `Resizer` it creates, so it is left entirely to the garbage collector.

That is expensive here. A `Resizer` owns a whole GPU device — a `VkDevice` plus shader/pipeline caches on Android, a `MTLDevice` + `CVMetalTextureCache` on iOS — and on Android an import cache that holds a reference on every camera `AHardwareBuffer` it has sampled. Leaving all of that to the GC means:

- **unmount** orphans the device until an unrelated JS-heap GC happens to collect a tiny wrapper object;
- **every options change** (a different model input size, a `scaleMode` switch, ...) orphans *another* whole device, because the effect creates a new one and simply drops the old reference;
- a `createResizer` that is still in flight when the deps change resolves into an instance nothing will ever reference — the current `if (isCanceled) return` drops it on the floor.

None of these are collected promptly, precisely because the pressure is native/GPU memory that Hermes barely accounts for.

## Changes

**Dispose on cleanup.** The effect tracks the instance it created and disposes it in cleanup, including the cancelled-mid-create case. Failures go through a `disposeNow` helper that catches and `console.warn`s instead of throwing — a cleanup throw would surface as an unhandled error, and falling back to the GC is exactly the previous behaviour, so a warning is the right severity.

**Reset state on cleanup.** `setState({ state: 'loading', ... })` so the hook never hands out a `resizer` that was just disposed while the replacement is still being created.

**`if (isCanceled) return` in the catch.** Without it, a create that rejects after the deps changed still writes `state: 'error'` over the newer run's state.

**New `enabled` option** (defaults to `true`). Passing `false` releases the GPU resources while nothing is being resized — the camera is paused, the screen is not visible, and so on — and creates a fresh `Resizer` when re-enabled. The hook reports `state: 'loading'` while disabled, which callers already have to tolerate (they get the same on first mount).

## Notes

This is the JS half of the resizer lifetime work; #4117 is the native half (bounding the `AHardwareBuffer` import cache, and guarding `dispose()` against an in-flight `resize()` — which becomes reachable exactly *because* this PR starts disposing from the JS thread while frames may still be in flight). They touch disjoint files and can land in either order, but this one is much less useful without #4117's `dispose()` guard.

One case is deliberately left alone: if a `GPUFrame` returned by the last `resize()` is still checked out, `dispose()` refuses with `"Previous GPUFrame is still active"` and this hook warns and falls back to the GC. That window is microseconds wide in practice (consumers dispose the `GPUFrame` immediately after copying out of it) and is usually already closed by the time a component unmounts.

## Testing

Run on-device (Android) with a per-frame Frame Processor: verified that unmounting and changing options release the device promptly instead of ratcheting, and that toggling `enabled` around camera pause/resume releases and recreates cleanly. Formatted and linted with the repo's Biome config.
