### PR TITLE
docs: serve Markdown pages at .md URLs

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -16,12 +16,28 @@ const config = {
   },
   rewrites: async () => [
     {
+      source: '/docs.md',
+      destination: '/llms.mdx/docs',
+    },
+    {
+      source: '/docs/:path*.md',
+      destination: '/llms.mdx/docs/:path*',
+    },
+    {
       source: '/docs.mdx',
       destination: '/llms.mdx/docs',
     },
     {
       source: '/docs/:path*.mdx',
       destination: '/llms.mdx/docs/:path*',
+    },
+    {
+      source: '/api.md',
+      destination: '/llms.mdx/api',
+    },
+    {
+      source: '/api/:path*.md',
+      destination: '/llms.mdx/api/:path*',
     },
     {
       source: '/api.mdx',

--- a/docs/src/components/page-actions.tsx
+++ b/docs/src/components/page-actions.tsx
@@ -32,7 +32,7 @@ async function getMarkdownContent(markdownUrl: string): Promise<string> {
 
 export function LLMCopyButton({
   /**
-   * A URL to fetch the raw Markdown/MDX content of page
+   * A URL to fetch the Markdown content of a page
    */
   markdownUrl,
 }: {
@@ -141,7 +141,7 @@ export function ViewOptions({
   githubUrl,
 }: {
   /**
-   * A URL to the raw Markdown/MDX content of page
+   * A URL to the Markdown content of a page
    */
   markdownUrl: string
 

--- a/docs/src/lib/llms.ts
+++ b/docs/src/lib/llms.ts
@@ -61,7 +61,7 @@ export async function getLLMIndex(): Promise<string> {
   return [
     `# ${siteConfig.name} documentation`,
     '',
-    'Use the `.mdx` page endpoints for source-friendly markdown. Use `/llms-full.txt` for the full corpus.',
+    'Use the `.md` page endpoints for source-friendly markdown. Use `/llms-full.txt` for the full corpus.',
     '',
     formatIndexSection('docs'),
     '',

--- a/docs/src/lib/site-config.test.ts
+++ b/docs/src/lib/site-config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test'
+import { getMarkdownPath } from '@/lib/site-config'
+
+describe('getMarkdownPath', () => {
+  test('uses the interoperable .md suffix', () => {
+    expect(getMarkdownPath('/docs/zooming')).toBe('/docs/zooming.md')
+    expect(getMarkdownPath('/api')).toBe('/api.md')
+  })
+})

--- a/docs/src/lib/site-config.ts
+++ b/docs/src/lib/site-config.ts
@@ -28,7 +28,7 @@ export function absoluteUrl(pathname: string): string {
 }
 
 export function getMarkdownPath(pageUrl: string): string {
-  return `${pageUrl}.mdx`
+  return `${pageUrl}.md`
 }
 
 export function getOgImageUrl(pageUrl: string): string {

--- a/docs/src/proxy.ts
+++ b/docs/src/proxy.ts
@@ -17,11 +17,14 @@ export const config = {
 }
 
 export default function proxy(request: NextRequest) {
-  if (!isMarkdownPreferred(request)) {
+  const pathname = request.nextUrl.pathname
+  const isExplicitMarkdownPath =
+    pathname.endsWith('.md') || pathname.endsWith('.mdx')
+
+  if (isExplicitMarkdownPath || !isMarkdownPreferred(request)) {
     return NextResponse.next()
   }
 
-  const pathname = request.nextUrl.pathname
   const result = [
     rewriteDocsRoot(pathname),
     rewriteDocsMarkdown(pathname),


### PR DESCRIPTION
## Summary

- add `.md` aliases for guide and API Markdown routes
- make generated links and page actions prefer the interoperable `.md` suffix
- retain all existing `.mdx` routes for compatibility
- prevent Accept negotiation from reprocessing explicit `.md` and `.mdx` URLs

## Why

The generated responses contain processed Markdown, so `.md` is the more widely understood public suffix. Explicit Markdown paths also need to bypass content negotiation so clients that send `Accept: text/markdown` do not accidentally include the suffix in the internal page slug.

## Impact

Existing `.mdx` URLs continue to work. New and generated links prefer `.md`.

## Validation

- `bun test src/lib/site-config.test.ts` — passed
- Biome check on all changed files
- `git diff --check`
- production route behavior previously exercised for guide and API root/nested aliases
