### PR TITLE
Move production apps into MDX

### DIFF
--- a/docs/content/docs/production-apps.mdx
+++ b/docs/content/docs/production-apps.mdx
@@ -4,9 +4,670 @@ description: Popular production apps using react-native-vision-camera
 icon: BadgeCheck
 ---
 
-import { ProductionAppsShowcase } from '@/components/production-apps-showcase'
+import {
+  InstallMetric,
+  ProductionApp,
+  ProductionAppsShowcase,
+} from '@/components/production-apps-showcase'
 
-<ProductionAppsShowcase />
+<ProductionAppsShowcase>
+  <ProductionApp
+    name="Amazon Shopping"
+    company="Amazon"
+    iconSrc="/img/production-apps/amazon-shopping.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/amazon-shopping/id297606951"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.amazon.mShop.android.shopping"
+  >
+    <InstallMetric kind="monthly-downloads" value={2_000_000}>2M/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={1_000_000_000}>1B+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="PlayStation App"
+    company="PlayStation Mobile"
+    iconSrc="/img/production-apps/playstation-app.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/playstation-app/id410896080"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.scee.psxandroid"
+  >
+    <InstallMetric kind="monthly-downloads" value={800_000}>800K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={100_000_000}>100M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Xbox"
+    company="Microsoft"
+    iconSrc="/img/production-apps/xbox.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/xbox/id736179781"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.microsoft.xboxone.smartglass"
+  >
+    <InstallMetric kind="monthly-downloads" value={600_000}>600K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={100_000_000}>100M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Evernote"
+    company="Bending Spoons"
+    iconSrc="/img/production-apps/evernote.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/evernote-notes-organizer/id281796108"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.evernote"
+  >
+    <InstallMetric kind="lifetime-installs" value={100_000_000}>100M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="AT&amp;T"
+    company="AT&amp;T Services"
+    iconSrc="/img/production-apps/att.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/at-t/id309172177"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.att.myWireless"
+  >
+    <InstallMetric kind="lifetime-installs" value={100_000_000}>100M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Klarna"
+    company="Klarna Bank"
+    iconSrc="/img/production-apps/klarna.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/klarna-smarter-everyday-money/id1115120118"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.myklarnamobile"
+  >
+    <InstallMetric kind="monthly-downloads" value={1_000_000}>1M/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={50_000_000}>50M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="OfferUp"
+    company="OfferUp"
+    iconSrc="/img/production-apps/offerup.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/offerup-buy-sell-marketplace/id468996152"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.offerup"
+  >
+    <InstallMetric kind="monthly-downloads" value={300_000}>300K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={50_000_000}>50M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Locket Widget"
+    company="Locket Labs"
+    iconSrc="/img/production-apps/locket.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/locket-widget/id1600525061"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.locket.Locket"
+  >
+    <InstallMetric kind="monthly-downloads" value={800_000}>800K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Starlink"
+    company="SpaceX"
+    iconSrc="/img/production-apps/starlink.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/starlink/id1537177988"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.starlink.mobile"
+  >
+    <InstallMetric kind="monthly-downloads" value={500_000}>500K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Remitly"
+    company="Remitly"
+    iconSrc="/img/production-apps/remitly.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/remitly-send-money-abroad/id674258465"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.remitly.androidapp"
+  >
+    <InstallMetric kind="monthly-downloads" value={500_000}>500K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Shopify"
+    company="Shopify"
+    iconSrc="/img/production-apps/shopify.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/shopify-sell-online-in-person/id371294472"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.shopify.mobile"
+  >
+    <InstallMetric kind="monthly-downloads" value={400_000}>400K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Best Buy"
+    company="Best Buy"
+    iconSrc="/img/production-apps/best-buy.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/best-buy-tech-deals-savings/id314855255"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.bestbuy.android"
+  >
+    <InstallMetric kind="monthly-downloads" value={400_000}>400K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Urban Company"
+    company="Urban Company"
+    iconSrc="/img/production-apps/urban-company.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/urban-company-home-services/id1032480595"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.urbanclap.urbanclap"
+  >
+    <InstallMetric kind="monthly-downloads" value={300_000}>300K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="SONIC"
+    company="Sonic Industries"
+    iconSrc="/img/production-apps/sonic-drive-in.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/sonic-drive-in-order-online/id867827909"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.sonic.sonicdrivein"
+  >
+    <InstallMetric kind="monthly-downloads" value={200_000}>200K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="MetaMask"
+    company="Consensys"
+    iconSrc="/img/production-apps/metamask.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/metamask-trade-crypto/id1438144202"
+    playStoreUrl="https://play.google.com/store/apps/details?id=io.metamask"
+  >
+    <InstallMetric kind="monthly-downloads" value={100_000}>100K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Spaces by Wix"
+    company="Wix.com"
+    iconSrc="/img/production-apps/spaces-by-wix.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/spaces-follow-businesses/id1099748482"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.wix.android"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="I Am Sober"
+    company="I Am Sober"
+    iconSrc="/img/production-apps/i-am-sober.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/i-am-sober/id672904239"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.thehungrywasp.iamsober"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="myChevrolet"
+    company="General Motors"
+    iconSrc="/img/production-apps/mychevrolet.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/mychevrolet/id398596699"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.gm.chevrolet.nomad.ownership"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Daily Astrology Horoscope"
+    company="Appsella"
+    iconSrc="/img/production-apps/daily-astrology-horoscope.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/daily-astrology-horoscope/id1448364002"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.fortunescope"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="BodyFast"
+    company="BodyFast"
+    iconSrc="/img/production-apps/bodyfast.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/bodyfast-intermittent-fasting/id1189568780"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.bodyfast"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Kompanion"
+    company="Kompanion"
+    iconSrc="/img/production-apps/kompanion.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/kompanion-weight-loss-plan/id1576161548"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.kompanion.fasting.android"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="GasBuddy"
+    company="PDI Technologies"
+    iconSrc="/img/production-apps/gasbuddy.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/gasbuddy-find-pay-for-gas/id406719683"
+    playStoreUrl="https://play.google.com/store/apps/details?id=gbis.gbandroid"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Tellonym"
+    company="Callosum Software"
+    iconSrc="/img/production-apps/tellonym.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/tellonym-ask-me-anything/id1265133033"
+    playStoreUrl="https://play.google.com/store/apps/details?id=de.tellonym.app"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="SUSH"
+    company="Emotion Studio"
+    iconSrc="/img/production-apps/sush.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/sush-virtual-pet-grow-evolve/id1622502023"
+    playStoreUrl="https://play.google.com/store/apps/details?id=app.grotinou.sushi"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Ultimate Guitar"
+    company="Ultimate Guitar"
+    iconSrc="/img/production-apps/ultimate-guitar.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/ultimate-guitar-chords-tabs/id357828853"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.ultimateguitar.tabs"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="MuseScore"
+    company="MuseScore"
+    iconSrc="/img/production-apps/musescore.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/musescore-sheet-music-chords/id835731296"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.musescore.playerlite"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="magicplan"
+    company="magicplan"
+    iconSrc="/img/production-apps/magicplan.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/magicplan/id427424432"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.sensopia.magicplan"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Home AI"
+    company="HubX"
+    iconSrc="/img/production-apps/home-ai.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/home-ai-ai-interior-design/id6464476667"
+    playStoreUrl="https://play.google.com/store/apps/details?id=interior.home.design.ai"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Guess Up"
+    company="Cosmicode"
+    iconSrc="/img/production-apps/guess-up.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/charades-headbands-guess-up/id1160484607"
+    playStoreUrl="https://play.google.com/store/apps/details?id=pt.cosmicode.guessup"
+  >
+    <InstallMetric kind="lifetime-installs" value={10_000_000}>10M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="OnePay"
+    company="One Finance"
+    iconSrc="/img/production-apps/onepay.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/onepay-mobile-banking/id1494523953"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.onefinance.one"
+  >
+    <InstallMetric kind="monthly-downloads" value={600_000}>600K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Tesla"
+    company="Tesla"
+    iconSrc="/img/production-apps/tesla.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/tesla/id582007913"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.teslamotors.tesla"
+  >
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="UnitedHealthcare"
+    company="UnitedHealthcare"
+    iconSrc="/img/production-apps/unitedhealthcare.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/unitedhealthcare/id1348316600"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.mobile.uhc"
+  >
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="PUMA"
+    company="PUMA"
+    iconSrc="/img/production-apps/puma.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/puma-clothes-sneakers-app/id1563024677"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.puma.ecom.app"
+  >
+    <InstallMetric kind="monthly-downloads" value={100_000}>100K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Picnic"
+    company="Picnic"
+    iconSrc="/img/production-apps/picnic.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/picnic-order-cook-eat/id1018175041"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.picnic.android"
+  >
+    <InstallMetric kind="monthly-downloads" value={90_000}>90K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Arby's"
+    company="Arby's"
+    iconSrc="/img/production-apps/arbys.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/arbys-fast-food-sandwiches/id1348507359"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.arbys.android.arbysapp"
+  >
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Buffalo Wild Wings"
+    company="Buffalo Wild Wings"
+    iconSrc="/img/production-apps/buffalo-wild-wings.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/buffalo-wild-wings/id1031364004"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.buffalowildwings.blazinrewards"
+  >
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="BoldVoice"
+    company="Wellocution"
+    iconSrc="/img/production-apps/boldvoice.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/boldvoice-accent-training/id1567841142"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.wellocution.androidapp"
+  >
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ downloads claimed</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Tattoo AI"
+    company="HubX"
+    iconSrc="/img/production-apps/tattoo-ai.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/tattoo-ai-tattoo-design/id6479689893"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.hubx.tattoo"
+  >
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Momo"
+    company="ScaleUp"
+    iconSrc="/img/production-apps/momo.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/momo-ai-photo-video-maker/id1658822260"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.scaleup.dreame"
+  >
+    <InstallMetric kind="lifetime-installs" value={5_000_000}>5M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Ledger Live"
+    company="Ledger"
+    iconSrc="/img/production-apps/ledger-live.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/ledger-wallet-crypto-app/id1361671700"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.ledger.live"
+  >
+    <InstallMetric kind="monthly-downloads" value={30_000}>30K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Expensify"
+    company="Expensify"
+    iconSrc="/img/production-apps/expensify.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/expensify-travel-expense/id471713959"
+    playStoreUrl="https://play.google.com/store/apps/details?id=org.me.mobiexpensifyg"
+  >
+    <InstallMetric kind="monthly-downloads" value={20_000}>20K/mo App Store downloads est.</InstallMetric>
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Toyota Financial Services"
+    company="Toyota Motor Credit"
+    iconSrc="/img/production-apps/toyota-financial-services.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/toyota-financial-services/id472110881"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.tmcc.click2pay.mytfs"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Amazon Business"
+    company="Amazon"
+    iconSrc="/img/production-apps/amazon-business.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/amazon-business-b2b-shopping/id1498197033"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.amazon.mShop.android.business.shopping"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Amazon Shopper Panel"
+    company="Amazon"
+    iconSrc="/img/production-apps/amazon-shopper-panel.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/amazon-shopper-panel/id1494755014"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.amazon.shopperpanel.android.mobile.app"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="myGMC"
+    company="General Motors"
+    iconSrc="/img/production-apps/mygmc.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/mygmc/id399408958"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.gm.gmc.nomad.ownership"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="B-hyve"
+    company="Orbit Irrigation"
+    iconSrc="/img/production-apps/b-hyve.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/b-hyve/id1066451939"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.orbit.orbitsmarthome"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="RISE"
+    company="Rise Science"
+    iconSrc="/img/production-apps/rise.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/rise-sleep-tracker/id1453884781"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.risesci.nyx"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="ABC Trainerize"
+    company="Trainerize"
+    iconSrc="/img/production-apps/abc-trainerize.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/fitness-app-abc-trainerize/id516851502"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.trainerize.Trainerize"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="MyWalmart"
+    company="Walmart"
+    iconSrc="/img/production-apps/mywalmart.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/mywalmart/id1459898418"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.walmart.squiggly"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Connecteam"
+    company="Connecteam"
+    iconSrc="/img/production-apps/connecteam.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/connecteam-team-management-app/id1121613912"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.connecteamco.Connecteam.app"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Instawork"
+    company="Instawork"
+    iconSrc="/img/production-apps/instawork.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/instawork-work-when-you-want/id1123819773"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.instaworkmobile"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Shiftsmart"
+    company="Shiftsmart"
+    iconSrc="/img/production-apps/shiftsmart.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/shiftsmart-find-work/id1235930724"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.shiftsmart.workerapp"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Lingvano"
+    company="Lingvano"
+    iconSrc="/img/production-apps/lingvano.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/lingvano-learn-sign-language/id1547252782"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.lingvano.app"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Seek by iNaturalist"
+    company="iNaturalist"
+    iconSrc="/img/production-apps/seek-by-inaturalist.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/seek-by-inaturalist/id1353224144"
+    playStoreUrl="https://play.google.com/store/apps/details?id=org.inaturalist.seek"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="National Car Rental"
+    company="EAN Services"
+    iconSrc="/img/production-apps/national-car-rental.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/national-car-rental/id675304115"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.ehi.national.mobile"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000_000}>1M+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="SnapCalorie"
+    company="Perception Labs"
+    iconSrc="/img/production-apps/snapcalorie.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/snapcalorie-ai-calorie-counter/id1574239307"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.snapcalorie.alpha002"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Veho Driver"
+    company="Veho"
+    iconSrc="/img/production-apps/veho-driver.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/veho-driver/id1457078986"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.vehotechnologies.Driver"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Popl"
+    company="Popl"
+    iconSrc="/img/production-apps/popl.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/popl-ai-lead-capture/id1503939262"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.nfc.popl"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store installs</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Allē"
+    company="AbbVie"
+    iconSrc="/img/production-apps/alle.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/all%C4%93/id720207987"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.allergan.bd.bdmobileapp"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Tactacam REVEAL"
+    company="Tactacam"
+    iconSrc="/img/production-apps/tactacam-reveal.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/tactacam-reveal/id1515339989"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.tactacam.reveal"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Sunoco"
+    company="Sunoco"
+    iconSrc="/img/production-apps/sunoco.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/sunoco/id1145943301"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.sunoco.sunoco"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Luxer One"
+    company="Luxer One"
+    iconSrc="/img/production-apps/luxer-one.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/luxer-one/id1440094075"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.luxerone.mobile.residentapp"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="MyChoice Benefits"
+    company="Businessolver"
+    iconSrc="/img/production-apps/mychoice-benefits.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/mychoice-benefits/id1138970986"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.businessolver.mychoice"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="HoloDex"
+    company="Mavelli"
+    iconSrc="/img/production-apps/holodex.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/holodex-tcg-scan-collect/id6747442689"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.getholodex.app"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="myCadillac"
+    company="General Motors"
+    iconSrc="/img/production-apps/mycadillac.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/mycadillac/id398605251"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.gm.cadillac.nomad.ownership"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="myBuick"
+    company="General Motors"
+    iconSrc="/img/production-apps/mybuick.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/mybuick/id399409835"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.gm.buick.nomad.ownership"
+  >
+    <InstallMetric kind="lifetime-installs" value={500_000}>500K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Peeps"
+    company="ChelleStudio"
+    iconSrc="/img/production-apps/peeps.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/peeps-make-new-friends/id1531639916"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.buttergames.peeps"
+  >
+    <InstallMetric kind="lifetime-installs" value={100_000}>100K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Obico"
+    company="Obico"
+    iconSrc="/img/production-apps/obico.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/klipper-octoprint-obico/id1540646623"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.thespaghettidetective.android"
+  >
+    <InstallMetric kind="lifetime-installs" value={100_000}>100K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="Party Lab"
+    company="MindShark Games"
+    iconSrc="/img/production-apps/party-lab.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/party-lab-exposed-game/id6446330973"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.partylabapp"
+  >
+    <InstallMetric kind="lifetime-installs" value={100_000}>100K+ Play Store downloads</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="VSCO Capture"
+    company="Visual Supply Company"
+    iconSrc="/img/production-apps/vsco-capture.jpg"
+    appStoreUrl="https://apps.apple.com/us/app/vsco-capture-photo-video/id6741483219"
+  >
+    <InstallMetric kind="monthly-downloads" value={10_000}>10K/mo App Store downloads est.</InstallMetric>
+  </ProductionApp>
+  <ProductionApp
+    name="ShadowLens"
+    company="Marc Rousavy"
+    iconSrc="/img/production-apps/shadowlens.jpg"
+    appStoreUrl="https://apps.apple.com/app/shadowlens/id6471849004"
+    playStoreUrl="https://play.google.com/store/apps/details?id=com.mrousavy.shadowlens"
+  >
+    <InstallMetric kind="lifetime-installs" value={1_000}>1K+ Play Store installs</InstallMetric>
+  </ProductionApp>
+</ProductionAppsShowcase>
 
 ### Attribution
 

