### PR TITLE
fix: detach preview layers before camera teardown

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.camera-view.harness.tsx
@@ -325,6 +325,79 @@ describe('VisionCamera - Camera View', () => {
     }
   })
 
+  it('captures a photo before unmounting and remounting the Camera view', async () => {
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      const cameraRef = createRef<CameraRef>()
+      const layout = deferred<Layout>()
+      const started = deferred()
+      const previewStarted = deferred()
+      const onError = fn((error: Error) => {
+        layout.reject(error)
+        started.reject(error)
+        previewStarted.reject(error)
+      })
+
+      const { unmount } = await render(
+        <Camera
+          ref={cameraRef}
+          device={backDevice}
+          isActive={true}
+          outputs={[photoOutput]}
+          style={StyleSheet.absoluteFill}
+          onLayout={(event) => {
+            layout.resolve(toLayout(event))
+          }}
+          onStarted={started.resolve}
+          onPreviewStarted={previewStarted.resolve}
+          onError={onError}
+        />,
+      )
+
+      const cameraLayout = await withTimeout(
+        layout.promise,
+        10_000,
+        `photo remount Camera onLayout attempt ${attempt}`,
+      )
+      await withTimeout(
+        started.promise,
+        15_000,
+        `photo remount Camera onStarted attempt ${attempt}`,
+      )
+      await withTimeout(
+        previewStarted.promise,
+        15_000,
+        `photo remount Camera onPreviewStarted attempt ${attempt}`,
+      )
+      expect(onError).not.toHaveBeenCalled()
+
+      const camera = cameraRef.current
+      if (camera == null) throw new Error('no Camera ref')
+      expectPreviewGeometry(camera, cameraLayout)
+
+      const photo = await photoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      try {
+        expect(photo.width).toBeGreaterThan(0)
+        expect(photo.height).toBeGreaterThan(0)
+      } finally {
+        photo.dispose()
+      }
+
+      // Do not wait for a timer here. This intentionally exercises the
+      // unmount/remount boundary that can race with native session teardown.
+      unmount()
+    }
+  })
+
   it('replaces an active Camera view with another active Camera view in one update', async () => {
     const firstRef = createRef<CameraRef>()
     const secondRef = createRef<CameraRef>()

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
@@ -66,6 +66,12 @@ final class HybridCameraSession: HybridCameraSessionSpec {
         )
       }
 
+      // Removing an input or output can implicitly remove its AVCaptureConnection
+      // before updateConnections(...) gets a chance to inspect it. Detach preview
+      // layers first so they do not keep a stale reference to this session while
+      // the Camera view is being unmounted.
+      self.detachUnwantedPreviewLayers(connections)
+
       // Remove all unwanted inputs and add all new inputs
       try self.updateInputs(connections)
       // Remove all unwanted outputs and add all new outputs
@@ -358,6 +364,17 @@ final class HybridCameraSession: HybridCameraSessionSpec {
             }
           }
         }
+      }
+    }
+  }
+
+  private func detachUnwantedPreviewLayers(
+    _ targetConnections: [ResolvedCameraSessionConnection]
+  ) {
+    for currentConnection in self.session.connections {
+      let containsConnection = targetConnections.contains { $0.contains(connection: currentConnection) }
+      if !containsConnection {
+        currentConnection.videoPreviewLayer?.session = nil
       }
     }
   }


### PR DESCRIPTION
Detaches unwanted iOS preview layers before AVCaptureSession removes inputs or outputs.

Adds a Harness regression test covering photo capture followed by Camera unmount and remount.

Validated on a physical iPhone 17 Pro running iOS 26.5.