### PR TITLE
fix: Emit interface orientation when updates start and on didBecomeActive

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridInterfaceOrientationManager.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridInterfaceOrientationManager.swift
@@ -12,6 +12,7 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
   let source: OrientationSource = .interface
   private(set) var currentOrientation: CameraOrientation? = nil
   private var observer: NSObjectProtocol? = nil
+  private var didBecomeActiveObserver: NSObjectProtocol? = nil
 
   override init() {
     super.init()
@@ -33,6 +34,34 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
 
       // Start new listener (beginGeneratingDeviceOrientationNotifications() can be nested)
       UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+
+      // On a cold launch the window scene is not yet foregroundActive - during
+      // init() and potentially still at this point - so interfaceOrientation
+      // resolves to .unknown (treated as portrait), and orientationDidChange
+      // does not fire until the device physically rotates. An app launched in
+      // landscape therefore renders all outputs 90° rotated until the first
+      // rotation. Emit the current orientation now (in case the scene is
+      // already active), and again when the app becomes active - the moment
+      // the scene state is guaranteed to be correct.
+      let emitCurrentOrientation: () -> Void = { [weak self] in
+        guard let self else { return }
+        let interfaceOrientation = UIApplication.shared.interfaceOrientation
+        guard interfaceOrientation != .unknown else { return }
+        let orientation = CameraOrientation(interfaceOrientation: interfaceOrientation)
+        if self.currentOrientation != orientation {
+          logger.info("Interface orientation resolved: \(orientation.stringValue)")
+          self.currentOrientation = orientation
+          onChanged(orientation)
+        }
+      }
+      emitCurrentOrientation()
+      self.didBecomeActiveObserver = NotificationCenter.default.addObserver(
+        forName: UIApplication.didBecomeActiveNotification,
+        object: nil,
+        queue: .main
+      ) { _ in
+        emitCurrentOrientation()
+      }
 
       self.observer = NotificationCenter.default.addObserver(
         forName: UIDevice.orientationDidChangeNotification,
@@ -61,6 +90,10 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
         logger.info("Stopping interface orientation updates...")
         NotificationCenter.default.removeObserver(observer)
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
+      }
+      if let didBecomeActiveObserver = self.didBecomeActiveObserver {
+        NotificationCenter.default.removeObserver(didBecomeActiveObserver)
+        self.didBecomeActiveObserver = nil
       }
     }
   }


### PR DESCRIPTION
## What

Fixes the camera preview (and all outputs) rendering 90° rotated when an app is **cold-launched while the device is held in landscape** — easiest to reproduce on iPad, where landscape launches are normal. Physically rotating the device once corrects it, and it stays correct for the rest of the session. Both `orientationSource="interface"` and `"device"` reproduce it.

## Root cause

Two things combine in `HybridInterfaceOrientationManager`:

1. `init()` reads `UIApplication.shared.interfaceOrientation`, which filters `connectedScenes` for `.foregroundActive` — but during a cold launch the scene is not yet `foregroundActive`, so the orientation resolves to `.unknown` (treated as portrait). This can still be true by the time `startOrientationUpdates()` runs, since the camera typically starts very early in the launch sequence.
2. After that, updates only come from `UIDevice.orientationDidChangeNotification` — which **never fires until the device is physically rotated**, so the wrong initial value is never corrected.

## Fix

Emit the current interface orientation when orientation updates start (covers warm starts), and re-emit on `UIApplication.didBecomeActiveNotification` — the moment the scene state is guaranteed correct (covers cold launches). The `didBecomeActive` observer is cleaned up in `stopOrientationUpdates()`.

An emit-only-at-`startOrientationUpdates` variant was **not** sufficient in our testing — the scene can still be inactive at that point during a cold launch — which is why the `didBecomeActive` re-emit is the load-bearing part.

## Testing

- Reproduced on iPad mini (6th generation), iPadOS 26, VisionCamera 5.2.0: cold launch in landscape → preview rotated 90°; rotate once → corrects.
- With this fix (applied via patch-package to 5.2.0 and rebuilt): cold landscape launch renders correctly from the first frame; rotation behaviour afterwards unchanged; portrait launches unchanged. Verified through TestFlight on physical hardware.

## Notes

`HybridDeviceOrientationManager` may benefit from a similar guard for its initial reading, but this PR intentionally only touches the interface manager, which is the path we could verify on hardware.