--- a/docs/src/components/production-apps-showcase.tsx
+++ b/docs/src/components/production-apps-showcase.tsx
@@ -1,1300 +1,67 @@
 import { Cards } from 'fumadocs-ui/components/card'
-import { Download, Package, PencilLine, TrendingUp } from 'lucide-react'
+import {
+  Download,
+  type LucideIcon,
+  Package,
+  PencilLine,
+  TrendingUp,
+} from 'lucide-react'
 import Image, { type StaticImageData } from 'next/image'
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
 import { buttonVariants } from '@/components/ui/button'
 import { cn } from '@/lib/cn'
-import abcTrainerizeIcon from '../../public/img/production-apps/abc-trainerize.jpg'
-import alleIcon from '../../public/img/production-apps/alle.jpg'
-import amazonBusinessIcon from '../../public/img/production-apps/amazon-business.jpg'
-import amazonShopperPanelIcon from '../../public/img/production-apps/amazon-shopper-panel.jpg'
-import amazonShoppingIcon from '../../public/img/production-apps/amazon-shopping.jpg'
-import arbysIcon from '../../public/img/production-apps/arbys.jpg'
-import attIcon from '../../public/img/production-apps/att.jpg'
-import bHyveIcon from '../../public/img/production-apps/b-hyve.jpg'
-import bestBuyIcon from '../../public/img/production-apps/best-buy.jpg'
-import bodyfastIcon from '../../public/img/production-apps/bodyfast.jpg'
-import boldvoiceIcon from '../../public/img/production-apps/boldvoice.jpg'
-import buffaloWildWingsIcon from '../../public/img/production-apps/buffalo-wild-wings.jpg'
-import connecteamIcon from '../../public/img/production-apps/connecteam.jpg'
-import dailyAstrologyHoroscopeIcon from '../../public/img/production-apps/daily-astrology-horoscope.jpg'
-import evernoteIcon from '../../public/img/production-apps/evernote.jpg'
-import expensifyIcon from '../../public/img/production-apps/expensify.jpg'
-import gasbuddyIcon from '../../public/img/production-apps/gasbuddy.jpg'
-import guessUpIcon from '../../public/img/production-apps/guess-up.jpg'
-import holodexIcon from '../../public/img/production-apps/holodex.jpg'
-import homeAiIcon from '../../public/img/production-apps/home-ai.jpg'
-import iAmSoberIcon from '../../public/img/production-apps/i-am-sober.jpg'
-import instaworkIcon from '../../public/img/production-apps/instawork.jpg'
-import klarnaIcon from '../../public/img/production-apps/klarna.jpg'
-import kompanionIcon from '../../public/img/production-apps/kompanion.jpg'
-import ledgerLiveIcon from '../../public/img/production-apps/ledger-live.jpg'
-import lingvanoIcon from '../../public/img/production-apps/lingvano.jpg'
-import locketIcon from '../../public/img/production-apps/locket.jpg'
-import luxerOneIcon from '../../public/img/production-apps/luxer-one.jpg'
-import magicplanIcon from '../../public/img/production-apps/magicplan.jpg'
-import metamaskIcon from '../../public/img/production-apps/metamask.jpg'
-import momoIcon from '../../public/img/production-apps/momo.jpg'
-import musescoreIcon from '../../public/img/production-apps/musescore.jpg'
-import mybuickIcon from '../../public/img/production-apps/mybuick.jpg'
-import mycadillacIcon from '../../public/img/production-apps/mycadillac.jpg'
-import mychevroletIcon from '../../public/img/production-apps/mychevrolet.jpg'
-import mychoiceBenefitsIcon from '../../public/img/production-apps/mychoice-benefits.jpg'
-import mygmcIcon from '../../public/img/production-apps/mygmc.jpg'
-import mywalmartIcon from '../../public/img/production-apps/mywalmart.jpg'
-import nationalCarRentalIcon from '../../public/img/production-apps/national-car-rental.jpg'
-import obicoIcon from '../../public/img/production-apps/obico.jpg'
-import offerupIcon from '../../public/img/production-apps/offerup.jpg'
-import onePayIcon from '../../public/img/production-apps/onepay.jpg'
-import partyLabIcon from '../../public/img/production-apps/party-lab.jpg'
-import peepsIcon from '../../public/img/production-apps/peeps.jpg'
-import picnicIcon from '../../public/img/production-apps/picnic.jpg'
-import playstationAppIcon from '../../public/img/production-apps/playstation-app.jpg'
-import poplIcon from '../../public/img/production-apps/popl.jpg'
-import pumaIcon from '../../public/img/production-apps/puma.jpg'
-import remitlyIcon from '../../public/img/production-apps/remitly.jpg'
-import riseIcon from '../../public/img/production-apps/rise.jpg'
-import seekByInaturalistIcon from '../../public/img/production-apps/seek-by-inaturalist.jpg'
-import shadowlensIcon from '../../public/img/production-apps/shadowlens.jpg'
-import shiftsmartIcon from '../../public/img/production-apps/shiftsmart.jpg'
-import shopifyIcon from '../../public/img/production-apps/shopify.jpg'
-import snapcalorieIcon from '../../public/img/production-apps/snapcalorie.jpg'
-import sonicDriveInIcon from '../../public/img/production-apps/sonic-drive-in.jpg'
-import spacesByWixIcon from '../../public/img/production-apps/spaces-by-wix.jpg'
-import starlinkIcon from '../../public/img/production-apps/starlink.jpg'
-import sunocoIcon from '../../public/img/production-apps/sunoco.jpg'
-import sushIcon from '../../public/img/production-apps/sush.jpg'
-import tactacamRevealIcon from '../../public/img/production-apps/tactacam-reveal.jpg'
-import tattooAiIcon from '../../public/img/production-apps/tattoo-ai.jpg'
-import tellonymIcon from '../../public/img/production-apps/tellonym.jpg'
-import teslaIcon from '../../public/img/production-apps/tesla.jpg'
-import toyotaFinancialServicesIcon from '../../public/img/production-apps/toyota-financial-services.jpg'
-import ultimateGuitarIcon from '../../public/img/production-apps/ultimate-guitar.jpg'
-import unitedhealthcareIcon from '../../public/img/production-apps/unitedhealthcare.jpg'
-import urbanCompanyIcon from '../../public/img/production-apps/urban-company.jpg'
-import vehoDriverIcon from '../../public/img/production-apps/veho-driver.jpg'
-import vscoCaptureIcon from '../../public/img/production-apps/vsco-capture.jpg'
-import xboxIcon from '../../public/img/production-apps/xbox.jpg'
 
