### PR TITLE
fix: surface `configure()` rejections to `onError` instead of swallowing them

### DIFF
--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
@@ -16,6 +16,7 @@ interface Config extends CameraSessionConfiguration {
   onSessionConfigSelected?: (config: CameraSessionConfig) => void
 
   onConfigured?: () => void
+  onError?: (error: Error) => void
   getInitialZoom?: () => number | undefined
   getInitialExposureBias?: () => number | undefined
 }
@@ -39,6 +40,7 @@ export function useCameraController(
     allowHapticsAndSystemSoundsPlayback,
     getInitialExposureBias,
     onConfigured,
+    onError,
     getInitialZoom,
   }: Config = {},
 ): CameraController | undefined {
@@ -53,6 +55,7 @@ export function useCameraController(
     getInitialZoom ?? (() => undefined),
   )
   const stableOnConfigured = useStableCallback(onConfigured ?? (() => {}))
+  const stableOnError = useStableCallback(onError ?? (() => {}))
   const stableOnSessionConfigSelected = useStableCallback(
     onSessionConfigSelected ?? (() => {}),
   )
@@ -85,26 +88,44 @@ export function useCameraController(
         setController(undefined)
       } else {
         // Device + outputs - configure session
-        const controllers = await session.configure(
-          [
+        const controllers = await session
+          .configure(
+            [
+              {
+                input: device,
+                outputs: stableOutputs.map((o) => ({
+                  output: o,
+                  mirrorMode: mirrorMode,
+                })),
+                constraints: stableConstraints,
+                initialExposureBias: stableGetInitialExposureBias?.(),
+                initialZoom: stableGetInitialZoom?.(),
+                onSessionConfigSelected: stableOnSessionConfigSelected,
+              },
+            ],
             {
-              input: device,
-              outputs: stableOutputs.map((o) => ({
-                output: o,
-                mirrorMode: mirrorMode,
-              })),
-              constraints: stableConstraints,
-              initialExposureBias: stableGetInitialExposureBias?.(),
-              initialZoom: stableGetInitialZoom?.(),
-              onSessionConfigSelected: stableOnSessionConfigSelected,
+              allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
+              allowHapticsAndSystemSoundsPlayback:
+                allowHapticsAndSystemSoundsPlayback,
             },
-          ],
-          {
-            allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
-            allowHapticsAndSystemSoundsPlayback:
-              allowHapticsAndSystemSoundsPlayback,
-          },
-        )
+          )
+          .catch((error: Error) => {
+            // A rejected `configure()` means the CameraSession could never be
+            // built - e.g. the device rejected the requested use-case
+            // combination, or Camera permission was not granted (yet).
+            // Without this handler the rejection is unhandled: no controller
+            // is ever set, nothing reaches `onError`, and the preview stays
+            // black forever with no way for the user to react to it.
+            if (!isCanceled) {
+              setController(undefined)
+              stableOnError(error)
+            }
+            return undefined
+          })
+        if (controllers == null) {
+          // `configure(..)` rejected (and was already reported above).
+          return
+        }
         if (isCanceled) {
           controllers.forEach((c) => {
             c.dispose()
@@ -127,6 +148,7 @@ export function useCameraController(
     allowHapticsAndSystemSoundsPlayback,
     stableOutputs,
     stableOnConfigured,
+    stableOnError,
     stableGetInitialExposureBias,
     stableGetInitialZoom,
     stableOnSessionConfigSelected,

--- a/packages/react-native-vision-camera/src/hooks/useCamera.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCamera.ts
@@ -299,6 +299,9 @@ export function useCamera({
   const controller = useCameraController(session, input, outputs, {
     mirrorMode: mirrorMode,
     onConfigured: onConfigured,
+    // Route CameraSession configuration failures to the same `onError` the
+    // runtime session errors already use.
+    onError: onError,
     getInitialExposureBias: () => getAnimatableNumberInitialValue(exposure),
     getInitialZoom: () => getAnimatableNumberInitialValue(zoom),
     constraints: constraints,


### PR DESCRIPTION
## The problem

`useCameraController` calls `load()` as a floating promise:

```ts
load()
return () => {
  isCanceled = true
}
```

So when `session.configure(..)` rejects, the rejection is unhandled — a LogBox warning in dev, **silent in release**. The effect never sets a `controller`, so the app is left with a permanently black preview, and `onError` never fires. There is no way for the app to detect that anything went wrong.

## Why this is worth fixing

Most of the throw sites reachable from `configure()` are programmer errors you'd hit on your first run (`"Output ... is not of type NativeCameraOutput!"`, `"No Context!"`). Swallowing those is bad, but survivable.

Two classes are **device- and timing-dependent**, and no amount of correct JS prevents them:

**Android** — `cameraProvider.bindToLifecycle(..)` in `HybridCameraSession.kt` throws `IllegalArgumentException` when the resolved use-case / surface combination isn't supported by that particular device's camera. Nothing in VisionCamera throws here; it comes straight out of CameraX and dies in the unhandled promise.

This is not hypothetical — it's how I found it. A frame-output pixel-format configuration that works on the large majority of devices is rejected by CameraX on some, a Galaxy S22 Ultra among them (~10 affected users visible in our crash/analytics data). The only symptom is a black camera that never recovers, with zero diagnostics on any channel. Once the error is surfaced, the app can respond — in our case by falling back to a different pixel format and persisting that choice. Without it there is nothing to respond to.

**iOS** — `configure()` throws `"Camera Permission not yet granted!"` (`HybridCameraSession.swift:42`) when it runs before the permission grant has landed, and `"Audio Permission not yet granted!"` for a connection that requires the mic. Same silent black-preview outcome.

## The change

Two files, and **no public API change**. `onError` is a new field on the *internal* hook's `Config`; from a user's perspective nothing is added — `configure()` failures simply start arriving at the `onError` they already pass to `useCamera` / `<Camera />`, alongside the runtime session errors that already go there.

The shape mirrors how the controller updaters already report failures (`useZoomUpdater` etc. do `controller.setZoom(..).catch(stableOnError)`), so this uses the same `useStableCallback` + `.catch` pattern rather than introducing a new one.

## Relationship to #4084 / #4101

#4084 bundled this together with controller-setter rejection handling, and you closed it noting you'd fixed it in #4101. #4101 covered the **setter** side — the `session.configure(..)` rejection is still unhandled on `main` today. This PR is only the configure half, with none of the setter changes.

## Notes and open questions

1. `onSessionConfigSelected` is invoked natively from inside `configure()` (`HybridCameraSession.kt`), so a throw from that user callback will now arrive at `onError` looking like a configure failure. Deliberate, but worth flagging.
2. The `device == null` branch also floats `session.configure([], {})` with no handler. I left it alone to keep this single-concern — happy to include it if you'd like.
3. Argument evaluation (`getInitialZoom?.()` etc.) happens before `.catch` is attached, so a throw from a user-supplied getter keeps its current behavior instead of being misreported as a configure failure. That's intentional.
4. **Alternative worth considering:** emit configure failures through the session's existing native error listener (`addOnErrorListener`) instead of catching in JS. That's arguably the cleaner design, but it's a two-platform native change rather than a JS-only one. Happy to do it that way instead if you prefer — I went with the minimal fix.

## Testing

The equivalent change has been running in a production app on both platforms via `patch-package` (a variant that routes to a dedicated `onConfigureError` prop rather than reusing `onError`). It is what turned an unexplained, unreportable black preview into an actionable error the app could fall back from.
