### PR TITLE
fix: emit current orientation on subscribe

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/orientation/HybridDeviceOrientationManager.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/orientation/HybridDeviceOrientationManager.kt
@@ -32,9 +32,11 @@ class HybridDeviceOrientationManager : HybridOrientationManagerSpec() {
 
   override fun startOrientationUpdates(onChanged: (orientation: CameraOrientation) -> Unit) {
     orientationListener?.disable()
+    currentOrientation?.let(onChanged)
     orientationListener =
       object : OrientationEventListener(context) {
         override fun onOrientationChanged(rotationDegrees: Int) {
+          if (orientationListener !== this) return
           if (rotationDegrees == ORIENTATION_UNKNOWN) {
             // phone is laying flat - orientation is unknown! Avoid sending out event.
             return
@@ -51,6 +53,8 @@ class HybridDeviceOrientationManager : HybridOrientationManagerSpec() {
   }
 
   override fun stopOrientationUpdates() {
-    orientationListener?.disable()
+    val listener = orientationListener
+    orientationListener = null
+    listener?.disable()
   }
 }

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/orientation/HybridInterfaceOrientationManager.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/orientation/HybridInterfaceOrientationManager.kt
@@ -32,6 +32,11 @@ class HybridInterfaceOrientationManager : HybridOrientationManagerSpec() {
     listener?.let { listener ->
       displayManager.unregisterDisplayListener(listener)
     }
+    val defaultDisplay = displayManager.displays.firstOrNull()
+    if (defaultDisplay != null) {
+      currentOrientation = CameraOrientation.fromSurfaceRotation(defaultDisplay.rotation)
+    }
+    currentOrientation?.let(onChanged)
     val listener =
       object : DisplayManager.DisplayListener {
         override fun onDisplayAdded(displayId: Int) = Unit
@@ -39,6 +44,7 @@ class HybridInterfaceOrientationManager : HybridOrientationManagerSpec() {
         override fun onDisplayRemoved(displayId: Int) = Unit
 
         override fun onDisplayChanged(displayId: Int) {
+          if (this@HybridInterfaceOrientationManager.listener !== this) return
           val display = displayManager.getDisplay(displayId) ?: return
           val surfaceRotation = display.rotation
           val orientation = CameraOrientation.fromSurfaceRotation(surfaceRotation)
@@ -54,9 +60,8 @@ class HybridInterfaceOrientationManager : HybridOrientationManagerSpec() {
   }
 
   override fun stopOrientationUpdates() {
-    listener?.let { listener ->
-      displayManager.unregisterDisplayListener(listener)
-    }
+    val currentListener = listener
     listener = null
+    currentListener?.let(displayManager::unregisterDisplayListener)
   }
 }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridDeviceOrientationManager.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridDeviceOrientationManager.swift
@@ -29,6 +29,9 @@ final class HybridDeviceOrientationManager: HybridOrientationManagerSpec {
     if motionManager.isAccelerometerActive {
       motionManager.stopAccelerometerUpdates()
     }
+    if let currentOrientation {
+      onChanged(currentOrientation)
+    }
 
     if motionManager.isAccelerometerAvailable {
       motionManager.startAccelerometerUpdates(to: operationQueue) {

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridInterfaceOrientationManager.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Orientation/HybridInterfaceOrientationManager.swift
@@ -34,6 +34,13 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
       // Start new listener (beginGeneratingDeviceOrientationNotifications() can be nested)
       UIDevice.current.beginGeneratingDeviceOrientationNotifications()
 
+      let interfaceOrientation = UIApplication.shared.interfaceOrientation
+      if interfaceOrientation != .unknown {
+        let orientation = CameraOrientation(interfaceOrientation: interfaceOrientation)
+        self.currentOrientation = orientation
+        onChanged(orientation)
+      }
+
       self.observer = NotificationCenter.default.addObserver(
         forName: UIDevice.orientationDidChangeNotification,
         object: nil,
@@ -60,6 +67,7 @@ final class HybridInterfaceOrientationManager: HybridOrientationManagerSpec {
       if let observer = self.observer {
         logger.info("Stopping interface orientation updates...")
         NotificationCenter.default.removeObserver(observer)
+        self.observer = nil
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
       }
     }

--- a/packages/react-native-vision-camera/src/hooks/useOrientation.ts
+++ b/packages/react-native-vision-camera/src/hooks/useOrientation.ts
@@ -20,6 +20,7 @@ export function useOrientation(
 ): CameraOrientation | undefined {
   const orientationManager = useOrientationManager(source)
   const currentOrientation = useRef(orientationManager?.currentOrientation)
+  currentOrientation.current = orientationManager?.currentOrientation
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {


### PR DESCRIPTION
## Summary

- Emit the current orientation immediately when the existing iOS and Android managers start updates
- Refresh Android interface orientation when subscribing
- Clear retained native listener handles on stop and ignore queued stale Android callbacks
- Reset the `useOrientation` snapshot when its source changes

## Why

The managers could already know their current orientation before JavaScript subscribed, but only delivered later changes. If the device or interface did not rotate afterward, the hook could remain `undefined` or expose a stale value. Listener handles also remained retained after teardown in some paths.

This keeps the existing `startOrientationUpdates` / `stopOrientationUpdates` API and fixes the behavior in place.

## Validation

- `bun camera typecheck`
- `./gradlew :react-native-vision-camera:compileDebugKotlin --no-daemon --console=plain`
- VisionCamera iOS simulator scheme build with `xcodebuild`
- Focused Kotlin and Swift formatting checks
- `git diff --check`