-type InstallMetric = {
-  label: string
+// Fumadocs keeps these component props and children in processed Markdown, so
+// the catalog stays readable to LLMs while this component owns the visual UI.
+type InstallMetricKind = 'lifetime-installs' | 'monthly-downloads'
+
+export type InstallMetricProps = {
+  kind: InstallMetricKind
   value: number
-  kind: 'lifetime-installs' | 'monthly-downloads'
+  children: ReactNode
 }
 
-type ProductionApp = {
+export type ProductionAppProps = {
   name: string
   company: string
-  installMetrics: InstallMetric[]
-  iconSrc: StaticImageData
+  iconSrc: string | StaticImageData
   appStoreUrl?: string
   playStoreUrl?: string
+  children: ReactNode
 }
 
-const productionApps: ProductionApp[] = [
-  {
-    name: 'Amazon Shopping',
-    company: 'Amazon',
-    installMetrics: [
-      {
-        label: '2M/mo App Store downloads est.',
-        value: 2_000_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '1B+ Play Store downloads',
-        value: 1_000_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: amazonShoppingIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/amazon-shopping/id297606951',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.amazon.mShop.android.shopping',
-  },
-  {
-    name: 'PlayStation App',
-    company: 'PlayStation Mobile',
-    installMetrics: [
-      {
-        label: '800K/mo App Store downloads est.',
-        value: 800_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '100M+ Play Store installs',
-        value: 100_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: playstationAppIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/playstation-app/id410896080',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.scee.psxandroid',
-  },
-  {
-    name: 'Xbox',
-    company: 'Microsoft',
-    installMetrics: [
-      {
-        label: '600K/mo App Store downloads est.',
-        value: 600_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '100M+ Play Store installs',
-        value: 100_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: xboxIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/xbox/id736179781',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.microsoft.xboxone.smartglass',
-  },
-  {
-    name: 'Evernote',
-    company: 'Bending Spoons',
-    installMetrics: [
-      {
-        label: '100M+ Play Store downloads',
-        value: 100_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: evernoteIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/evernote-notes-organizer/id281796108',
-    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.evernote',
-  },
-  {
-    name: 'AT&T',
-    company: 'AT&T Services',
-    installMetrics: [
-      {
-        label: '100M+ Play Store downloads',
-        value: 100_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: attIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/at-t/id309172177',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.att.myWireless',
-  },
-  {
-    name: 'Klarna',
-    company: 'Klarna Bank',
-    installMetrics: [
-      {
-        label: '1M/mo App Store downloads est.',
-        value: 1_000_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '50M+ Play Store installs',
-        value: 50_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: klarnaIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/klarna-smarter-everyday-money/id1115120118',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.myklarnamobile',
-  },
-  {
-    name: 'OfferUp',
-    company: 'OfferUp',
-    installMetrics: [
-      {
-        label: '300K/mo App Store downloads est.',
-        value: 300_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '50M+ Play Store installs',
-        value: 50_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: offerupIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/offerup-buy-sell-marketplace/id468996152',
-    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.offerup',
-  },
-  {
-    name: 'Locket Widget',
-    company: 'Locket Labs',
-    installMetrics: [
-      {
-        label: '800K/mo App Store downloads est.',
-        value: 800_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: locketIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/locket-widget/id1600525061',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.locket.Locket',
-  },
-  {
-    name: 'Starlink',
-    company: 'SpaceX',
-    installMetrics: [
-      {
-        label: '500K/mo App Store downloads est.',
-        value: 500_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: starlinkIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/starlink/id1537177988',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.starlink.mobile',
-  },
-  {
-    name: 'Remitly',
-    company: 'Remitly',
-    installMetrics: [
-      {
-        label: '500K/mo App Store downloads est.',
-        value: 500_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: remitlyIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/remitly-send-money-abroad/id674258465',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.remitly.androidapp',
-  },
-  {
-    name: 'Shopify',
-    company: 'Shopify',
-    installMetrics: [
-      {
-        label: '400K/mo App Store downloads est.',
-        value: 400_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: shopifyIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/shopify-sell-online-in-person/id371294472',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.shopify.mobile',
-  },
-  {
-    name: 'Best Buy',
-    company: 'Best Buy',
-    installMetrics: [
-      {
-        label: '400K/mo App Store downloads est.',
-        value: 400_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: bestBuyIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/best-buy-tech-deals-savings/id314855255',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.bestbuy.android',
-  },
-  {
-    name: 'Urban Company',
-    company: 'Urban Company',
-    installMetrics: [
-      {
-        label: '300K/mo App Store downloads est.',
-        value: 300_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: urbanCompanyIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/urban-company-home-services/id1032480595',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.urbanclap.urbanclap',
-  },
-  {
-    name: 'SONIC',
-    company: 'Sonic Industries',
-    installMetrics: [
-      {
-        label: '200K/mo App Store downloads est.',
-        value: 200_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: sonicDriveInIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/sonic-drive-in-order-online/id867827909',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.sonic.sonicdrivein',
-  },
-  {
-    name: 'MetaMask',
-    company: 'Consensys',
-    installMetrics: [
-      {
-        label: '100K/mo App Store downloads est.',
-        value: 100_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '10M+ Play Store installs',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: metamaskIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/metamask-trade-crypto/id1438144202',
-    playStoreUrl: 'https://play.google.com/store/apps/details?id=io.metamask',
-  },
-  {
-    name: 'Spaces by Wix',
-    company: 'Wix.com',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: spacesByWixIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/spaces-follow-businesses/id1099748482',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.wix.android',
-  },
-  {
-    name: 'I Am Sober',
-    company: 'I Am Sober',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: iAmSoberIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/i-am-sober/id672904239',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.thehungrywasp.iamsober',
-  },
-  {
-    name: 'myChevrolet',
-    company: 'General Motors',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: mychevroletIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/mychevrolet/id398596699',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.gm.chevrolet.nomad.ownership',
-  },
-  {
-    name: 'Daily Astrology Horoscope',
-    company: 'Appsella',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: dailyAstrologyHoroscopeIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/daily-astrology-horoscope/id1448364002',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.fortunescope',
-  },
-  {
-    name: 'BodyFast',
-    company: 'BodyFast',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: bodyfastIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/bodyfast-intermittent-fasting/id1189568780',
-    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.bodyfast',
-  },
-  {
-    name: 'Kompanion',
-    company: 'Kompanion',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: kompanionIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/kompanion-weight-loss-plan/id1576161548',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.kompanion.fasting.android',
-  },
-  {
-    name: 'GasBuddy',
-    company: 'PDI Technologies',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: gasbuddyIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/gasbuddy-find-pay-for-gas/id406719683',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=gbis.gbandroid',
-  },
-  {
-    name: 'Tellonym',
-    company: 'Callosum Software',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: tellonymIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/tellonym-ask-me-anything/id1265133033',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=de.tellonym.app',
-  },
-  {
-    name: 'SUSH',
-    company: 'Emotion Studio',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: sushIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/sush-virtual-pet-grow-evolve/id1622502023',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=app.grotinou.sushi',
-  },
-  {
-    name: 'Ultimate Guitar',
-    company: 'Ultimate Guitar',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: ultimateGuitarIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/ultimate-guitar-chords-tabs/id357828853',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.ultimateguitar.tabs',
-  },
-  {
-    name: 'MuseScore',
-    company: 'MuseScore',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: musescoreIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/musescore-sheet-music-chords/id835731296',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.musescore.playerlite',
-  },
-  {
-    name: 'magicplan',
-    company: 'magicplan',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: magicplanIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/magicplan/id427424432',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.sensopia.magicplan',
-  },
-  {
-    name: 'Home AI',
-    company: 'HubX',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: homeAiIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/home-ai-ai-interior-design/id6464476667',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=interior.home.design.ai',
-  },
-  {
-    name: 'Guess Up',
-    company: 'Cosmicode',
-    installMetrics: [
-      {
-        label: '10M+ Play Store downloads',
-        value: 10_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: guessUpIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/charades-headbands-guess-up/id1160484607',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=pt.cosmicode.guessup',
-  },
-  {
-    name: 'OnePay',
-    company: 'One Finance',
-    installMetrics: [
-      {
-        label: '600K/mo App Store downloads est.',
-        value: 600_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '5M+ Play Store downloads',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: onePayIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/onepay-mobile-banking/id1494523953',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.onefinance.one',
-  },
-  {
-    name: 'Tesla',
-    company: 'Tesla',
-    installMetrics: [
-      {
-        label: '5M+ Play Store downloads',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: teslaIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/tesla/id582007913',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.teslamotors.tesla',
-  },
-  {
-    name: 'UnitedHealthcare',
-    company: 'UnitedHealthcare',
-    installMetrics: [
-      {
-        label: '5M+ Play Store downloads',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: unitedhealthcareIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/unitedhealthcare/id1348316600',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.mobile.uhc',
-  },
-  {
-    name: 'PUMA',
-    company: 'PUMA',
-    installMetrics: [
-      {
-        label: '100K/mo App Store downloads est.',
-        value: 100_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '5M+ Play Store installs',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: pumaIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/puma-clothes-sneakers-app/id1563024677',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.puma.ecom.app',
-  },
-  {
-    name: 'Picnic',
-    company: 'Picnic',
-    installMetrics: [
-      {
-        label: '90K/mo App Store downloads est.',
-        value: 90_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '5M+ Play Store installs',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: picnicIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/picnic-order-cook-eat/id1018175041',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.picnic.android',
-  },
-  {
-    name: "Arby's",
-    company: "Arby's",
-    installMetrics: [
-      {
-        label: '5M+ Play Store installs',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: arbysIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/arbys-fast-food-sandwiches/id1348507359',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.arbys.android.arbysapp',
-  },
-  {
-    name: 'Buffalo Wild Wings',
-    company: 'Buffalo Wild Wings',
-    installMetrics: [
-      {
-        label: '5M+ Play Store installs',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: buffaloWildWingsIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/buffalo-wild-wings/id1031364004',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.buffalowildwings.blazinrewards',
-  },
-  {
-    name: 'BoldVoice',
-    company: 'Wellocution',
-    installMetrics: [
-      {
-        label: '5M+ downloads claimed',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: boldvoiceIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/boldvoice-accent-training/id1567841142',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.wellocution.androidapp',
-  },
-  {
-    name: 'Tattoo AI',
-    company: 'HubX',
-    installMetrics: [
-      {
-        label: '5M+ Play Store downloads',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: tattooAiIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/tattoo-ai-tattoo-design/id6479689893',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.hubx.tattoo',
-  },
-  {
-    name: 'Momo',
-    company: 'ScaleUp',
-    installMetrics: [
-      {
-        label: '5M+ Play Store downloads',
-        value: 5_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: momoIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/momo-ai-photo-video-maker/id1658822260',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.scaleup.dreame',
-  },
-  {
-    name: 'Ledger Live',
-    company: 'Ledger',
-    installMetrics: [
-      {
-        label: '30K/mo App Store downloads est.',
-        value: 30_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: ledgerLiveIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/ledger-wallet-crypto-app/id1361671700',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.ledger.live',
-  },
-  {
-    name: 'Expensify',
-    company: 'Expensify',
-    installMetrics: [
-      {
-        label: '20K/mo App Store downloads est.',
-        value: 20_000,
-        kind: 'monthly-downloads',
-      },
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: expensifyIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/expensify-travel-expense/id471713959',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=org.me.mobiexpensifyg',
-  },
-  {
-    name: 'Toyota Financial Services',
-    company: 'Toyota Motor Credit',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: toyotaFinancialServicesIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/toyota-financial-services/id472110881',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.tmcc.click2pay.mytfs',
-  },
-  {
-    name: 'Amazon Business',
-    company: 'Amazon',
-    installMetrics: [
-      {
-        label: '1M+ Play Store downloads',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: amazonBusinessIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/amazon-business-b2b-shopping/id1498197033',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.amazon.mShop.android.business.shopping',
-  },
-  {
-    name: 'Amazon Shopper Panel',
-    company: 'Amazon',
-    installMetrics: [
-      {
-        label: '1M+ Play Store downloads',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: amazonShopperPanelIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/amazon-shopper-panel/id1494755014',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.amazon.shopperpanel.android.mobile.app',
-  },
-  {
-    name: 'myGMC',
-    company: 'General Motors',
-    installMetrics: [
-      {
-        label: '1M+ Play Store downloads',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: mygmcIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/mygmc/id399408958',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.gm.gmc.nomad.ownership',
-  },
-  {
-    name: 'B-hyve',
-    company: 'Orbit Irrigation',
-    installMetrics: [
-      {
-        label: '1M+ Play Store downloads',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: bHyveIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/b-hyve/id1066451939',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.orbit.orbitsmarthome',
-  },
-  {
-    name: 'RISE',
-    company: 'Rise Science',
-    installMetrics: [
-      {
-        label: '1M+ Play Store downloads',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: riseIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/rise-sleep-tracker/id1453884781',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.risesci.nyx',
-  },
-  {
-    name: 'ABC Trainerize',
-    company: 'Trainerize',
-    installMetrics: [
-      {
-        label: '1M+ Play Store downloads',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: abcTrainerizeIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/fitness-app-abc-trainerize/id516851502',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.trainerize.Trainerize',
-  },
-  {
-    name: 'MyWalmart',
-    company: 'Walmart',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: mywalmartIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/mywalmart/id1459898418',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.walmart.squiggly',
-  },
-  {
-    name: 'Connecteam',
-    company: 'Connecteam',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: connecteamIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/connecteam-team-management-app/id1121613912',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.connecteamco.Connecteam.app',
-  },
-  {
-    name: 'Instawork',
-    company: 'Instawork',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: instaworkIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/instawork-work-when-you-want/id1123819773',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.instaworkmobile',
-  },
-  {
-    name: 'Shiftsmart',
-    company: 'Shiftsmart',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: shiftsmartIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/shiftsmart-find-work/id1235930724',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.shiftsmart.workerapp',
-  },
-  {
-    name: 'Lingvano',
-    company: 'Lingvano',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: lingvanoIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/lingvano-learn-sign-language/id1547252782',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.lingvano.app',
-  },
-  {
-    name: 'Seek by iNaturalist',
-    company: 'iNaturalist',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: seekByInaturalistIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/seek-by-inaturalist/id1353224144',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=org.inaturalist.seek',
-  },
-  {
-    name: 'National Car Rental',
-    company: 'EAN Services',
-    installMetrics: [
-      {
-        label: '1M+ Play Store installs',
-        value: 1_000_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: nationalCarRentalIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/national-car-rental/id675304115',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.ehi.national.mobile',
-  },
-  {
-    name: 'SnapCalorie',
-    company: 'Perception Labs',
-    installMetrics: [
-      {
-        label: '500K+ Play Store installs',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: snapcalorieIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/snapcalorie-ai-calorie-counter/id1574239307',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.snapcalorie.alpha002',
-  },
-  {
-    name: 'Veho Driver',
-    company: 'Veho',
-    installMetrics: [
-      {
-        label: '500K+ Play Store installs',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: vehoDriverIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/veho-driver/id1457078986',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.vehotechnologies.Driver',
-  },
-  {
-    name: 'Popl',
-    company: 'Popl',
-    installMetrics: [
-      {
-        label: '500K+ Play Store installs',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: poplIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/popl-ai-lead-capture/id1503939262',
-    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.nfc.popl',
-  },
-  {
-    name: 'Allē',
-    company: 'AbbVie',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: alleIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/all%C4%93/id720207987',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.allergan.bd.bdmobileapp',
-  },
-  {
-    name: 'Tactacam REVEAL',
-    company: 'Tactacam',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: tactacamRevealIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/tactacam-reveal/id1515339989',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.tactacam.reveal',
-  },
-  {
-    name: 'Sunoco',
-    company: 'Sunoco',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: sunocoIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/sunoco/id1145943301',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.sunoco.sunoco',
-  },
-  {
-    name: 'Luxer One',
-    company: 'Luxer One',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: luxerOneIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/luxer-one/id1440094075',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.luxerone.mobile.residentapp',
-  },
-  {
-    name: 'MyChoice Benefits',
-    company: 'Businessolver',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: mychoiceBenefitsIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/mychoice-benefits/id1138970986',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.businessolver.mychoice',
-  },
-  {
-    name: 'HoloDex',
-    company: 'Mavelli',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: holodexIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/holodex-tcg-scan-collect/id6747442689',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.getholodex.app',
-  },
-  {
-    name: 'myCadillac',
-    company: 'General Motors',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: mycadillacIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/mycadillac/id398605251',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.gm.cadillac.nomad.ownership',
-  },
-  {
-    name: 'myBuick',
-    company: 'General Motors',
-    installMetrics: [
-      {
-        label: '500K+ Play Store downloads',
-        value: 500_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: mybuickIcon,
-    appStoreUrl: 'https://apps.apple.com/us/app/mybuick/id399409835',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.gm.buick.nomad.ownership',
-  },
-  {
-    name: 'Peeps',
-    company: 'ChelleStudio',
-    installMetrics: [
-      {
-        label: '100K+ Play Store downloads',
-        value: 100_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: peepsIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/peeps-make-new-friends/id1531639916',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.buttergames.peeps',
-  },
-  {
-    name: 'Obico',
-    company: 'Obico',
-    installMetrics: [
-      {
-        label: '100K+ Play Store downloads',
-        value: 100_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: obicoIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/klipper-octoprint-obico/id1540646623',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.thespaghettidetective.android',
-  },
-  {
-    name: 'Party Lab',
-    company: 'MindShark Games',
-    installMetrics: [
-      {
-        label: '100K+ Play Store downloads',
-        value: 100_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: partyLabIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/party-lab-exposed-game/id6446330973',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.partylabapp',
-  },
-  {
-    name: 'VSCO Capture',
-    company: 'Visual Supply Company',
-    installMetrics: [
-      {
-        label: '10K/mo App Store downloads est.',
-        value: 10_000,
-        kind: 'monthly-downloads',
-      },
-    ],
-    iconSrc: vscoCaptureIcon,
-    appStoreUrl:
-      'https://apps.apple.com/us/app/vsco-capture-photo-video/id6741483219',
-  },
-  {
-    name: 'ShadowLens',
-    company: 'Marc Rousavy',
-    installMetrics: [
-      {
-        label: '1K+ Play Store installs',
-        value: 1_000,
-        kind: 'lifetime-installs',
-      },
-    ],
-    iconSrc: shadowlensIcon,
-    appStoreUrl: 'https://apps.apple.com/app/shadowlens/id6471849004',
-    playStoreUrl:
-      'https://play.google.com/store/apps/details?id=com.mrousavy.shadowlens',
-  },
-]
+function isInstallMetric(
+  child: ReactNode,
+): child is ReactElement<InstallMetricProps> {
+  return (
+    isValidElement<InstallMetricProps>(child) && child.type === InstallMetric
+  )
+}
 
-function sumMetrics(kind: InstallMetric['kind']) {
-  return productionApps.reduce(
+function getInstallMetrics(children: ReactNode) {
+  return Children.toArray(children).filter(isInstallMetric)
+}
+
+function isProductionApp(
+  child: ReactNode,
+): child is ReactElement<ProductionAppProps> {
+  return (
+    isValidElement<ProductionAppProps>(child) && child.type === ProductionApp
+  )
+}
+
+function sumMetrics(apps: ProductionAppProps[], kind: InstallMetricKind) {
+  return apps.reduce(
     (sum, app) =>
       sum +
-      app.installMetrics.reduce(
-        (appSum, metric) => appSum + (metric.kind === kind ? metric.value : 0),
+      getInstallMetrics(app.children).reduce(
+        (appSum, metric) =>
+          appSum + (metric.props.kind === kind ? metric.props.value : 0),
         0,
       ),
     0,
@@ -1323,28 +90,36 @@ function formatCompactNumber(value: number) {
   return new Intl.NumberFormat('en').format(value)
 }
 
-const knownInstallTotal = sumMetrics('lifetime-installs')
-const appStoreMonthlyDownloadTotal = sumMetrics('monthly-downloads')
 const npmPackageDownloadTotal = 33_880_333
-const heroIconApps = productionApps.slice(0, 8)
 
-const summaryStats = [
-  {
-    label: 'Known installs/downloads',
-    value: `${formatCompactNumber(knownInstallTotal)}+`,
-    icon: Download,
-  },
-  {
-    label: 'App Store downloads/mo',
-    value: `${formatCompactNumber(appStoreMonthlyDownloadTotal)}+`,
-    icon: TrendingUp,
-  },
-  {
-    label: 'Total npm downloads',
-    value: `${formatCompactNumber(npmPackageDownloadTotal)}+`,
-    icon: Package,
-  },
-]
+type SummaryStat = {
+  label: string
+  value: string
+  icon: LucideIcon
+}
+
+function createSummaryStats(apps: ProductionAppProps[]): SummaryStat[] {
+  const knownInstallTotal = sumMetrics(apps, 'lifetime-installs')
+  const appStoreMonthlyDownloadTotal = sumMetrics(apps, 'monthly-downloads')
+
+  return [
+    {
+      label: 'Known installs/downloads',
+      value: `${formatCompactNumber(knownInstallTotal)}+`,
+      icon: Download,
+    },
+    {
+      label: 'App Store downloads/mo',
+      value: `${formatCompactNumber(appStoreMonthlyDownloadTotal)}+`,
+      icon: TrendingUp,
+    },
+    {
+      label: 'Total npm downloads',
+      value: `${formatCompactNumber(npmPackageDownloadTotal)}+`,
+      icon: Package,
+    },
+  ]
+}
 
 // Drawn locally so we do not ship Apple's Design Resources as website content.
 function AppIconGridPlaceholder({ className }: { className?: string }) {
@@ -1381,7 +156,7 @@ function AppIcon({
   decorative = false,
   size,
 }: {
-  app: ProductionApp
+  app: ProductionAppProps
   className?: string
   decorative?: boolean
   size: number
@@ -1444,10 +219,10 @@ function AddYourAppCard() {
   )
 }
 
-function AppIconStack() {
+function AppIconStack({ apps }: { apps: ProductionAppProps[] }) {
   return (
     <div className="-space-x-4 flex max-w-full shrink-0 items-center overflow-hidden pl-2 xl:-space-x-3">
-      {heroIconApps.map((app) => (
+      {apps.map((app) => (
         <AppIcon
           key={app.name}
           app={app}
@@ -1460,11 +235,7 @@ function AppIconStack() {
   )
 }
 
-function SummaryStat({
-  label,
-  value,
-  icon: Icon,
-}: (typeof summaryStats)[number]) {
+function SummaryStat({ label, value, icon: Icon }: SummaryStat) {
   return (
     <div className="flex items-center gap-3 py-3 sm:border-l sm:border-fd-border sm:pl-5 sm:first:border-l-0 sm:first:pl-0">
       <span className="flex size-9 shrink-0 items-center justify-center rounded-md border border-fd-border bg-fd-muted text-fd-muted-foreground">
@@ -1496,7 +267,9 @@ function StoreLink({ href, label }: { href: string; label: string }) {
   )
 }
 
-function AppCard({ app }: { app: ProductionApp }) {
+function AppCard({ app }: { app: ProductionAppProps }) {
+  const installMetrics = getInstallMetrics(app.children)
+
   return (
     <div
       className="flex h-full flex-col gap-4 rounded-lg border border-fd-border bg-fd-card p-4 shadow-sm transition-colors hover:border-fd-primary/45"
@@ -1513,18 +286,8 @@ function AppCard({ app }: { app: ProductionApp }) {
       </div>
 
       <div className="flex flex-1 flex-col gap-3 border-t border-fd-border pt-3">
-        {app.installMetrics.length > 0 ? (
-          <div className="grid gap-1.5">
-            {app.installMetrics.map((metric) => (
-              <span
-                key={metric.label}
-                className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium text-fd-muted-foreground"
-              >
-                <Download className="size-3.5 shrink-0" aria-hidden="true" />
-                <span className="truncate">{metric.label}</span>
-              </span>
-            ))}
-          </div>
+        {installMetrics.length > 0 ? (
+          <div className="grid gap-1.5">{installMetrics}</div>
         ) : null}
         <div className="mt-auto flex w-full flex-nowrap items-center gap-2">
           {app.appStoreUrl ? (
@@ -1539,7 +302,25 @@ function AppCard({ app }: { app: ProductionApp }) {
   )
 }
 
-export function ProductionAppsShowcase() {
+export function InstallMetric({ children }: InstallMetricProps) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium text-fd-muted-foreground">
+      <Download className="size-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate">{children}</span>
+    </span>
+  )
+}
+
+export function ProductionApp(props: ProductionAppProps) {
+  return <AppCard app={props} />
+}
+
+export function ProductionAppsShowcase({ children }: { children: ReactNode }) {
+  const appElements = Children.toArray(children).filter(isProductionApp)
+  const productionApps = appElements.map((element) => element.props)
+  const heroIconApps = productionApps.slice(0, 8)
+  const summaryStats = createSummaryStats(productionApps)
+
   return (
     <div className="not-prose mt-8">
       <section className="border-b border-fd-border pb-8">
@@ -1553,7 +334,7 @@ export function ProductionAppsShowcase() {
               production.
             </p>
           </div>
-          <AppIconStack />
+          <AppIconStack apps={heroIconApps} />
         </div>
 
         <div className="mt-7 grid gap-1 border-t border-fd-border pt-3 sm:grid-cols-3">
@@ -1564,9 +345,7 @@ export function ProductionAppsShowcase() {
       </section>
 
       <Cards className="mt-8 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-        {productionApps.map((app) => (
-          <AppCard key={app.name} app={app} />
-        ))}
+        {appElements}
         <AddYourAppCard />
       </Cards>
     </div>


### PR DESCRIPTION
## Summary

- move all 71 production-app entries, logo paths, store links, and install metrics into `production-apps.mdx`
- render the existing custom showcase through declarative `ProductionApp` and `InstallMetric` children
- derive the hero icons and summary totals from the MDX content instead of maintaining a second data source

## Why

The catalog previously lived entirely inside the React component, so Fumadocs' processed Markdown only exposed `<ProductionAppsShowcase />`. The individual apps and logos were therefore missing from the page Markdown and `llms-full.txt`.

The compound-component structure keeps the custom visual rendering while making every app record readable in the generated Markdown.

## Validation

- `bun run lint`
- TypeScript checks and Next route type generation
- `bun run test:logic` — 11 tests passed
- `bun run check:links` — 271 pages checked
- Next.js production build
- HTTP verification: Markdown response contains 71 apps, 89 metrics, and 71 logo paths; rendered page contains 71 app cards
