### PR TITLE
fix(ios): serialize preview layer attach/detach on the session queue

### DIFF
--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraSession.swift
@@ -10,7 +10,11 @@ import NitroModules
 
 final class HybridCameraSession: HybridCameraSessionSpec {
   let session: AVCaptureSession
-  private static let queue: DispatchQueue = DispatchQueue(
+  // Internal (was private) so HybridPreviewView can serialize its
+  // preview-layer attach/detach with configure()/start(). AVCaptureSession is
+  // not thread-safe; every session mutation in this module must go through
+  // this one serial queue.
+  static let queue: DispatchQueue = DispatchQueue(
     label: "com.margelo.camera.session",
     qos: .userInteractive,
     attributes: [],

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Views/HybridPreviewView.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Views/HybridPreviewView.swift
@@ -126,43 +126,142 @@ final class HybridPreviewView: HybridPreviewViewSpec {
   private func updatePreviewLayer() {
     DispatchQueue.main.async {
       if let previewLayer = self.previewLayer {
-        // Remove all sublayers that are not our AVCaptureVideoPreviewLayer
-        self.view.layer.sublayers?.removeAll { $0 != previewLayer }
-        if self.view.layer.sublayers?.contains(previewLayer) != true {
-          // If we don't have the preview layer, we add it here
-          self.view.layer.addSublayer(previewLayer)
-        }
-        previewLayer.frame = self.view.bounds
-
-        // Update resizeMode
-        let resizeMode = self.resizeMode ?? .cover
-        previewLayer.videoGravity = resizeMode.toAVLayerVideoGravity()
-
-        // Add listener to `isPreviewing`
-        self.isPreviewingObserver = previewLayer.observe(
-          \.isPreviewing,
-          options: [.initial, .new, .old],
-          changeHandler: { [weak self] _, change in
-            guard let self else { return }
-            guard let wasPreviewing = change.oldValue,
-              let isPreviewing = change.newValue
-            else { return }
-            guard wasPreviewing != isPreviewing else { return }
-            if isPreviewing {
-              logger.info("PreviewView started!")
-              self.onPreviewStarted?()
-            } else {
-              logger.info("PreviewView stopped!")
-              self.onPreviewStopped?()
+        // Never touch the AVCaptureSession from the main thread.
+        //
+        // The deadlock this avoids (#4098, and #3356): addSublayer() takes
+        // the CoreAnimation transaction lock and AVFoundation then waits on
+        // the capture session lock inside layerDidBecomeVisible:, while the
+        // AVFCapture KVO thread holds the session lock and waits on the CA
+        // lock. Classic ABBA, and it hangs the main thread permanently.
+        //
+        // Detaching and re-attaching the session on the MAIN thread does fix
+        // that cycle, but it then races CameraSession's serial queue:
+        // AVCaptureSession is not thread-safe, so a main-thread
+        // beginConfiguration/commitConfiguration pair interleaving with
+        // configure()/start() produced "startRunning may not be called
+        // between calls to beginConfiguration and commitConfiguration" traps
+        // and attach/detachFromFigCaptureSession assertions for us.
+        //
+        // So: ALL session mutation goes on HybridCameraSession.queue (the
+        // same serial queue configure() and start() use) and only pure
+        // CoreAnimation work stays on main. The main thread never waits for
+        // the session lock, so no lock cycle is possible, and no two threads
+        // ever configure the session concurrently.
+        let needsLayerAttach = self.view.layer.sublayers?.contains(previewLayer) != true
+        if needsLayerAttach, previewLayer.session != nil {
+          // The layer is session-connected and not in the layer tree yet:
+          // detach on the session queue, do the CA work on main, then
+          // re-attach on the session queue.
+          HybridCameraSession.queue.async {
+            let detachedSession = previewLayer.session
+            let detachedInputPort = previewLayer.connection?.inputPorts.first
+            previewLayer.session = nil
+            DispatchQueue.main.async {
+              self.attachAndStyleLayerOnMain(previewLayer)
+              guard let session = detachedSession, let inputPort = detachedInputPort else {
+                return
+              }
+              HybridCameraSession.queue.async {
+                guard previewLayer.session == nil else {
+                  // A configure() ran while the layer was detached and
+                  // re-attached it itself (updateOutputs adds any preview
+                  // whose session is nil); nothing left to do.
+                  return
+                }
+                // Rebuild the preview connection the same way CameraSession
+                // does (setSessionWithNoConnection plus a manual
+                // AVCaptureConnection; a plain .session setter would form an
+                // implicit connection to the wrong port, or none at all).
+                session.beginConfiguration()
+                previewLayer.setSessionWithNoConnection(session)
+                let connection = AVCaptureConnection(
+                  inputPort: inputPort, videoPreviewLayer: previewLayer)
+                if session.canAddConnection(connection) {
+                  session.addConnection(connection)
+                  logger.info(
+                    "preview re-attached on the session queue (deadlock-safe ordering engaged)."
+                  )
+                } else {
+                  // The captured input port went stale (the device changed
+                  // while the layer was detached); the next configure()
+                  // rebuilds the preview connection from scratch.
+                  logger.error(
+                    "could not re-add the preview connection; the next configure() will rebuild it."
+                  )
+                }
+                session.commitConfiguration()
+              }
             }
-          })
+          }
+        } else {
+          // Either the layer is already in the tree (pure property updates)
+          // or it has no session yet (configure() has not attached one, so
+          // addSublayer has no running session to contend with). Plain CA
+          // work is safe as-is.
+          self.attachAndStyleLayerOnMain(previewLayer)
+        }
       } else {
-        // Remove all sublayers (including the AVCaptureVideoPreviewLayer)
-        self.view.layer.sublayers?.removeAll()
-        // Remove listener to `isPreviewing`
-        self.onPreviewStopped?()
-        self.isPreviewingObserver = nil
+        // If the outgoing sublayer is a session-connected preview layer,
+        // detach it on the session queue first, so the layer never leaves the
+        // tree or deallocates while still wired into a running session.
+        let attachedPreviewLayer = self.view.layer.sublayers?
+          .compactMap { $0 as? AVCaptureVideoPreviewLayer }
+          .first { $0.session != nil }
+        if let attachedPreviewLayer {
+          HybridCameraSession.queue.async {
+            attachedPreviewLayer.session = nil
+            DispatchQueue.main.async {
+              self.removeAllSublayersOnMain()
+            }
+          }
+        } else {
+          self.removeAllSublayersOnMain()
+        }
       }
     }
+  }
+
+  /// Pure CoreAnimation work plus KVO registration. Must run on the main
+  /// thread and must never touch the AVCaptureSession.
+  private func attachAndStyleLayerOnMain(_ previewLayer: AVCaptureVideoPreviewLayer) {
+    // Remove all sublayers that are not our AVCaptureVideoPreviewLayer
+    self.view.layer.sublayers?.removeAll { $0 != previewLayer }
+    if self.view.layer.sublayers?.contains(previewLayer) != true {
+      // If we don't have the preview layer, we add it here
+      self.view.layer.addSublayer(previewLayer)
+    }
+    previewLayer.frame = self.view.bounds
+
+    // Update resizeMode
+    let resizeMode = self.resizeMode ?? .cover
+    previewLayer.videoGravity = resizeMode.toAVLayerVideoGravity()
+
+    // Add listener to `isPreviewing`
+    self.isPreviewingObserver = previewLayer.observe(
+      \.isPreviewing,
+      options: [.initial, .new, .old],
+      changeHandler: { [weak self] _, change in
+        guard let self else { return }
+        guard let wasPreviewing = change.oldValue,
+          let isPreviewing = change.newValue
+        else { return }
+        guard wasPreviewing != isPreviewing else { return }
+        if isPreviewing {
+          logger.info("PreviewView started!")
+          self.onPreviewStarted?()
+        } else {
+          logger.info("PreviewView stopped!")
+          self.onPreviewStopped?()
+        }
+      })
+  }
+
+  /// Main-thread teardown of the layer tree.
+  private func removeAllSublayersOnMain() {
+    // Remove all sublayers (including the AVCaptureVideoPreviewLayer)
+    self.view.layer.sublayers?.removeAll()
+    // Remove listener to `isPreviewing`
+    self.onPreviewStopped?()
+    self.isPreviewingObserver = nil
   }
 }


### PR DESCRIPTION
Fixes #4098 (same cycle as #3356).

### The deadlock

`addSublayer()` takes the CoreAnimation transaction lock, and AVFoundation then waits on the capture session lock inside `layerDidBecomeVisible()`. Meanwhile the AVFCapture KVO thread holds the session lock and commits a CA transaction, waiting on the CA lock. ABBA, and the main thread hangs permanently.

### Why not just detach on the main thread

That breaks the cycle but races `CameraSession`'s serial queue. `AVCaptureSession` is not thread-safe, so a main-thread `beginConfiguration`/`commitConfiguration` pair interleaving with `configure()`/`start()` gave us `startRunning may not be called between calls to beginConfiguration and commitConfiguration` traps plus `attach/detachFromFigCaptureSession` assertions.

### What this does

All session mutation moves onto `HybridCameraSession.queue`, the same serial queue `configure()` and `start()` already use. Only pure CoreAnimation work stays on the main thread, so the main thread never waits for the session lock and no two threads ever configure the session concurrently.

The preview connection is rebuilt the way `CameraSession` does it (`setSessionWithNoConnection` plus an explicit `AVCaptureConnection`), since the plain `.session` setter forms an implicit connection to the wrong port. The re-attach is a no-op if a `configure()` ran while the layer was detached and re-attached it already.

`HybridCameraSession.queue` becomes internal so the preview view can share it.

### Testing

Running in production since late July on a fleet of unattended iOS kiosks (iOS 17.6 through 26.0, iPad and iPhone). The app-hang cluster this was causing has been at zero since.

Note #4134 does not cover this one: `HybridPreviewView.swift` is byte-identical between 5.1.1 and 5.2.2, so `updatePreviewLayer` and the lock ordering are unchanged.