### PR TITLE
docs: add metadata to Markdown responses

### DIFF
--- a/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import { getLLMText } from '@/lib/get-llm-text'
 import { getLLMIndex, resolveScopedPage } from '@/lib/llms'
+import { createMarkdownResponse } from '@/lib/llms-response'
 import { apiSource, docsSource } from '@/lib/source'
 
 export const revalidate = false
@@ -11,21 +12,16 @@ export async function GET(
 ) {
   const { slug } = await params
   if (!Array.isArray(slug) || slug.length === 0) {
-    return new Response(await getLLMIndex(), {
-      headers: {
-        'Content-Type': 'text/markdown',
-      },
-    })
+    return createMarkdownResponse(await getLLMIndex(), '/llms.txt')
   }
 
   const resolved = resolveScopedPage(slug)
   if (resolved == null) notFound()
 
-  return new Response(await getLLMText(resolved.page, resolved.scope), {
-    headers: {
-      'Content-Type': 'text/markdown',
-    },
-  })
+  return createMarkdownResponse(
+    await getLLMText(resolved.page, resolved.scope),
+    resolved.page.url,
+  )
 }
 
 export function generateStaticParams() {

--- a/docs/src/lib/llms-response.test.ts
+++ b/docs/src/lib/llms-response.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test'
+import { createMarkdownResponse } from '@/lib/llms-response'
+
+describe('createMarkdownResponse', () => {
+  test('identifies Markdown content, cache variance, and its canonical HTML page', async () => {
+    const response = createMarkdownResponse('# Zooming', '/docs/zooming')
+
+    expect(response.headers.get('Content-Type')).toBe(
+      'text/markdown; charset=utf-8',
+    )
+    expect(response.headers.get('Vary')).toBe('Accept')
+    expect(response.headers.get('Link')).toBe(
+      '<https://visioncamera.margelo.com/docs/zooming>; rel="canonical"',
+    )
+    expect(await response.text()).toBe('# Zooming')
+  })
+})

--- a/docs/src/lib/llms-response.ts
+++ b/docs/src/lib/llms-response.ts
@@ -1,0 +1,14 @@
+import { absoluteUrl } from '@/lib/site-config'
+
+export function createMarkdownResponse(
+  content: string,
+  canonicalPath: string,
+): Response {
+  return new Response(content, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      Link: `<${absoluteUrl(canonicalPath)}>; rel="canonical"`,
+      Vary: 'Accept',
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- serve Markdown with `text/markdown; charset=utf-8`
- add `Vary: Accept` for content-negotiated caches
- attach an HTTP `Link` canonical pointing each Markdown page to its HTML page
- canonicalize the internal Markdown index route to `/llms.txt`
- centralize these headers in one response helper

## Why

Markdown representations duplicate the human-facing documentation at separate URLs. Explicit response metadata keeps content negotiation cache-safe and tells search engines which HTML URL is canonical.

## Impact

Response bodies and routes are unchanged. Only response metadata is standardized.

## Validation

- `bun test src/lib/llms-response.test.ts` — passed
- Biome check on all changed files
- `git diff --check`
