### PR TITLE
fix: Use `onError` to emit configure/start errors

### DIFF
--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
@@ -15,6 +15,7 @@ interface Config extends CameraSessionConfiguration {
   constraints?: Constraint[]
   onSessionConfigSelected?: (config: CameraSessionConfig) => void
 
+  onError: (error: Error) => void
   onConfigured?: () => void
   getInitialZoom?: () => number | undefined
   getInitialExposureBias?: () => number | undefined
@@ -38,9 +39,10 @@ export function useCameraController(
     allowBackgroundAudioPlayback,
     allowHapticsAndSystemSoundsPlayback,
     getInitialExposureBias,
+    onError,
     onConfigured,
     getInitialZoom,
-  }: Config = {},
+  }: Config,
 ): CameraController | undefined {
   const [controller, setController] = useState<CameraController>()
 
@@ -56,6 +58,7 @@ export function useCameraController(
   const stableOnSessionConfigSelected = useStableCallback(
     onSessionConfigSelected ?? (() => {}),
   )
+  const stableOnError = useStableCallback(onError)
 
   // TODO: Can we use something like useSyncExternalStore or whatever to avoid "wrong" dependencies?
   // biome-ignore lint/correctness/useExhaustiveDependencies: It's an array of objects, we either have to deep-memo or just stringify.
@@ -79,40 +82,44 @@ export function useCameraController(
 
     let isCanceled = false
     const load = async () => {
-      if (device == null) {
-        // No device, configure with empty devices
-        session.configure([], {})
-        setController(undefined)
-      } else {
-        // Device + outputs - configure session
-        const controllers = await session.configure(
-          [
+      try {
+        if (device == null) {
+          // No device, configure with empty devices
+          session.configure([], {})
+          setController(undefined)
+        } else {
+          // Device + outputs - configure session
+          const controllers = await session.configure(
+            [
+              {
+                input: device,
+                outputs: stableOutputs.map((o) => ({
+                  output: o,
+                  mirrorMode: mirrorMode,
+                })),
+                constraints: stableConstraints,
+                initialExposureBias: stableGetInitialExposureBias?.(),
+                initialZoom: stableGetInitialZoom?.(),
+                onSessionConfigSelected: stableOnSessionConfigSelected,
+              },
+            ],
             {
-              input: device,
-              outputs: stableOutputs.map((o) => ({
-                output: o,
-                mirrorMode: mirrorMode,
-              })),
-              constraints: stableConstraints,
-              initialExposureBias: stableGetInitialExposureBias?.(),
-              initialZoom: stableGetInitialZoom?.(),
-              onSessionConfigSelected: stableOnSessionConfigSelected,
+              allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
+              allowHapticsAndSystemSoundsPlayback:
+                allowHapticsAndSystemSoundsPlayback,
             },
-          ],
-          {
-            allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
-            allowHapticsAndSystemSoundsPlayback:
-              allowHapticsAndSystemSoundsPlayback,
-          },
-        )
-        if (isCanceled) {
-          controllers.forEach((c) => {
-            c.dispose()
-          })
-          return
+          )
+          if (isCanceled) {
+            controllers.forEach((c) => {
+              c.dispose()
+            })
+            return
+          }
+          stableOnConfigured?.()
+          setController(controllers[0])
         }
-        stableOnConfigured?.()
-        setController(controllers[0])
+      } catch (error) {
+        stableOnError(error as Error)
       }
     }
     load()
@@ -131,6 +138,7 @@ export function useCameraController(
     stableGetInitialZoom,
     stableOnSessionConfigSelected,
     stableConstraints,
+    stableOnError,
   ])
 
   return controller

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraControllerConfiguration.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraControllerConfiguration.ts
@@ -3,10 +3,12 @@ import type {
   CameraController,
   CameraControllerConfiguration,
 } from '../../specs/CameraController.nitro'
+import { useStableCallback } from './useStableCallback'
 
 export function useCameraControllerConfiguration(
   controller: CameraController | undefined,
   config: CameraControllerConfiguration,
+  onError: (error: Error) => void,
 ): void {
   const memoizedConfig = useMemo<CameraControllerConfiguration>(
     () => ({
@@ -20,6 +22,7 @@ export function useCameraControllerConfiguration(
       config.enableSmoothAutoFocus,
     ],
   )
+  const stableOnError = useStableCallback(onError)
 
   useEffect(() => {
     if (controller == null) return
@@ -28,8 +31,12 @@ export function useCameraControllerConfiguration(
       return
     }
     const load = async () => {
-      await controller.configure(memoizedConfig)
+      try {
+        await controller.configure(memoizedConfig)
+      } catch (error) {
+        stableOnError(error as Error)
+      }
     }
     load()
-  }, [memoizedConfig, controller])
+  }, [memoizedConfig, controller, stableOnError])
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraSession.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraSession.ts
@@ -1,32 +1,40 @@
 import { useEffect, useState } from 'react'
 import type { CameraSession } from '../../specs/session/CameraSession.nitro'
 import { VisionCamera } from '../../VisionCamera'
+import { useStableCallback } from './useStableCallback'
 
 interface Props {
   enableMultiCamSupport: boolean
+  onError: (error: Error) => void
 }
 
 export function useCameraSession({
   enableMultiCamSupport,
+  onError,
 }: Props): CameraSession | undefined {
   const [session, setSession] = useState<CameraSession>()
+  const stableOnError = useStableCallback(onError)
 
   // session creation
   useEffect(() => {
     let isCanceled = false
     const load = async () => {
-      const s = await VisionCamera.createCameraSession(enableMultiCamSupport)
-      if (isCanceled) {
-        s.dispose()
-        return
+      try {
+        const s = await VisionCamera.createCameraSession(enableMultiCamSupport)
+        if (isCanceled) {
+          s.dispose()
+          return
+        }
+        setSession(s)
+      } catch (error) {
+        stableOnError(error as Error)
       }
-      setSession(s)
     }
     load()
     return () => {
       isCanceled = true
     }
-  }, [enableMultiCamSupport])
+  }, [enableMultiCamSupport, stableOnError])
 
   // session teardown
   useEffect(() => {

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraSessionIsRunning.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraSessionIsRunning.ts
@@ -1,19 +1,27 @@
 import { useEffect } from 'react'
 import type { CameraSession } from '../../specs/session/CameraSession.nitro'
+import { useStableCallback } from './useStableCallback'
 
 export function useCameraSessionIsRunning(
   session: CameraSession | undefined,
   isActive: boolean,
+  onError: (error: Error) => void,
 ): void {
+  const stableOnError = useStableCallback(onError)
+
   useEffect(() => {
     if (session == null) return
     const load = async () => {
-      if (isActive) {
-        await session.start()
-      } else {
-        await session.stop()
+      try {
+        if (isActive) {
+          await session.start()
+        } else {
+          await session.stop()
+        }
+      } catch (error) {
+        stableOnError(error as Error)
       }
     }
     load()
-  }, [isActive, session])
+  }, [isActive, session, stableOnError])
 }

--- a/packages/react-native-vision-camera/src/hooks/useCamera.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCamera.ts
@@ -305,18 +305,23 @@ export function useCamera({
     onSessionConfigSelected: onSessionConfigSelected,
     allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
     allowHapticsAndSystemSoundsPlayback: allowHapticsAndSystemSoundsPlayback,
+    onError: onError,
   })
 
   // 5. Configure the Controller with some settings
-  useCameraControllerConfiguration(controller, {
-    enableSmoothAutoFocus: enableSmoothAutoFocus,
-    enableDistortionCorrection: enableDistortionCorrection,
-    enableLowLightBoost: enableLowLightBoost,
-  })
+  useCameraControllerConfiguration(
+    controller,
+    {
+      enableSmoothAutoFocus: enableSmoothAutoFocus,
+      enableDistortionCorrection: enableDistortionCorrection,
+      enableLowLightBoost: enableLowLightBoost,
+    },
+    onError,
+  )
 
   // 6. Start (or stop) the Session if we have a Controller and `isActive` is true.
   const hasController = controller != null
-  useCameraSessionIsRunning(session, isActive && hasController)
+  useCameraSessionIsRunning(session, isActive && hasController, onError)
 
   // 7. Set up listeners and delegate to JS
   useListenerSubscription(session, 'addOnStartedListener', onStarted)

--- a/packages/react-native-vision-camera/src/hooks/useCamera.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCamera.ts
@@ -261,7 +261,10 @@ export function useCamera({
   torchMode,
 }: CameraProps): CameraController | undefined {
   // 1. Create session
-  const session = useCameraSession({ enableMultiCamSupport: false })
+  const session = useCameraSession({
+    enableMultiCamSupport: false,
+    onError: onError,
+  })
 
   // 2. Update output orientations
   const orientationSourceOrUndefined =


### PR DESCRIPTION
Uses the `onError` event in the `<Camera />` component to pass up any kind of asynchronous configuration errors.

- Closes https://github.com/mrousavy/react-native-vision-camera/pull/4119