### PR TITLE
fix(android): compose Photo.toImage() rotation before mirroring

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -9,6 +9,7 @@ import {
   waitUntil,
 } from 'react-native-harness'
 import type { Image } from 'react-native-nitro-image'
+import { Images } from 'react-native-nitro-image'
 import type {
   CameraDevice,
   CameraDeviceFactory,
@@ -986,6 +987,128 @@ describe('VisionCamera - Photo', () => {
     ])
     try {
       expect(photoOutput.supportsDepthDataDelivery).toBe(true)
+    } finally {
+      await session.stop()
+    }
+  })
+
+  it('renders toImage() the same way the reported orientation describes', async (context) => {
+    // Regression: `HybridPhoto.toImage()` composed the mirror with `preScale` and
+    // the rotation with `postRotate`, which applies the mirror first. A reflection
+    // conjugates a rotation into its inverse, so the two orderings differ by twice
+    // the rotation - a half turn at a quarter-turn orientation. At `up` and `down`
+    // both orderings are the same matrix, so only quarter turns expose it.
+    const frontDevice = factory.getDefaultCamera('front')
+    assert.exists(frontDevice, 'no front camera')
+
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 1,
+      qualityPrioritization: 'balanced',
+    })
+    await session.configure([
+      {
+        input: frontDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+    await session.start()
+
+    try {
+      // Taken as the pipeline reports it. Forcing `outputOrientation` does not help:
+      // CameraX then rotates the pixels itself and reports no rotation at all.
+      const photo = await photoOutput.capturePhoto(
+        { flashMode: 'off', enableShutterSound: false },
+        {},
+      )
+      try {
+        const quarterTurns = { left: 90, right: 270 } as const
+        const rotation =
+          quarterTurns[photo.orientation as keyof typeof quarterTurns]
+        if (rotation == null) {
+          return context.skip(
+            `photo.orientation is "${photo.orientation}": this device does not report a quarter turn, so the mirror and rotation never compose`,
+          )
+        }
+        if (!photo.isMirrored) {
+          return context.skip(
+            'photo.isMirrored is false: without a mirror both orderings are the same matrix',
+          )
+        }
+
+        const storedPath = await photo.saveToTemporaryFileAsync()
+        const storedImage = await Images.loadFromFileAsync(storedPath)
+        const renderedImage = await photo.toImageAsync()
+        try {
+          const stored = await storedImage.toRawPixelDataAsync(false)
+          const rendered = await renderedImage.toRawPixelDataAsync(false)
+          if (
+            stored.width !== rendered.height ||
+            stored.height !== rendered.width
+          ) {
+            return context.skip(
+              `stored ${stored.width}x${stored.height} against rendered ${rendered.width}x${rendered.height}: this platform's decoder already applied the orientation, so the two cannot be compared point by point`,
+            )
+          }
+
+          const readChannelAverage = (
+            pixels: typeof stored,
+            x: number,
+            y: number,
+          ) => {
+            const bytes = new Uint8Array(pixels.buffer)
+            const bytesPerPixel = Math.floor(
+              bytes.length / (pixels.width * pixels.height),
+            )
+            const offset = (y * pixels.width + x) * bytesPerPixel
+            let sum = 0
+            for (let channel = 0; channel < 3; channel++) {
+              sum += bytes[offset + channel] ?? 0
+            }
+            return sum / 3
+          }
+
+          // Where a rendered point came from in the stored frame, if the rotation
+          // the Photo reports is applied first and the mirror after it.
+          const toStoredPoint = (x: number, y: number): [number, number] => {
+            const mirroredX = rendered.width - 1 - x
+            return rotation === 90
+              ? [y, stored.height - 1 - mirroredX]
+              : [stored.width - 1 - y, mirroredX]
+          }
+
+          const steps = 16
+          let totalDifference = 0
+          let samples = 0
+          for (let row = 1; row < steps; row++) {
+            for (let column = 1; column < steps; column++) {
+              const x = Math.floor((column * rendered.width) / steps)
+              const y = Math.floor((row * rendered.height) / steps)
+              const [storedX, storedY] = toStoredPoint(x, y)
+              totalDifference += Math.abs(
+                readChannelAverage(rendered, x, y) -
+                  readChannelAverage(stored, storedX, storedY),
+              )
+              samples++
+            }
+          }
+
+          // Both images decode the same JPEG, so the rendering the Photo describes
+          // is pixel identical to the stored frame read through it - the scene in
+          // front of the camera does not matter. Composing the other way round
+          // lands a half turn off, on unrelated pixels.
+          const meanDifference = totalDifference / samples
+          expect(meanDifference).toBeCloseTo(0, 0)
+        } finally {
+          storedImage.dispose()
+          renderedImage.dispose()
+        }
+      } finally {
+        photo.dispose()
+      }
     } finally {
       await session.stop()
     }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+toBitmap.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ImageProxy+toBitmap.kt
@@ -13,11 +13,11 @@ fun ImageProxy.toBitmap(
 
   val matrix =
     Matrix().apply {
-      if (isMirrored) {
-        preScale(-1f, 1f)
-      }
       if (orientation != CameraOrientation.UP) {
         postRotate(orientation.degrees.toFloat())
+      }
+      if (isMirrored) {
+        postScale(-1f, 1f)
       }
     }
   if (matrix.isIdentity) {

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/instances/HybridPhoto.kt
@@ -156,12 +156,12 @@ class HybridPhoto(
 
     val matrix =
       Matrix().apply {
-        if (isMirrored) {
-          preScale(-1f, 1f)
-        }
         if (orientation != CameraOrientation.UP) {
           val orientationToApply = orientation.counterRotated()
           postRotate(orientationToApply.degrees.toFloat())
+        }
+        if (isMirrored) {
+          postScale(-1f, 1f)
         }
       }
     if (matrix.isIdentity) {


### PR DESCRIPTION
## What

`HybridPhoto.toImage()` builds its transform with `preScale(-1f, 1f)` for the mirror and `postRotate(...)` for the orientation. `preScale` right-multiplies and `postRotate` left-multiplies, so the composition is mirror-first. A reflection conjugates a rotation into its inverse, so the two possible orderings differ by twice the rotation — a half turn at the quarter-turn orientations a portrait capture produces, and nothing at all at `up` or `down`.

The effect is that `toImage()` disagrees by 180° with `saveToTemporaryFile()`, with `capturePhotoToFile()` and with the live preview, for one and the same capture. `orientation` and `isMirrored` are both reported correctly — only the composition is wrong.

CameraX composes it the other way round: `Exif.flipHorizontally()` maps orientation 6→5 and 8→7, which is a flip in display space, and `FileUtil.updateFileExif` calls `Exif.rotate(...)` before `Exif.flipHorizontally()`. `HybridPhoto.attachExifData` follows that same order, so before this change the two ways out of one `Photo` contradicted each other.

The same composition appears a second time in `ImageProxy.toBitmap(orientation, isMirrored)`, which `HybridFrameConverter.convertFrameToImage` and `convertDepthToImage` both go through. Fixed there too, since it is the same defect reached from a different entry point.

## Fix

Apply both transforms with `post*`, so they run in written order: rotate upright, then mirror.

## Test

`visioncamera.photo.harness.ts` gains one case. It captures a mirrored front-camera photo, saves it, and reads the stored frame back with `Images.loadFromFileAsync`. For a grid of sample points it maps each rendered point back into the stored frame through the rotation the `Photo` reports, applied before the mirror, and averages the absolute difference.

Both images decode the same JPEG, so a correct rendering is pixel identical and the mean difference is exactly `0` — the scene in front of the camera does not matter, which should keep it stable on a taped Device Farm sensor. Composing the other way round lands every sample a half turn away, on unrelated pixels.

Verified on an emulator, following the procedure in the tests README:

- on `main`: `expected 49.90518518518518 to be close to +0`
- with the fix: passes

The test skips, with a reason, in the three cases where both orderings are the same matrix and there is nothing to observe: when the reported orientation is not a quarter turn, when the photo is not mirrored, and when the platform's decoder has already applied the orientation to the stored frame.

## Notes

**This is device-dependent.** The rotation branch only runs when `photo.orientation` is not `up`, and that value comes from `ImageProxy.imageInfo.rotationDegrees`. CameraX can honour the requested orientation either by rotating the pixels in the pipeline — reporting `0` — or by leaving them and reporting the degrees; only the second path reaches this code. A Huawei P40 (Android 10) always reports `up` while the photo dimensions swap, so the defect cannot be produced on it at all. An emulator with a host webcam as the front camera reports `left` and reproduces it.

Setting `photoOutput.outputOrientation` is not a way to force the case: CameraX then takes the bake-the-rotation path and the reported orientation drops back to `up`. The test therefore uses the orientation as the pipeline reports it, and skips rather than pretending to cover the case.

**No platform guard.** The behaviour should hold on both platforms and iOS composes it correctly today. On an iOS simulator the test currently skips, because the connection orientation defaults to portrait and the reported orientation is `up`.

**A question, not a claim, about the rotation direction.** `ImageProxy.toBitmap` rotates by `orientation.degrees` while `HybridPhoto.toImage` rotates by `orientation.counterRotated().degrees`. Both are handed the same value — `HybridFrameOutput` passes `image.orientation` and `HybridPhoto.orientation` is `image.orientation` — so for a frame reported as `left` one path turns 90° and the other 270°. I only measured the photo path, where `counterRotated()` is what agrees with the EXIF file and the preview; I have not run the frame converter, and the comment in `HybridFrameOutput` about orientation being "relative to current target orientation" leaves room for `ImageAnalysis` following a different convention. Left untouched here — happy to follow up separately once you say which is intended.

An image from the emulator:

<img width="499" height="1010" alt="Screenshot 2026-08-10 at 12 44 20" src="https://github.com/user-attachments/assets/be1126e1-74b8-45b6-9ca1-73303c3a1636" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)
