### PR TITLE
fix: Don't throw in `setTorchMode('off')` if device doesnt have a torch

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -210,6 +210,13 @@ class HybridCameraController(
     return Promise.async {
       when (mode) {
         TorchMode.OFF -> {
+          if (!camera.cameraInfo.hasFlashUnit()) {
+            // We want to turn off the torch, but the device
+            // doesn't have a flash.
+            // We can ignore this call so CameraX doesn't throw.
+            return@async
+          }
+
           camera.cameraControl
             .enableTorch(false)
             .await()


### PR DESCRIPTION
- Fixes https://github.com/mrousavy/react-native-vision-camera/issues/4069