### PR TITLE
docs: format llms.txt as Markdown

### DIFF
--- a/docs/src/lib/llms.test.ts
+++ b/docs/src/lib/llms.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test'
+import { getLLMIndex } from '@/lib/llms'
+import { absoluteUrl, getMarkdownPath } from '@/lib/site-config'
+
+describe('getLLMIndex', () => {
+  test('composes the Fumadocs page trees with Markdown page URLs', async () => {
+    const index = await getLLMIndex()
+
+    expect(index).toStartWith('# VisionCamera documentation')
+    expect(index).toContain('## Guides')
+    expect(index).not.toContain('- **Guides**')
+    expect(index).toContain('- **Topics**')
+    expect(index).toContain(
+      `- [Zooming](${absoluteUrl(getMarkdownPath('/docs/zooming'))})`,
+    )
+    expect(index).toContain('## API Reference')
+    expect(index).toContain(
+      `[CameraSession](${absoluteUrl(getMarkdownPath('/api/react-native-vision-camera/hybrid-objects/CameraSession'))})`,
+    )
+    expect(index).not.toContain('VisionCamera guide covering')
+  })
+})

--- a/docs/src/lib/llms.ts
+++ b/docs/src/lib/llms.ts
@@ -1,3 +1,5 @@
+import type { Item, Node } from 'fumadocs-core/page-tree'
+import { llms } from 'fumadocs-core/source'
 import { getLLMCorpus } from '@/lib/get-llm-corpus'
 import { absoluteUrl, getMarkdownPath, siteConfig } from '@/lib/site-config'
 import { apiSource, docsSource } from '@/lib/source'
@@ -15,19 +17,44 @@ function normalizeSlug(slug: string[] | undefined): string[] | undefined {
   return Array.isArray(slug) && slug.length > 0 ? slug : undefined
 }
 
+function withMarkdownUrl(page: Item): Item {
+  if (page.external === true) {
+    return page
+  }
+
+  return {
+    ...page,
+    url: absoluteUrl(getMarkdownPath(page.url)),
+  }
+}
+
+function withMarkdownUrls(node: Node): Node {
+  if (node.type === 'page') {
+    return withMarkdownUrl(node)
+  }
+
+  if (node.type === 'folder') {
+    return {
+      ...node,
+      index: node.index == null ? undefined : withMarkdownUrl(node.index),
+      children: node.children.map(withMarkdownUrls),
+    }
+  }
+
+  return node
+}
+
 function formatIndexSection(scope: Scope): string {
   const pageSource = scope === 'api' ? apiSource : docsSource
+  const generator = scope === 'api' ? llms(apiSource) : llms(docsSource)
   const title = scope === 'api' ? 'API Reference' : 'Guides'
-  const entries = pageSource
-    .getPages()
-    .map((page) => {
-      const pageTitle =
-        typeof page.data.title === 'string' && page.data.title.length > 0
-          ? page.data.title
-          : page.url
-
-      return `- ${pageTitle}: ${absoluteUrl(getMarkdownPath(page.url))}`
-    })
+  const nodes = pageSource.getPageTree().children
+  const sectionNodes =
+    nodes[0]?.type === 'separator' && nodes[0].name === title
+      ? nodes.slice(1)
+      : nodes
+  const entries = sectionNodes
+    .map((node) => generator.indexNode(withMarkdownUrls(node)).trim())
     .join('\n')
 
   return `## ${title}\n\n${entries}`


### PR DESCRIPTION
## Summary

- generate `llms.txt` entries through Fumadocs' official `llms()` API
- compose the separate guide and API page trees with `indexNode()`
- preserve Fumadocs' hierarchy, Markdown formatting, escaping, titles, and future source descriptions
- point every internal entry at its absolute `.md` representation

## Why

Fumadocs already owns page-tree traversal and the standard Markdown index format, so this keeps only a thin composition layer for VisionCamera's separate guide/API loaders and a small URL adapter for the public `.md` aliases.

Missing descriptions remain omitted instead of being replaced with generic boilerplate.

- [Fumadocs AI & LLMs integration](https://www.fumadocs.dev/docs/integrations/llms)
- [llms.txt proposal](https://llmstxt.org/)

## Impact

`llms.txt` now uses standard Markdown links, follows the documentation hierarchy, and lists all 271 guide/API pages at their machine-readable `.md` URLs.

## Validation

- `bun test ./src` — 14 passed
- `bun run lint` — passed (existing warnings only)
- Fumadocs generation, Next type generation, and both TypeScript checks — passed
- `bun run check:links` — 271 pages, no broken internal links
- production Next.js webpack build — 551 static pages generated
- output audit — 271 unique `.md` links for 271 pages
- `git diff --check` — passed
